### PR TITLE
HOTFIX: TTS keeps saying the word "quote" at the end of all speech, I…

### DIFF
--- a/Scripts/Services/TextToSpeech/TextToSpeech.cs
+++ b/Scripts/Services/TextToSpeech/TextToSpeech.cs
@@ -303,14 +303,14 @@ namespace IBM.Watson.DeveloperCloud.Services.TextToSpeech.v1
             if (usePost)
             {
                 Dictionary<string, string> upload = new Dictionary<string, string>();
-                upload["text"] = "\"" + text + "\"";
+                upload["text"] = text;
 
                 req.Send = Encoding.UTF8.GetBytes(Json.Serialize(upload));
                 req.Headers["Content-Type"] = "application/json";
             }
             else
             {
-                req.Parameters["text"] = "\"" + text + "\"";
+                req.Parameters["text"] = text;
             }
 
             return connector.Send(req);


### PR DESCRIPTION
… don't think it's required to put quotes around the parameters anymore.