### PR TITLE
HOTFIX: Increased fragment to max size for now.

### DIFF
--- a/ThirdParty/WebSocketSharp/WebSocket.cs
+++ b/ThirdParty/WebSocketSharp/WebSocket.cs
@@ -148,7 +148,7 @@ namespace WebSocketSharp
     static WebSocket ()
     {
       EmptyBytes = new byte[0];
-      FragmentLength = 1016;
+      FragmentLength =  Int32.MaxValue - 14; // 1016
       RandomNumber = new RNGCryptoServiceProvider ();
     }
 


### PR DESCRIPTION
### Summary
Increased fragment size to maxiumum since the low-level offered no benefit other than increasing the amount of bandwidth needed to send the same amount of data. WebSocket frame already support up to 64-bit lengths.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here.


Thanks for contributing to the Watson Developer Cloud!
