### PR TITLE
rename chunked gameobject in example streaming scene

### DIFF
--- a/Examples/ServiceExamples/ExampleStreaming.unity
+++ b/Examples/ServiceExamples/ExampleStreaming.unity
@@ -122,7 +122,7 @@ GameObject:
   - component: {fileID: 249853926}
   - component: {fileID: 249853925}
   m_Layer: 0
-  m_Name: ExampleStreamingChunked
+  m_Name: ExampleStreamingSplitSamples
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -235,7 +235,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 278297820}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 574, y: 313.5, z: 0}
+  m_LocalPosition: {x: 574, y: 278, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1863902090}


### PR DESCRIPTION
### Summary

Example streaming scene was not saved. Changing the name of a game object to reflect the attached script.