### PR TITLE
add node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: objective-c
 osx_image: xcode61
+node_js:
+- "8"
 rvm:
 - 2.2
 cache:


### PR DESCRIPTION
### Summary
This pull request adds node 8 to the travis build process because semantic release was failing