### PR TITLE
update unity version allowed for UnityWebRequest.SendWebRequest()

### DIFF
--- a/Scripts/Connection/RESTConnector.cs
+++ b/Scripts/Connection/RESTConnector.cs
@@ -552,7 +552,7 @@ namespace IBM.Watson.DeveloperCloud.Connection
 				deleteReq.method = UnityWebRequest.kHttpVerbDELETE;
                 foreach (var kp in Headers)
                     deleteReq.SetRequestHeader(kp.Key, kp.Value);
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
                 deleteReq.SendWebRequest();
 #else
                 deleteReq.Send();


### PR DESCRIPTION
### Summary

UnityWebRequest.SendWebRequest is not available until unity 2017.2 but I had an ifdef for 2017.1 or newer.  Corrected the Unity version where we use SendWebRequest() instead of Send().