### PR TITLE
Update links to developercloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Contributing
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
-[wdc]: http://www.ibm.com/watson/developercloud/
+[wdc]: https://www.ibm.com/watson/developer/
 [wdc_unity_sdk]: https://github.com/watson-developer-cloud/unity-sdk
 [latest_release]: https://github.com/watson-developer-cloud/unity-sdk/releases/latest
 [bluemix_registration]: http://bluemix.net/registration
@@ -264,7 +264,7 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 [expressive_ssml]: https://console.bluemix.net/docs/services/text-to-speech/http.html#expressive
 [ssml]: https://console.bluemix.net/docs/services/text-to-speech/SSML.html
 [discovery-query]: https://console.bluemix.net/docs/services/discovery/using.html
-[natural_language_understanding]: https://www.ibm.com/watson/developercloud/natural-language-understanding.html
+[natural_language_understanding]: https://www.ibm.com/watson/services/natural-language-understanding/
 [nlu_models]: https://console.bluemix.net/docs/services/natural-language-understanding/customizing.html
 [nlu_entities]: https://console.bluemix.net/docs/services/natural-language-understanding/entity-types.html
 [nlu_relations]: https://console.bluemix.net/docs/services/natural-language-understanding/relations.html

--- a/Scripts/Services/Discovery/v1/Discovery.cs
+++ b/Scripts/Services/Discovery/v1/Discovery.cs
@@ -29,7 +29,7 @@ namespace IBM.Watson.DeveloperCloud.Services.Discovery.v1
 {
     /// <summary>
     /// This class wraps the Discovery service
-    /// <a href="http://www.ibm.com/watson/developercloud/discovery.html">Discovery Service</a>
+    /// <a href="https://www.ibm.com/watson/services/discovery/">Discovery Service</a>
     /// </summary>
     public class Discovery : IWatsonService
     {
@@ -226,7 +226,7 @@ namespace IBM.Watson.DeveloperCloud.Services.Discovery.v1
         /// <param name="failCallback">The fail callback.</param>
         /// <param name="name">The name of the environment to be created.</param>
         /// <param name="description">The description of the environment to be created.</param>
-        /// <param name="size">The size of the environment to be created. See <a href="http://www.ibm.com/watson/developercloud/discovery.html#pricing-block">pricing.</a></param>
+        /// <param name="size">The size of the environment to be created. See <a href="https://www.ibm.com/watson/services/discovery/#pricing-block">pricing.</a></param>
         /// <param name="customData">Optional custom data.</param>
         /// <returns>True if the call succeeds, false if the call is unsuccessful.</returns>
         public bool AddEnvironment(SuccessCallback<Environment> successCallback, FailCallback failCallback, string name = default(string), string description = default(string), int size = 0, Dictionary<string, object> customData = null)

--- a/Scripts/Services/RetrieveAndRank/v1/RetrieveAndRank.cs
+++ b/Scripts/Services/RetrieveAndRank/v1/RetrieveAndRank.cs
@@ -28,7 +28,7 @@ namespace IBM.Watson.DeveloperCloud.Services.RetrieveAndRank.v1
 {
     /// <summary>
     /// This class wraps the Retrieve and Rank service.
-    /// <a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">Retrieve and Rank Service</a>
+    /// <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">Retrieve and Rank Service</a>
     /// </summary>
     public class RetrieveAndRank : IWatsonService
     {
@@ -239,7 +239,7 @@ namespace IBM.Watson.DeveloperCloud.Services.RetrieveAndRank.v1
 
         #region CreateCluster
         /// <summary>
-        /// Provisions a Solr cluster asynchronously. When the operation is successful, the status of the cluster is set to NOT_AVAILABLE. The status must be READY before you can use the cluster. For information about cluster sizing see http://www.ibm.com/watson/developercloud/doc/retrieve-rank/solr_ops.shtml#sizing.
+        /// Provisions a Solr cluster asynchronously. When the operation is successful, the status of the cluster is set to NOT_AVAILABLE. The status must be READY before you can use the cluster. For information about cluster sizing see https://console.bluemix.net/docs/services/retrieve-and-rank/using-solr.html.
         /// </summary>
         /// <param name="successCallback">The success callback.</param>
         /// <param name="failCallback">The fail callback.</param>
@@ -1344,7 +1344,7 @@ namespace IBM.Watson.DeveloperCloud.Services.RetrieveAndRank.v1
         /// </summary>
         /// <param name="successCallback">The success callback.</param>
         /// <param name="failCallback">The fail callback.</param>
-        /// <param name="trainingDataPath">Training data in CSV format. The first header must be question_id and the last header must be the relevance label. The other headers are alphanumeric feature names. For details, see Using your own data (http://www.ibm.com/watson/developercloud/doc/retrieve-rank/data_format.shtml).</param>
+        /// <param name="trainingDataPath">Training data in CSV format. The first header must be question_id and the last header must be the relevance label. The other headers are alphanumeric feature names. For details, see Using your own data (https://console.bluemix.net/docs/services/retrieve-and-rank/overview.html).</param>
         /// <param name="name">Metadata in JSON format. The metadata identifies an optional name to identify the ranker.</param>
         /// <param name="customData"></param>
         /// <returns></returns>
@@ -1456,7 +1456,7 @@ namespace IBM.Watson.DeveloperCloud.Services.RetrieveAndRank.v1
 
         #region Rank
         /// <summary>
-        /// Returns the top answer and a list of ranked answers with their ranked scores and confidence values. Use the Get information about a ranker method to retrieve the status (http://www.ibm.com/watson/developercloud/retrieve-and-rank/api/v1/#get_status). Use this method to return answers when you train the ranker with custom features. However, in most cases, you can use the Search and rank method (http://www.ibm.com/watson/developercloud/retrieve-and-rank/api/v1/#query_ranker).
+        /// Returns the top answer and a list of ranked answers with their ranked scores and confidence values. Use the Get information about a ranker method to retrieve the status (https://www.ibm.com/watson/developercloud/retrieve-and-rank/api/v1/?curl#get_status). Use this method to return answers when you train the ranker with custom features. However, in most cases, you can use the Search and rank method (https://www.ibm.com/watson/developercloud/retrieve-and-rank/api/v1/?curl#query_ranker).
         /// </summary>
         /// <param name="successCallback">The success callback.</param>
         /// <param name="failCallback">The fail callback.</param>

--- a/Scripts/UnitTests/TestAlchemyLanguage.cs
+++ b/Scripts/UnitTests/TestAlchemyLanguage.cs
@@ -117,7 +117,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
 
                 var fileContent = File.ReadAllText(environmentalVariable);

--- a/Scripts/UnitTests/TestConversation.cs
+++ b/Scripts/UnitTests/TestConversation.cs
@@ -53,7 +53,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestDiscovery.cs
+++ b/Scripts/UnitTests/TestDiscovery.cs
@@ -82,7 +82,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = System.Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestDocumentConversion.cs
+++ b/Scripts/UnitTests/TestDocumentConversion.cs
@@ -50,7 +50,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestLanguageTranslator.cs
+++ b/Scripts/UnitTests/TestLanguageTranslator.cs
@@ -60,7 +60,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestNaturalLanguageClassifier.cs
+++ b/Scripts/UnitTests/TestNaturalLanguageClassifier.cs
@@ -68,7 +68,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestNaturalLanguageUnderstanding.cs
+++ b/Scripts/UnitTests/TestNaturalLanguageUnderstanding.cs
@@ -49,7 +49,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestPersonalityInsights.cs
+++ b/Scripts/UnitTests/TestPersonalityInsights.cs
@@ -56,7 +56,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestRetrieveAndRank.cs
+++ b/Scripts/UnitTests/TestRetrieveAndRank.cs
@@ -95,7 +95,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestSpeechToText.cs
+++ b/Scripts/UnitTests/TestSpeechToText.cs
@@ -96,7 +96,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestTextToSpeech.cs
+++ b/Scripts/UnitTests/TestTextToSpeech.cs
@@ -71,7 +71,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestToneAnalyzer.cs
+++ b/Scripts/UnitTests/TestToneAnalyzer.cs
@@ -50,7 +50,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestTradeoffAnalytics.cs
+++ b/Scripts/UnitTests/TestTradeoffAnalytics.cs
@@ -49,7 +49,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 

--- a/Scripts/UnitTests/TestVisualRecognition.cs
+++ b/Scripts/UnitTests/TestVisualRecognition.cs
@@ -72,7 +72,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
                 fsData data = null;
 
                 //  Get credentials from a credential file defined in environmental variables in the VCAP_SERVICES format. 
-                //  See https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html.
+                //  See https://console.bluemix.net/docs/services/watson/getting-started-variables.html.
                 var environmentalVariable = Environment.GetEnvironmentVariable("VCAP_SERVICES");
                 var fileContent = File.ReadAllText(environmentalVariable);
 


### PR DESCRIPTION
Updating links that point to WDC documentation to go to the Watson console and links to service pages to go to marketing pages.