### PR TITLE
replace ToUnixTimeInSeconds() with dotnet 35 equivalent

### DIFF
--- a/Scripts/Utilities/Credentials.cs
+++ b/Scripts/Utilities/Credentials.cs
@@ -396,7 +396,8 @@ namespace IBM.Watson.DeveloperCloud.Utilities
             float fractionOfTtl = 0.8f;
             long? timeToLive = _iamTokenData.ExpiresIn;
             long? expireTime = _iamTokenData.Expiration;
-            long currentTime = DateTimeOffset.Now.ToUnixTimeSeconds();
+            System.DateTime epochStart = new System.DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
+            long currentTime = (int)(System.DateTime.UtcNow - epochStart).TotalSeconds;
 
             double? refreshTime = expireTime - (timeToLive * (1.0 - fractionOfTtl));
             return refreshTime < currentTime;
@@ -417,7 +418,8 @@ namespace IBM.Watson.DeveloperCloud.Utilities
             };
 
             long sevenDays = 7 * 24 * 3600;
-            long currentTime = DateTimeOffset.Now.ToUnixTimeSeconds();
+            System.DateTime epochStart = new System.DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
+            long currentTime = (int)(System.DateTime.UtcNow - epochStart).TotalSeconds;
             long? newTokenTime = _iamTokenData.Expiration + sevenDays;
             return newTokenTime < currentTime;
         }


### PR DESCRIPTION
### Summary
Fixes https://github.com/watson-developer-cloud/unity-sdk/issues/382

This pull request replaces .NET 4.6 safe ToUnixTimeInSeconds() with manually calculating epoch time. This is now safe for .NET 3.5.