### PR TITLE
refactor(Logger): install default reactors in Log.Debug()

### DIFF
--- a/Scripts/Logging/Logger.cs
+++ b/Scripts/Logging/Logger.cs
@@ -113,6 +113,15 @@ namespace IBM.Watson.DeveloperCloud.Logging
         /// Returns the singleton instance of the Logger object.
         /// </summary>
         public static LogSystem Instance { get { return Singleton<LogSystem>.Instance; } }
+
+        /// <summary>
+        /// Get or set the status of installed default refactors.
+        /// </summary>
+        public static bool InstalledDefaultReactors
+        {
+            get { return _bInstalledDefaultReactors; }
+            set { _bInstalledDefaultReactors = value; }
+        }
         #endregion
 
         #region Private Data
@@ -150,7 +159,7 @@ namespace IBM.Watson.DeveloperCloud.Logging
                 Application.logMessageReceived += UnityLogCallback;
             }
         }
-
+        
         static void UnityLogCallback(string condition, string stacktrace, LogType type)
         {
             if (type == LogType.Exception)
@@ -213,7 +222,8 @@ namespace IBM.Watson.DeveloperCloud.Logging
 #if UNITY_EDITOR || NETFX_CORE
         public static void Debug(string subSystem, string messageFmt, params object[] args)
         {
-            LogSystem.InstallDefaultReactors();
+			if(!LogSystem.InstalledDefaultReactors)
+                System.Console.WriteLine("Call LogSystem.InstallDefaultReactors() prior to logging to see the output of Log.Debug(), Log.Status(), Log.Warning(), Log.Error() and Log.Critical().");            
             LogSystem.Instance.ProcessLog(new LogRecord(LogLevel.DEBUG, subSystem, messageFmt, args));
 #if !NETFX_CORE
             System.Console.WriteLine("[{0}][{1}]: {2}", LogLevel.DEBUG, subSystem, string.Format(messageFmt, args));
@@ -233,6 +243,8 @@ namespace IBM.Watson.DeveloperCloud.Logging
         /// <param name="args">Formatting arguments.</param>
         public static void Status(string subSystem, string messageFmt, params object[] args)
         {
+            if(!LogSystem.InstalledDefaultReactors)
+                System.Console.WriteLine("Call LogSystem.InstallDefaultReactors() prior to logging to see the output of Log.Debug(), Log.Status(), Log.Warning(), Log.Error() and Log.Critical().");
             LogSystem.Instance.ProcessLog(new LogRecord(LogLevel.STATUS, subSystem, messageFmt, args));
 #if !NETFX_CORE
             System.Console.WriteLine("[{0}][{1}]: {2}", LogLevel.STATUS, subSystem, string.Format(messageFmt, args));
@@ -246,6 +258,8 @@ namespace IBM.Watson.DeveloperCloud.Logging
         /// <param name="args">Formatting arguments.</param>
         public static void Warning(string subSystem, string messageFmt, params object[] args)
         {
+            if(!LogSystem.InstalledDefaultReactors)
+                System.Console.WriteLine("Call LogSystem.InstallDefaultReactors() prior to logging to see the output of Log.Debug(), Log.Status(), Log.Warning(), Log.Error() and Log.Critical().");
             LogSystem.Instance.ProcessLog(new LogRecord(LogLevel.WARNING, subSystem, messageFmt, args));
 #if !NETFX_CORE
             System.Console.WriteLine("[{0}][{1}]: {2}", LogLevel.WARNING, subSystem, string.Format(messageFmt, args));
@@ -259,6 +273,8 @@ namespace IBM.Watson.DeveloperCloud.Logging
         /// <param name="args">Formatting arguments.</param>
         public static void Error(string subSystem, string messageFmt, params object[] args)
         {
+            if(!LogSystem.InstalledDefaultReactors)
+                System.Console.WriteLine("Call LogSystem.InstallDefaultReactors() prior to logging to see the output of Log.Debug(), Log.Status(), Log.Warning(), Log.Error() and Log.Critical().");
             LogSystem.Instance.ProcessLog(new LogRecord(LogLevel.ERROR, subSystem, messageFmt, args));
 #if !NETFX_CORE
             System.Console.WriteLine("[{0}][{1}]: {2}", LogLevel.ERROR, subSystem, string.Format(messageFmt, args));
@@ -272,6 +288,8 @@ namespace IBM.Watson.DeveloperCloud.Logging
         /// <param name="args">Formatting arguments.</param>
         public static void Critical(string subSystem, string messageFmt, params object[] args)
         {
+            if(!LogSystem.InstalledDefaultReactors)
+                System.Console.WriteLine("Call LogSystem.InstallDefaultReactors() prior to logging to see the output of Log.Debug(), Log.Status(), Log.Warning(), Log.Error() and Log.Critical().");
             LogSystem.Instance.ProcessLog(new LogRecord(LogLevel.CRITICAL, subSystem, messageFmt, args));
 #if !NETFX_CORE
             System.Console.WriteLine("[{0}][{1}]: {2}", LogLevel.CRITICAL, subSystem, string.Format(messageFmt, args));

--- a/Scripts/Logging/Logger.cs
+++ b/Scripts/Logging/Logger.cs
@@ -213,6 +213,7 @@ namespace IBM.Watson.DeveloperCloud.Logging
 #if UNITY_EDITOR || NETFX_CORE
         public static void Debug(string subSystem, string messageFmt, params object[] args)
         {
+            LogSystem.InstallDefaultReactors();
             LogSystem.Instance.ProcessLog(new LogRecord(LogLevel.DEBUG, subSystem, messageFmt, args));
 #if !NETFX_CORE
             System.Console.WriteLine("[{0}][{1}]: {2}", LogLevel.DEBUG, subSystem, string.Format(messageFmt, args));

--- a/Scripts/Logging/Logger.cs
+++ b/Scripts/Logging/Logger.cs
@@ -115,7 +115,8 @@ namespace IBM.Watson.DeveloperCloud.Logging
         public static LogSystem Instance { get { return Singleton<LogSystem>.Instance; } }
 
         /// <summary>
-        /// Get or set the status of installed default refactors.
+        /// Expose the status of installed default refactors.
+        /// User can get the status, and set the status.
         /// </summary>
         public static bool InstalledDefaultReactors
         {
@@ -159,7 +160,7 @@ namespace IBM.Watson.DeveloperCloud.Logging
                 Application.logMessageReceived += UnityLogCallback;
             }
         }
-        
+
         static void UnityLogCallback(string condition, string stacktrace, LogType type)
         {
             if (type == LogType.Exception)


### PR DESCRIPTION
### Summary

Related to https://github.com/watson-developer-cloud/unity-sdk/issues/328

`LogSystem.InstallDefaultReactors()` checks whether default reactors are installed or not before installing them, so we can just call it in `Log.Debug`.

Alternative:

- We can add a method to test whether they are installed or not in `LogSystem`
- And show warning in there, and only call `LogSystem.InstallDefaultReactors()` inside `Log.Debug` only when they are not installed.