### PR TITLE
Fix detect silence to work with smaller audio chunks

### DIFF
--- a/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
@@ -177,7 +177,7 @@ public class ExampleStreaming : MonoBehaviour
 
                 //  Create AudioData and use the samples we just created
                 AudioData record = new AudioData();
-                record.MaxLevel = Mathf.Abs(Mathf.Max(samples));
+                record.MaxLevel = Mathf.Max(Mathf.Abs(Mathf.Min(samples)), Mathf.Max(samples));
                 record.Clip = AudioClip.Create("Recording", chunkSize, _recording.channels, _recordingHZ, false);
                 record.Clip.SetData(samples, 0);
 

--- a/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
@@ -63,10 +63,10 @@ public class ExampleStreaming : MonoBehaviour
         {
             if (value && !_speechToText.IsListening)
             {
-                _speechToText.DetectSilence = false;
+                _speechToText.DetectSilence = true;
                 _speechToText.EnableWordConfidence = true;
                 _speechToText.EnableTimestamps = true;
-                _speechToText.SilenceThreshold = 0.1f;
+                _speechToText.SilenceThreshold = 0.01f;
                 _speechToText.MaxAlternatives = 0;
                 _speechToText.EnableInterimResults = true;
                 _speechToText.OnError = OnError;
@@ -177,7 +177,7 @@ public class ExampleStreaming : MonoBehaviour
 
                 //  Create AudioData and use the samples we just created
                 AudioData record = new AudioData();
-                record.MaxLevel = Mathf.Max(samples);
+                record.MaxLevel = Mathf.Abs(Mathf.Max(samples));
                 record.Clip = AudioClip.Create("Recording", chunkSize, _recording.channels, _recordingHZ, false);
                 record.Clip.SetData(samples, 0);
 


### PR DESCRIPTION
Now that we're using smaller audio chunks it isn't safe to discard individual silent chunks. I propose tracking the duration of the silence, and only sending a stop once we reach a specified duration. For now I've chosen 1.0 second, but smaller values might work as well. All silent audio chunks will be discarded after this cutoff, until a non-silent chunk is encountered.