### PR TITLE
Deprecate CF tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ private void OnMessage(object resp, Dictionary<string, object> customData)
 ```
 
 ## Authentication Tokens
+
+**Authenticating with the `X-Watson-Authorization-Token` header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. For details see [Authenticating with IAM tokens](https://console.bluemix.net/docs/services/watson/getting-started-iam.html#iam) or the [README](#IAM) in the IBM Watson SDK you use.**
+
 You use tokens to write applications that make authenticated requests to IBM Watson™ services without embedding service credentials in every call.
 
 You can write an authentication proxy in IBM Cloud that obtains and returns a token to your client application, which can then use the token to call the service directly. This proxy eliminates the need to channel all service requests through an intermediate server-side application, which is otherwise necessary to avoid exposing your service credentials from your client application.

--- a/Scripts/Utilities/Utility.cs
+++ b/Scripts/Utilities/Utility.cs
@@ -1178,6 +1178,7 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         /// <returns>True if the call succeeds.</returns>
         public static bool GetWatsonToken(OnGetWatsonToken callback, string serviceEndpoint, string username, string password, string tokenName = "")
         {
+            Log.Warning("Utility.GetWatsonToken()", "Authenticating with the `X-Watson-Authorization-Token` header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. For details see [Authenticating with IAM tokens](https://console.bluemix.net/docs/services/watson/getting-started-iam.html#iam) or the README in the IBM Watson SDK you use.");
             if (callback == null)
                 throw new ArgumentNullException("callback");
             if (string.IsNullOrEmpty(serviceEndpoint))


### PR DESCRIPTION
### Summary
This pull request adds a deprecation notice to the README and deprecation warning when attempting to get a Watson CF token.