### PR TITLE
Region streaming endpoints

### DIFF
--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -196,14 +196,30 @@ namespace IBM.Watson.DeveloperCloud.Connection
                 URL = URL.Replace("http://stream.", "ws://stream.");
             else if (URL.StartsWith("https://stream."))
                 URL = URL.Replace("https://stream.", "wss://stream.");
+
+            //  Old TLS 1.0 endpoint
             else if (URL.StartsWith("http://stream-tls10."))
                 URL = URL.Replace("http://stream-tls10.", "ws://stream.");
             else if (URL.StartsWith("https://stream-tls10."))
                 URL = URL.Replace("https://stream-tls10.", "wss://stream.");
-            else if (URL.StartsWith("http://stream-fra."))
-                URL = URL.Replace("http://stream-fra.", "ws://stream-fra.");
-            else if (URL.StartsWith("https://stream-fra."))
-                URL = URL.Replace("https://stream-fra.", "wss://stream-fra.");
+
+            //  Germany
+            else if (URL.StartsWith("http://gateway-fra."))
+                URL = URL.Replace("http://gateway-fra.", "ws://stream-fra.");
+            else if (URL.StartsWith("https://gateway-fra."))
+                URL = URL.Replace("https://gateway-fra.", "wss://stream-fra.");
+
+            //  US East
+            else if (URL.StartsWith("http://gateway-wdc."))
+                URL = URL.Replace("http://gateway-wdc.", "ws://stream.");
+            else if (URL.StartsWith("https://gateway-wdc."))
+                URL = URL.Replace("https://gateway-wdc.", "wss://stream.");
+
+            //  Sydney
+            else if (URL.StartsWith("http://gateway-syd."))
+                URL = URL.Replace("http://gateway-syd.", "ws://stream-syd.");
+            else if (URL.StartsWith("https://gateway-syd."))
+                URL = URL.Replace("https://gateway-syd.", "wss://stream-syd.");
 #else
             //  Redirect to TLS 1.0 endpoints. 
             //  Note frankfurt endpoint does not support TLS 1.0.

--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -205,33 +205,59 @@ namespace IBM.Watson.DeveloperCloud.Connection
 #if UNITY_2018_2_OR_NEWER
             //  Use standard endpoints since 2018.2 supports TLS 1.2
             if (URL.StartsWith("http://stream."))
+            {
                 URL = URL.Replace("http://stream.", "ws://stream.");
+            }
             else if (URL.StartsWith("https://stream."))
+            {
                 URL = URL.Replace("https://stream.", "wss://stream.");
+            }
 
-            //  Old TLS 1.0 endpoint
+            //  TLS 1.0 endpoint
             else if (URL.StartsWith("http://stream-tls10."))
+            {
                 URL = URL.Replace("http://stream-tls10.", "ws://stream.");
+            }
             else if (URL.StartsWith("https://stream-tls10."))
+            {
                 URL = URL.Replace("https://stream-tls10.", "wss://stream.");
+            }
 
             //  Germany
             else if (URL.StartsWith("http://gateway-fra."))
+            {
                 URL = URL.Replace("http://gateway-fra.", "ws://stream-fra.");
+            }
             else if (URL.StartsWith("https://gateway-fra."))
+            {
                 URL = URL.Replace("https://gateway-fra.", "wss://stream-fra.");
+            }
 
             //  US East
             else if (URL.StartsWith("http://gateway-wdc."))
-                URL = URL.Replace("http://gateway-wdc.", "ws://stream.");
+            {
+                URL = URL.Replace("http://gateway-wdc.", "ws://gateway-wdc.");
+            }
             else if (URL.StartsWith("https://gateway-wdc."))
-                URL = URL.Replace("https://gateway-wdc.", "wss://stream.");
+            {
+                URL = URL.Replace("https://gateway-wdc.", "wss://gateway-wdc.");
+            }
+
 
             //  Sydney
             else if (URL.StartsWith("http://gateway-syd."))
-                URL = URL.Replace("http://gateway-syd.", "ws://stream-syd.");
+            {
+                URL = URL.Replace("http://gateway-syd.", "ws://gateway-syd.");
+            }
             else if (URL.StartsWith("https://gateway-syd."))
-                URL = URL.Replace("https://gateway-syd.", "wss://stream-syd.");
+            {
+                URL = URL.Replace("https://gateway-syd.", "wss://gateway-syd.");
+            }
+
+            else
+            {
+                Log.Warning("WSConnector", "No case for URL for wss://. Leaving URL unchanged.");
+            }
 #else
             //  Redirect to TLS 1.0 endpoints. 
             //  Note frankfurt endpoint does not support TLS 1.0.

--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -158,7 +158,19 @@ namespace IBM.Watson.DeveloperCloud.Connection
         /// <summary>
         /// Headers to pass when making the socket.
         /// </summary>
-        public Dictionary<string, string> Headers { get; set; }
+        private Dictionary<string, string> _headers;
+        public Dictionary<string, string> Headers {
+            get
+            {
+                if (_headers == null)
+                    _headers = new Dictionary<string, string>();
+                return _headers;
+            }
+            set
+            {
+                _headers = value;
+            }
+        }
         /// <summary>
         /// Credentials used to authenticate with the server.
         /// </summary>

--- a/Scripts/Services/SpeechToText/v1/SpeechToText.cs
+++ b/Scripts/Services/SpeechToText/v1/SpeechToText.cs
@@ -320,9 +320,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -415,9 +415,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -515,9 +515,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             if (!CreateListenConnector())
                 return false;
 
-			if (customData == null)
-				customData = new Dictionary<string, object>();
-			
+            if (customData == null)
+                customData = new Dictionary<string, object>();
+
             Dictionary<string, string> customHeaders = new Dictionary<string, string>();
             if (customData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
@@ -528,7 +528,10 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             }
 
             if (customHeaders != null && _listenSocket != null)
-                _listenSocket.Headers = customHeaders;
+            {
+                foreach (KeyValuePair<string, string> kvp in customHeaders)
+                    _listenSocket.Headers.Add(kvp.Key, kvp.Value);
+            }
 
             _isListening = true;
             _listenCallback = callback;
@@ -698,16 +701,16 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             start["content-type"] = "audio/l16;rate=" + _recordingHZ.ToString() + ";channels=1;";
             start["inactivity_timeout"] = InactivityTimeout;
             start["interim_results"] = EnableInterimResults;
-            if(Keywords != null)
+            if (Keywords != null)
                 start["keywords"] = Keywords;
-            if(KeywordsThreshold != null)
+            if (KeywordsThreshold != null)
                 start["keywords_threshold"] = KeywordsThreshold;
             start["max_alternatives"] = MaxAlternatives;
             start["profanity_filter"] = ProfanityFilter;
             start["smart_formatting"] = SmartFormatting;
             start["speaker_labels"] = SpeakerLabels;
             start["timestamps"] = EnableTimestamps;
-            if(WordAlternativesThreshold != null)
+            if (WordAlternativesThreshold != null)
                 start["word_alternatives_threshold"] = WordAlternativesThreshold;
             start["word_confidence"] = EnableWordConfidence;
 
@@ -766,7 +769,7 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
                 WSConnector.TextMessage tm = (WSConnector.TextMessage)msg;
                 Dictionary<string, object> customData = new Dictionary<string, object>();
                 customData.Add(Constants.String.JSON, tm.Text);
-                if(tm.Headers != null && tm.Headers.Count > 0)
+                if (tm.Headers != null && tm.Headers.Count > 0)
                     customData.Add(Constants.String.RESPONSE_HEADERS, tm.Headers);
 
                 IDictionary json = Json.Deserialize(tm.Text) as IDictionary;
@@ -882,7 +885,7 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
                 throw new ArgumentNullException("failCallback");
             if (clip == null)
                 throw new ArgumentNullException("clip");
-            
+
             return Recognize(successCallback, failCallback, WaveFile.CreateWAV(clip), "audio/wav", customData);
         }
 
@@ -914,9 +917,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1006,7 +1009,7 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
 
                     customData.Add("json", data);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     Log.Error("SpeechToText.OnRecognizeResponse()", "OnGetAuthorsResponse Exception: {0}", e.ToString());
                     resp.Success = false;
@@ -1103,7 +1106,7 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
 
                     SpeechRecognitionResult result = new SpeechRecognitionResult();
                     result.final = (bool)iresult["final"];
-                    
+
                     IList iwordAlternatives = iresult["word_alternatives"] as IList;
                     if (iwordAlternatives != null)
                     {
@@ -1280,9 +1283,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1389,9 +1392,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1489,9 +1492,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1566,9 +1569,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1673,9 +1676,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1753,9 +1756,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1832,9 +1835,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -1912,9 +1915,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2014,9 +2017,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2115,9 +2118,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2197,9 +2200,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2279,9 +2282,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2474,9 +2477,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2557,9 +2560,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2637,9 +2640,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2732,9 +2735,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2841,9 +2844,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -2940,9 +2943,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -3016,9 +3019,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -3114,9 +3117,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -3196,9 +3199,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -3274,9 +3277,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -3373,9 +3376,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -3453,9 +3456,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }
@@ -3562,9 +3565,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
             req.SuccessCallback = successCallback;
             req.FailCallback = failCallback;
             req.CustomData = customData == null ? new Dictionary<string, object>() : customData;
-            if(req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
             {
-                foreach(KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
+                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
                 {
                     req.Headers.Add(kvp.Key, kvp.Value);
                 }


### PR DESCRIPTION
### Summary
In this pull request we add cases for streaming endpoints in different regions in `WSConnector.cs` FixupURL operation. We added regions for Frankfurt, Washington DC and Sydney. Additionally, `SpeechToText.cs` was reformatted.