### PR TITLE
* quick fix for header in web socket connection

### DIFF
--- a/ThirdParty/WebSocketSharp/WebSocket.cs
+++ b/ThirdParty/WebSocketSharp/WebSocket.cs
@@ -871,7 +871,7 @@ namespace WebSocketSharp
       if ( Headers != null )
       {
            foreach( var kp in Headers )
-                Headers[ kp.Key ] = kp.Value;
+                    ret.Headers[ kp.Key ] = kp.Value;
       }
 
       var headers = ret.Headers;


### PR DESCRIPTION
This is a quick fix for third party plugin for web socket connection. 
It has buggy for-each statement. This is the correct one. 