### PR TITLE
Iam example revisions

### DIFF
--- a/Examples/ServiceExamples/Scripts/ExampleAssistant.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleAssistant.cs
@@ -28,16 +28,30 @@ using UnityEngine;
 public class ExampleAssistant : MonoBehaviour
 {
     #region PLEASE SET THESE VARIABLES IN THE INSPECTOR
+    [Space(10)]
+    [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/assistant/api\"")]
     [SerializeField]
-    private string _username;
-    [SerializeField]
-    private string _password;
-    [SerializeField]
-    private string _url;
-    [SerializeField]
-    private string _versionDate;
+    private string _serviceUrl;
+    [Tooltip("The workspaceId to run the example.")]
     [SerializeField]
     private string _workspaceId;
+    [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]
+    [SerializeField]
+    private string _versionDate;
+    [Header("CF Authentication")]
+    [Tooltip("The authentication username.")]
+    [SerializeField]
+    private string _username;
+    [Tooltip("The authentication password.")]
+    [SerializeField]
+    private string _password;
+    [Header("IAM Authentication")]
+    [Tooltip("The IAM apikey.")]
+    [SerializeField]
+    private string _iamApikey;
+    [Tooltip("The IAM url used to authenticate the apikey (optional). This defaults to \"https://iam.bluemix.net/identity/token\".")]
+    [SerializeField]
+    private string _iamUrl;
     #endregion
 
     private string _createdWorkspaceId;
@@ -113,9 +127,37 @@ public class ExampleAssistant : MonoBehaviour
     void Start()
     {
         LogSystem.InstallDefaultReactors();
+        Runnable.Run(CreateService());
+    }
 
+    private IEnumerator CreateService()
+    {
         //  Create credential and instantiate service
-        Credentials credentials = new Credentials(_username, _password, _url);
+        Credentials credentials = null;
+        if (!string.IsNullOrEmpty(_username) && !string.IsNullOrEmpty(_password))
+        {
+            //  Authenticate using username and password
+            credentials = new Credentials(_username, _password, _serviceUrl);
+        }
+        else if (!string.IsNullOrEmpty(_iamApikey))
+        {
+            //  Authenticate using iamApikey
+            TokenOptions tokenOptions = new TokenOptions()
+            {
+                IamApiKey = _iamApikey,
+                IamUrl = _iamUrl
+            };
+
+            credentials = new Credentials(tokenOptions, _serviceUrl);
+
+            //  Wait for tokendata
+            while (!credentials.HasIamTokenData())
+                yield return null;
+        }
+        else
+        {
+            throw new WatsonException("Please provide either username and password or IAM apikey to authenticate the service."); 
+        }
 
         _service = new Assistant(credentials);
         _service.VersionDate = _versionDate;

--- a/Examples/ServiceExamples/Scripts/ExampleDiscovery.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleDiscovery.cs
@@ -26,17 +26,30 @@ using UnityEngine;
 public class ExampleDiscovery : MonoBehaviour
 {
     #region PLEASE SET THESE VARIABLES IN THE INSPECTOR
+    [Space(10)]
+    [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/discovery/api\"")]
     [SerializeField]
-    private string _username;
-    [SerializeField]
-    private string _password;
-    [SerializeField]
-    private string _url;
+    private string _serviceUrl;
+    [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]
     [SerializeField]
     private string _versionDate;
+    [Header("CF Authentication")]
+    [Tooltip("The authentication username.")]
+    [SerializeField]
+    private string _username;
+    [Tooltip("The authentication password.")]
+    [SerializeField]
+    private string _password;
+    [Header("IAM Authentication")]
+    [Tooltip("The IAM apikey.")]
+    [SerializeField]
+    private string _iamApikey;
+    [Tooltip("The IAM url used to authenticate the apikey (optional). This defaults to \"https://iam.bluemix.net/identity/token\".")]
+    [SerializeField]
+    private string _iamUrl;
     #endregion
 
-    private Discovery _discovery;
+    private Discovery _service;
 
     private string _createdEnvironmentID;
     private string _configurationJson = "{\"name\":\"IBM News {guid}\",\"description\":\"A configuration useful for ingesting IBM press releases. Safe to delete.\",\"conversions\":{\"html\":{\"exclude_tags_keep_content\":[\"span\"],\"exclude_content\":{\"xpaths\":[\"/home\"]}},\"segment\":{\"enabled\":true,\"selector_tags\":[\"h1\",\"h2\"]},\"json_normalizations\":[{\"operation\":\"move\",\"source_field\":\"extracted_metadata.title\",\"destination_field\":\"metadata.title\"},{\"operation\":\"move\",\"source_field\":\"extracted_metadata.author\",\"destination_field\":\"metadata.author\"},{\"operation\":\"remove\",\"source_field\":\"extracted_metadata\"}]},\"enrichments\":[{\"enrichment\":\"natural_language_understanding\",\"source_field\":\"title\",\"destination_field\":\"enriched_title\",\"options\":{\"features\":{\"keywords\":{\"sentiment\":true,\"emotion\":false,\"limit\":50},\"entities\":{\"sentiment\":true,\"emotion\":false,\"limit\":50,\"mentions\":true,\"mention_types\":true,\"sentence_locations\":true,\"model\":\"WKS-model-id\"},\"sentiment\":{\"document\":true,\"targets\":[\"IBM\",\"Watson\"]},\"emotion\":{\"document\":true,\"targets\":[\"IBM\",\"Watson\"]},\"categories\":{},\"concepts\":{\"limit\":8},\"semantic_roles\":{\"entities\":true,\"keywords\":true,\"limit\":50},\"relations\":{\"model\":\"WKS-model-id\"}}}},{\"enrichment\":\"elements\",\"source_field\":\"html\",\"destination_field\":\"enriched_html\",\"options\":{\"model\":\"contract\"}}],\"normalizations\":[{\"operation\":\"move\",\"source_field\":\"metadata.title\",\"destination_field\":\"title\"},{\"operation\":\"move\",\"source_field\":\"metadata.author\",\"destination_field\":\"author\"},{\"operation\":\"move\",\"source_field\":\"alchemy_enriched_text.language\",\"destination_field\":\"language\"},{\"operation\":\"remove\",\"source_field\":\"html\"},{\"operation\":\"remove\",\"source_field\":\"alchemy_enriched_text.status\"},{\"operation\":\"remove\",\"source_field\":\"alchemy_enriched_text.text\"},{\"operation\":\"remove\",\"source_field\":\"sire_enriched_text.language\"},{\"operation\":\"remove\",\"source_field\":\"sire_enriched_text.model\"},{\"operation\":\"remove\",\"source_field\":\"sire_enriched_text.status\"},{\"operation\":\"remove_nulls\"}]}";
@@ -74,14 +87,42 @@ public class ExampleDiscovery : MonoBehaviour
     private void Start()
     {
         LogSystem.InstallDefaultReactors();
-
-        //  Create credential and instantiate service
-        Credentials credentials = new Credentials(_username, _password, _url);
-
-        _discovery = new Discovery(credentials);
-        _discovery.VersionDate = _versionDate;
         _filePathToIngest = Application.dataPath + "/Watson/Examples/ServiceExamples/TestData/watson_beats_jeopardy.html";
         _documentFilePath = Application.dataPath + "/Watson/Examples/ServiceExamples/TestData/watson_beats_jeopardy.html";
+        Runnable.Run(CreateService());
+    }
+
+    private IEnumerator CreateService()
+    {
+        //  Create credential and instantiate service
+        Credentials credentials = null;
+        if (!string.IsNullOrEmpty(_username) && !string.IsNullOrEmpty(_password))
+        {
+            //  Authenticate using username and password
+            credentials = new Credentials(_username, _password, _serviceUrl);
+        }
+        else if (!string.IsNullOrEmpty(_iamApikey))
+        {
+            //  Authenticate using iamApikey
+            TokenOptions tokenOptions = new TokenOptions()
+            {
+                IamApiKey = _iamApikey,
+                IamUrl = _iamUrl
+            };
+
+            credentials = new Credentials(tokenOptions, _serviceUrl);
+
+            //  Wait for tokendata
+            while (!credentials.HasIamTokenData())
+                yield return null;
+        }
+        else
+        {
+            throw new WatsonException("Please provide either username and password or IAM apikey to authenticate the service.");
+        }
+
+        _service = new Discovery(credentials);
+        _service.VersionDate = _versionDate;
 
         Runnable.Run(Examples());
     }
@@ -90,7 +131,7 @@ public class ExampleDiscovery : MonoBehaviour
     {
         //  Get Environments
         Log.Debug("TestDiscovery.RunTest()", "Attempting to get environments");
-        if (!_discovery.GetEnvironments(OnGetEnvironments, OnFail))
+        if (!_service.GetEnvironments(OnGetEnvironments, OnFail))
             Log.Debug("TestDiscovery.GetEnvironments()", "Failed to get environments");
         while (!_getEnvironmentsTested)
             yield return null;
@@ -102,96 +143,96 @@ public class ExampleDiscovery : MonoBehaviour
 
         //  GetEnvironment
         Log.Debug("TestDiscovery.RunTest()", "Attempting to get environment");
-        if (!_discovery.GetEnvironment(OnGetEnvironment, OnFail, _environmentId))
+        if (!_service.GetEnvironment(OnGetEnvironment, OnFail, _environmentId))
             Log.Debug("TestDiscovery.GetEnvironment()", "Failed to get environment");
         while (!_getEnvironmentTested)
             yield return null;
 
         //  Get Configurations
         Log.Debug("TestDiscovery.RunTest()", "Attempting to get configurations");
-        if (!_discovery.GetConfigurations(OnGetConfigurations, OnFail, _environmentId))
+        if (!_service.GetConfigurations(OnGetConfigurations, OnFail, _environmentId))
             Log.Debug("TestDiscovery.GetConfigurations()", "Failed to get configurations");
         while (!_getConfigurationsTested)
             yield return null;
 
         //  Add Configuration
         Log.Debug("TestDiscovery.RunTest()", "Attempting to add configuration");
-        if (!_discovery.AddConfiguration(OnAddConfiguration, OnFail, _environmentId, _configurationJson.Replace("{guid}", GUID.Generate().ToString())))
+        if (!_service.AddConfiguration(OnAddConfiguration, OnFail, _environmentId, _configurationJson.Replace("{guid}", GUID.Generate().ToString())))
             Log.Debug("TestDiscovery.AddConfiguration()", "Failed to add configuration");
         while (!_addConfigurationTested)
             yield return null;
 
         //  Get Configuration
         Log.Debug("TestDiscovery.RunTest()", "Attempting to get configuration");
-        if (!_discovery.GetConfiguration(OnGetConfiguration, OnFail, _environmentId, _environmentId))
+        if (!_service.GetConfiguration(OnGetConfiguration, OnFail, _environmentId, _environmentId))
             Log.Debug("TestDiscovery.GetConfiguration()", "Failed to get configuration");
         while (!_getConfigurationTested)
             yield return null;
 
         //  Preview Configuration
         Log.Debug("TestDiscovery.RunTest()", "Attempting to preview configuration");
-        if (!_discovery.PreviewConfiguration(OnPreviewConfiguration, OnFail, _environmentId, _environmentId, null, _filePathToIngest, _metadata))
+        if (!_service.PreviewConfiguration(OnPreviewConfiguration, OnFail, _environmentId, _environmentId, null, _filePathToIngest, _metadata))
             Log.Debug("TestDiscovery.PreviewConfiguration()", "Failed to preview configuration");
         while (!_previewConfigurationTested)
             yield return null;
 
         //  Get Collections
         Log.Debug("TestDiscovery.RunTest()", "Attempting to get collections");
-        if (!_discovery.GetCollections(OnGetCollections, OnFail, _environmentId))
+        if (!_service.GetCollections(OnGetCollections, OnFail, _environmentId))
             Log.Debug("TestDiscovery.GetCollections()", "Failed to get collections");
         while (!_getCollectionsTested)
             yield return null;
 
         //  Add Collection
         Log.Debug("TestDiscovery.RunTest()", "Attempting to add collection");
-        if (!_discovery.AddCollection(OnAddCollection, OnFail, _environmentId, _createdCollectionName + GUID.Generate().ToString(), _createdCollectionDescription, _environmentId))
+        if (!_service.AddCollection(OnAddCollection, OnFail, _environmentId, _createdCollectionName + GUID.Generate().ToString(), _createdCollectionDescription, _environmentId))
             Log.Debug("TestDiscovery.AddCollection()", "Failed to add collection");
         while (!_addCollectionTested)
             yield return null;
 
         //  Get Collection
         Log.Debug("TestDiscovery.RunTest()", "Attempting to get collection");
-        if (!_discovery.GetCollection(OnGetCollection, OnFail, _environmentId, _createdCollectionID))
+        if (!_service.GetCollection(OnGetCollection, OnFail, _environmentId, _createdCollectionID))
             Log.Debug("TestDiscovery.GetCollection()", "Failed to get collection");
         while (!_getCollectionTested)
             yield return null;
 
-        if (!_discovery.GetFields(OnGetFields, OnFail, _environmentId, _createdCollectionID))
+        if (!_service.GetFields(OnGetFields, OnFail, _environmentId, _createdCollectionID))
             Log.Debug("TestDiscovery.GetFields()", "Failed to get fields");
         while (!_getFieldsTested)
             yield return null;
 
         //  Add Document
         Log.Debug("TestDiscovery.RunTest()", "Attempting to add document");
-        if (!_discovery.AddDocument(OnAddDocument, OnFail, _environmentId, _createdCollectionID, _documentFilePath, _environmentId, null))
+        if (!_service.AddDocument(OnAddDocument, OnFail, _environmentId, _createdCollectionID, _documentFilePath, _environmentId, null))
             Log.Debug("TestDiscovery.AddDocument()", "Failed to add document");
         while (!_addDocumentTested)
             yield return null;
 
         //  Get Document
         Log.Debug("TestDiscovery.RunTest()", "Attempting to get document");
-        if (!_discovery.GetDocument(OnGetDocument, OnFail, _environmentId, _createdCollectionID, _createdDocumentID))
+        if (!_service.GetDocument(OnGetDocument, OnFail, _environmentId, _createdCollectionID, _createdDocumentID))
             Log.Debug("TestDiscovery.GetDocument()", "Failed to get document");
         while (!_getDocumentTested)
             yield return null;
 
         //  Update Document
         Log.Debug("TestDiscovery.RunTest()", "Attempting to update document");
-        if (!_discovery.UpdateDocument(OnUpdateDocument, OnFail, _environmentId, _createdCollectionID, _createdDocumentID, _documentFilePath, _environmentId, null))
+        if (!_service.UpdateDocument(OnUpdateDocument, OnFail, _environmentId, _createdCollectionID, _createdDocumentID, _documentFilePath, _environmentId, null))
             Log.Debug("TestDiscovery.UpdateDocument()", "Failed to update document");
         while (!_updateDocumentTested)
             yield return null;
 
         //  Query
         Log.Debug("TestDiscovery.RunTest()", "Attempting to query");
-        if (!_discovery.Query(OnQuery, OnFail, _environmentId, _createdCollectionID, null, _query, null, 10, null, 0))
+        if (!_service.Query(OnQuery, OnFail, _environmentId, _createdCollectionID, null, _query, null, 10, null, 0))
             Log.Debug("TestDiscovery.Query()", "Failed to query");
         while (!_queryTested)
             yield return null;
 
         //  Delete Document
         Log.Debug("TestDiscovery.RunTest()", "Attempting to delete document {0}", _createdDocumentID);
-        if (!_discovery.DeleteDocument(OnDeleteDocument, OnFail, _environmentId, _createdCollectionID, _createdDocumentID))
+        if (!_service.DeleteDocument(OnDeleteDocument, OnFail, _environmentId, _createdCollectionID, _createdDocumentID))
             Log.Debug("TestDiscovery.DeleteDocument()", "Failed to delete document");
         while (!_deleteDocumentTested)
             yield return null;
@@ -210,7 +251,7 @@ public class ExampleDiscovery : MonoBehaviour
         _readyToContinue = false;
         //  Delete Collection
         Log.Debug("TestDiscovery.RunTest()", "Attempting to delete collection {0}", _createdCollectionID);
-        if (!_discovery.DeleteCollection(OnDeleteCollection, OnFail, _environmentId, _createdCollectionID))
+        if (!_service.DeleteCollection(OnDeleteCollection, OnFail, _environmentId, _createdCollectionID))
             Log.Debug("TestDiscovery.DeleteCollection()", "Failed to delete collection");
         while (!_deleteCollectionTested)
             yield return null;
@@ -229,7 +270,7 @@ public class ExampleDiscovery : MonoBehaviour
         _readyToContinue = false;
         //  Delete Configuration
         Log.Debug("TestDiscovery.RunTest()", "Attempting to delete configuration {0}", _environmentId);
-        if (!_discovery.DeleteConfiguration(OnDeleteConfiguration, OnFail, _environmentId, _environmentId))
+        if (!_service.DeleteConfiguration(OnDeleteConfiguration, OnFail, _environmentId, _environmentId))
             Log.Debug("TestDiscovery.DeleteConfiguration()", "Failed to delete configuration");
         while (!_deleteConfigurationTested)
             yield return null;
@@ -256,7 +297,7 @@ public class ExampleDiscovery : MonoBehaviour
         Log.Debug("TestDiscovery.CheckEnvironmentState()", "Attempting to get environment state");
         try
         {
-            _discovery.GetEnvironment(HandleCheckEnvironmentState, OnFail, _environmentId);
+            _service.GetEnvironment(HandleCheckEnvironmentState, OnFail, _environmentId);
         }
         catch (System.Exception e)
         {

--- a/Examples/ServiceExamples/Scripts/ExampleNaturalLanguageUnderstanding.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleNaturalLanguageUnderstanding.cs
@@ -27,17 +27,30 @@ using UnityEngine;
 public class ExampleNaturalLanguageUnderstanding : MonoBehaviour
 {
     #region PLEASE SET THESE VARIABLES IN THE INSPECTOR
+    [Space(10)]
+    [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/natural-language-understanding/api\"")]
     [SerializeField]
-    private string _username;
-    [SerializeField]
-    private string _password;
-    [SerializeField]
-    private string _url;
+    private string _serviceUrl;
+    [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]
     [SerializeField]
     private string _versionDate;
+    [Header("CF Authentication")]
+    [Tooltip("The authentication username.")]
+    [SerializeField]
+    private string _username;
+    [Tooltip("The authentication password.")]
+    [SerializeField]
+    private string _password;
+    [Header("IAM Authentication")]
+    [Tooltip("The IAM apikey.")]
+    [SerializeField]
+    private string _iamApikey;
+    [Tooltip("The IAM url used to authenticate the apikey (optional). This defaults to \"https://iam.bluemix.net/identity/token\".")]
+    [SerializeField]
+    private string _iamUrl;
     #endregion
 
-    NaturalLanguageUnderstanding _naturalLanguageUnderstanding;
+    NaturalLanguageUnderstanding _service;
 
     private bool _getModelsTested = false;
     private bool _analyzeTested = false;
@@ -45,12 +58,40 @@ public class ExampleNaturalLanguageUnderstanding : MonoBehaviour
     void Start()
     {
         LogSystem.InstallDefaultReactors();
+        Runnable.Run(CreateService());
+    }
 
+    private IEnumerator CreateService()
+    {
         //  Create credential and instantiate service
-        Credentials credentials = new Credentials(_username, _password, _url);
+        Credentials credentials = null;
+        if (!string.IsNullOrEmpty(_username) && !string.IsNullOrEmpty(_password))
+        {
+            //  Authenticate using username and password
+            credentials = new Credentials(_username, _password, _serviceUrl);
+        }
+        else if (!string.IsNullOrEmpty(_iamApikey))
+        {
+            //  Authenticate using iamApikey
+            TokenOptions tokenOptions = new TokenOptions()
+            {
+                IamApiKey = _iamApikey,
+                IamUrl = _iamUrl
+            };
 
-        _naturalLanguageUnderstanding = new NaturalLanguageUnderstanding(credentials);
-        _naturalLanguageUnderstanding.VersionDate = _versionDate;
+            credentials = new Credentials(tokenOptions, _serviceUrl);
+
+            //  Wait for tokendata
+            while (!credentials.HasIamTokenData())
+                yield return null;
+        }
+        else
+        {
+            throw new WatsonException("Please provide either username and password or IAM apikey to authenticate the service.");
+        }
+
+        _service = new NaturalLanguageUnderstanding(credentials);
+        _service.VersionDate = _versionDate;
 
         Runnable.Run(Examples());
     }
@@ -58,7 +99,7 @@ public class ExampleNaturalLanguageUnderstanding : MonoBehaviour
     private IEnumerator Examples()
     {
         Log.Debug("ExampleNaturalLanguageUnderstanding.Examples()", "attempting to get models...");
-        if (!_naturalLanguageUnderstanding.GetModels(OnGetModels, OnFail))
+        if (!_service.GetModels(OnGetModels, OnFail))
             Log.Debug("ExampleNaturalLanguageUnderstanding.GetModels()", "Failed to get models.");
         while (!_getModelsTested)
             yield return null;
@@ -86,7 +127,7 @@ public class ExampleNaturalLanguageUnderstanding : MonoBehaviour
         };
 
         Log.Debug("ExampleNaturalLanguageUnderstanding.Examples()", "attempting to analyze...");
-        if (!_naturalLanguageUnderstanding.Analyze(OnAnalyze, OnFail, parameters))
+        if (!_service.Analyze(OnAnalyze, OnFail, parameters))
             Log.Debug("ExampleNaturalLanguageUnderstanding.Analyze()", "Failed to get models.");
         while (!_analyzeTested)
             yield return null;

--- a/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
@@ -27,15 +27,28 @@ using UnityEngine.UI;
 public class ExampleStreaming : MonoBehaviour
 {
     #region PLEASE SET THESE VARIABLES IN THE INSPECTOR
+    [Space(10)]
+    [Tooltip("The service URL (optional). This defaults to \"https://stream.watsonplatform.net/speech-to-text/api\"")]
+    [SerializeField]
+    private string _serviceUrl;
+    [Tooltip("Text field to display the results of streaming.")]
+    public Text ResultsField;
+    [Header("CF Authentication")]
+    [Tooltip("The authentication username.")]
     [SerializeField]
     private string _username;
+    [Tooltip("The authentication password.")]
     [SerializeField]
     private string _password;
+    [Header("IAM Authentication")]
+    [Tooltip("The IAM apikey.")]
     [SerializeField]
-    private string _url;
+    private string _iamApikey;
+    [Tooltip("The IAM url used to authenticate the apikey (optional). This defaults to \"https://iam.bluemix.net/identity/token\".")]
+    [SerializeField]
+    private string _iamUrl;
     #endregion
 
-    public Text ResultsField;
 
     private int _recordingRoutine = 0;
     private string _microphoneID = null;
@@ -43,45 +56,74 @@ public class ExampleStreaming : MonoBehaviour
     private int _recordingBufferSize = 1;
     private int _recordingHZ = 22050;
 
-    private SpeechToText _speechToText;
+    private SpeechToText _service;
 
     void Start()
     {
         LogSystem.InstallDefaultReactors();
+        Runnable.Run(CreateService());
+    }
 
+    private IEnumerator CreateService()
+    {
         //  Create credential and instantiate service
-        Credentials credentials = new Credentials(_username, _password, _url);
+        Credentials credentials = null;
+        if (!string.IsNullOrEmpty(_username) && !string.IsNullOrEmpty(_password))
+        {
+            //  Authenticate using username and password
+            credentials = new Credentials(_username, _password, _serviceUrl);
+        }
+        else if (!string.IsNullOrEmpty(_iamApikey))
+        {
+            //  Authenticate using iamApikey
+            TokenOptions tokenOptions = new TokenOptions()
+            {
+                IamApiKey = _iamApikey,
+                IamUrl = _iamUrl
+            };
 
-        _speechToText = new SpeechToText(credentials);
+            credentials = new Credentials(tokenOptions, _serviceUrl);
+
+            //  Wait for tokendata
+            while (!credentials.HasIamTokenData())
+                yield return null;
+        }
+        else
+        {
+            throw new WatsonException("Please provide either username and password or IAM apikey to authenticate the service.");
+        }
+
+        _service = new SpeechToText(credentials);
+        _service.StreamMultipart = true;
+
         Active = true;
-
         StartRecording();
     }
 
     public bool Active
     {
-        get { return _speechToText.IsListening; }
+        get { return _service.IsListening; }
         set
         {
-            if (value && !_speechToText.IsListening)
+            if (value && !_service.IsListening)
             {
-                _speechToText.DetectSilence = true;
-                _speechToText.EnableWordConfidence = true;
-                _speechToText.EnableTimestamps = true;
-                _speechToText.SilenceThreshold = 0.01f;
-                _speechToText.MaxAlternatives = 0;
-                _speechToText.EnableInterimResults = true;
-                _speechToText.OnError = OnError;
-                _speechToText.InactivityTimeout = -1;
-                _speechToText.ProfanityFilter = false;
-                _speechToText.SmartFormatting = true;
-                _speechToText.SpeakerLabels = false;
-                _speechToText.WordAlternativesThreshold = null;
-                _speechToText.StartListening(OnRecognize, OnRecognizeSpeaker);
+                _service.DetectSilence = true;
+                _service.EnableWordConfidence = true;
+                _service.EnableTimestamps = true;
+                _service.SilenceThreshold = 0.01f;
+                _service.MaxAlternatives = 0;
+                _service.EnableInterimResults = true;
+                _service.OnError = OnError;
+                _service.InactivityTimeout = -1;
+                _service.ProfanityFilter = false;
+                _service.SmartFormatting = true;
+                _service.SpeakerLabels = false;
+                _service.WordAlternativesThreshold = null;
+                _service.StartListening(OnRecognize, OnRecognizeSpeaker);
             }
-            else if (!value && _speechToText.IsListening)
+            else if (!value && _service.IsListening)
             {
-                _speechToText.StopListening();
+                _service.StopListening();
             }
         }
     }
@@ -151,7 +193,7 @@ public class ExampleStreaming : MonoBehaviour
                 record.Clip = AudioClip.Create("Recording", midPoint, _recording.channels, _recordingHZ, false);
                 record.Clip.SetData(samples, 0);
 
-                _speechToText.OnListen(record);
+                _service.OnListen(record);
 
                 bFirstBlock = !bFirstBlock;
             }

--- a/Scripts/Services/Assistant/v1/Assistant.cs
+++ b/Scripts/Services/Assistant/v1/Assistant.cs
@@ -77,6 +77,11 @@ namespace IBM.Watson.DeveloperCloud.Services.Assistant.v1
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/Conversation/v1/Conversation.cs
+++ b/Scripts/Services/Conversation/v1/Conversation.cs
@@ -97,6 +97,11 @@ namespace IBM.Watson.DeveloperCloud.Services.Conversation.v1
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/Discovery/v1/Discovery.cs
+++ b/Scripts/Services/Discovery/v1/Discovery.cs
@@ -105,6 +105,11 @@ namespace IBM.Watson.DeveloperCloud.Services.Discovery.v1
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/LanguageTranslator/v2/LanguageTranslator.cs
+++ b/Scripts/Services/LanguageTranslator/v2/LanguageTranslator.cs
@@ -77,6 +77,11 @@ namespace IBM.Watson.DeveloperCloud.Services.LanguageTranslator.v2
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/NaturalLanguageClassifier/v2/NaturalLanguageClassifier.cs
+++ b/Scripts/Services/NaturalLanguageClassifier/v2/NaturalLanguageClassifier.cs
@@ -41,6 +41,11 @@ namespace IBM.Watson.DeveloperCloud.Services.NaturalLanguageClassifier.v1
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/NaturalLanguageUnderstanding/v1/NaturalLanguageUnderstanding.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/v1/NaturalLanguageUnderstanding.cs
@@ -87,6 +87,11 @@ namespace IBM.Watson.DeveloperCloud.Services.NaturalLanguageUnderstanding.v1
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/PersonalityInsights/v3/PersonalityInsights.cs
+++ b/Scripts/Services/PersonalityInsights/v3/PersonalityInsights.cs
@@ -89,6 +89,11 @@ namespace IBM.Watson.DeveloperCloud.Services.PersonalityInsights.v3
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/SpeechToText/v1/SpeechToText.cs
+++ b/Scripts/Services/SpeechToText/v1/SpeechToText.cs
@@ -267,6 +267,11 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/Services/ToneAnalyzer/v3/ToneAnalyzer.cs
+++ b/Scripts/Services/ToneAnalyzer/v3/ToneAnalyzer.cs
@@ -88,6 +88,11 @@ namespace IBM.Watson.DeveloperCloud.Services.ToneAnalyzer.v3
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {

--- a/Scripts/UnitTests/TestVisualRecognitionCF.cs
+++ b/Scripts/UnitTests/TestVisualRecognitionCF.cs
@@ -52,6 +52,7 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
         private bool _trainClassifierTested = false;
         private bool _getClassifierTested = false;
         private bool _getCoreMLModelTested = false;
+        private bool _isClassifierReady = false;
 #endif
 #if DELETE_TRAINED_CLASSIFIER
         private bool _deleteClassifierTested = false;
@@ -60,8 +61,6 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
         private bool _classifyPostTested = false;
         private bool _detectFacesGetTested = false;
         private bool _detectFacesPostTested = false;
-
-        private bool _isClassifierReady = false;
 
         public override IEnumerator RunTest()
         {

--- a/Scripts/Utilities/Credentials.cs
+++ b/Scripts/Utilities/Credentials.cs
@@ -120,7 +120,8 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         {
             Username = username;
             Password = password;
-            Url = url;
+            if(!string.IsNullOrEmpty(url))
+                Url = url;
         }
 
         /// <summary>
@@ -138,9 +139,10 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         /// Constructor that takes IAM token options.
         /// </summary>
         /// <param name="iamTokenOptions"></param>
-        public Credentials(TokenOptions iamTokenOptions, string serviceUrl)
+        public Credentials(TokenOptions iamTokenOptions, string serviceUrl = null)
         {
-            Url = serviceUrl;
+            if(!string.IsNullOrEmpty(serviceUrl))
+                Url = serviceUrl;
             _iamUrl = !string.IsNullOrEmpty(iamTokenOptions.IamUrl) ? iamTokenOptions.IamUrl : "https://iam.bluemix.net/identity/token";
             _iamTokenData = new IamTokenData();
 


### PR DESCRIPTION
### Summary
This pull request revises the example scenes to accept either u/p or apikey for authentication. Additionally if the passed in Credentials object does not have a service url, we set that from the service. In each example I renamed the service instance to `_service`. Finally, i added a check for null credentials to avoid overwriting my credentials.

Examples will have public fields exposed (with tooltips) in Unity Editor
![example-in-inspector](https://user-images.githubusercontent.com/4381558/41240429-16b26178-6d60-11e8-9dfb-b17cd700ccb7.PNG)
