### PR TITLE
redirect streaming requests to TLS 1.0 endpoint

### DIFF
--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -174,10 +174,10 @@ namespace IBM.Watson.DeveloperCloud.Connection
         /// <returns>The fixed up URL.</returns>
         public static string FixupURL(string URL)
         {
-            if (URL.StartsWith("http://"))
-                URL = URL.Replace("http://", "ws://");
-            else if (URL.StartsWith("https://"))
-                URL = URL.Replace("https://", "wss://");
+            if (URL.StartsWith("http://stream"))
+                URL = URL.Replace("http://stream", "ws://stream-tls10");
+            else if (URL.StartsWith("https://stream"))
+                URL = URL.Replace("https://stream", "wss://stream-tls10");
 
             return URL;
         }


### PR DESCRIPTION
Need to investigate why we cannot connect to the streaming endpoint now that we have transitioned to TLS 1.2. Redirecting to TLS 1.0 endpoint for now.