### PR TITLE
Marked deprecated Watson Services in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ To get started with the Watson Services in Unity, click on each service below to
 * [Alchemy Language](/Scripts/Services/AlchemyAPI/v1)
 * [Conversation](/Scripts/Services/Conversation/v1)
 * [Discovery](/Scripts/Services/Discovery/v1)
-* [Document Conversion](/Scripts/Services/DocumentConversion/v1)
+* [Document Conversion](/Scripts/Services/DocumentConversion/v1) **Deprecated**
 * [Language Translator](/Scripts/Services/LanguageTranslator/v2)
 * [Natural Language Classifier](/Scripts/Services/NaturalLanguageClassifier/v2)
 * [Natural Language Understanding](/Scripts/Services/NaturalLanguageUnderstanding/v1)
 * [Personality Insights](/Scripts/Services/PersonalityInsights/v3)
-* [Retrieve and Rank](/Scripts/Services/RetrieveAndRank/v1)
+* [Retrieve and Rank](/Scripts/Services/RetrieveAndRank/v1) **Deprecated**
 * [Speech to Text](/Scripts/Services/SpeechToText/v1)
 * [Text to Speech](/Scripts/Services/TextToSpeech/v1)
 * [Tone Analyzer](/Scripts/Services/ToneAnalyzer/v3)


### PR DESCRIPTION
### Summary

Marked **Document Conversion** and **Retrieve and Rank** services as deprecated, per Bluemix documentation. No new service instances can be created, but existing ones may still be leveraged.

### Other Information

Alchemy Language was retired and incorporated into the NLU service. This may require changes to the NLU service calls, but I'm not sure. More info here: https://www.ibm.com/watson/developercloud/alchemy-language.html