### PR TITLE
Allow websocketsharp dll on WSA with IL2CPP backend

### DIFF
--- a/Plugins/websocket-sharp.dll.meta
+++ b/Plugins/websocket-sharp.dll.meta
@@ -24,7 +24,7 @@ PluginImporter:
           Exclude OSXUniversal: 0
           Exclude Win: 0
           Exclude Win64: 0
-          Exclude WindowsStoreApps: 1
+          Exclude WindowsStoreApps: 0
     data:
       first:
         Any: 
@@ -112,13 +112,13 @@ PluginImporter:
       first:
         Windows Store Apps: WindowsStoreApps
       second:
-        enabled: 0
+        enabled: 1
         settings:
           CPU: AnyCPU
           DontProcess: False
           PlaceholderPath: 
           SDK: AnySDK
-          ScriptingBackend: AnyScriptingBackend
+          ScriptingBackend: Il2Cpp
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/ThirdParty/WebSocketSharp/websocket-sharp.csproj.meta
+++ b/ThirdParty/WebSocketSharp/websocket-sharp.csproj.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0fbe68503a01cc440bbbf2f8130640f2
-timeCreated: 1499973980
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Improved the exclude flags on the new websocketsharp dll (it will be excluded on WSA with the .NET scripting backend, but will be included on WSA with the IL2CPP scripting backend).

I just tested two UWP desktop builds, one using .NET and one using IL2CPP. Both compile and work as expected using this setup.

I also tested IL2CPP on Hololens. While a few exceptions are logged at startup, after a few seconds the speech-to-text streaming sample works as expected.

Also removed a lingering meta file in the WebSocketSharp folder.