### PR TITLE
TLS 1.0 support for .NET 3.x on Unity 2018.2+

### DIFF
--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -190,6 +190,8 @@ namespace IBM.Watson.DeveloperCloud.Connection
         private AutoResetEvent _receiveEvent = new AutoResetEvent(false);
         private Queue<Message> _receiveQueue = new Queue<Message>();
         private int _receiverRoutine = 0;
+        private static readonly string https = "https://";
+        private static readonly string wss = "wss://";
         #endregion
 
         /// <summary>
@@ -231,7 +233,7 @@ namespace IBM.Watson.DeveloperCloud.Connection
             }
             else
             {
-                URL = URL.Replace("https://", "wss://");
+                URL = URL.Replace(https, wss);
                 Log.Warning("WSConnector", "No case for URL for wss://. Replacing https:// with wss://.");
             }
 #else
@@ -247,7 +249,7 @@ namespace IBM.Watson.DeveloperCloud.Connection
             }
             else
             {
-                URL = URL.Replace("https://", "wss://");
+                URL = URL.Replace(https, wss);
                 Log.Warning("WSConnector", "No case for URL for wss://. Replacing https:// with wss://.");
                 Log.Warning("WSConnector", "Streaming with TLS 1.0 is only available in US South. Please create your Speech to Text instance in US South. Alternatviely, use Unity 2018.2 with .NET 4.x Scripting Runtime Version enabled (File > Build Settings > Player Settings > Other Settings > Scripting Runtime Version).");
             }
@@ -265,7 +267,7 @@ namespace IBM.Watson.DeveloperCloud.Connection
             }
             else
             {
-                URL = URL.Replace("https://", "wss://");
+                URL = URL.Replace(https, wss);
                 Log.Warning("WSConnector", "No case for URL for wss://. Replacing https:// with wss://.");
                 Log.Warning("WSConnector", "Streaming with TLS 1.0 is only available in US South. Please create your Speech to Text instance in US South. Alternatviely, use Unity 2018.2 with .NET 4.x Scripting Runtime Version enabled (File > Build Settings > Player Settings > Other Settings > Scripting Runtime Version).");
             }

--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -414,8 +414,10 @@ namespace IBM.Watson.DeveloperCloud.Connection
                 ws.OnClose += OnWSClose;
                 ws.OnError += OnWSError;
                 ws.OnMessage += OnWSMessage;
-#if UNITY_2018_2_OR_NEWER
+#if NET_4_6
                 ws.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+#else
+                ws.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls;
 #endif
                 ws.Connect();
 

--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -213,14 +213,16 @@ namespace IBM.Watson.DeveloperCloud.Connection
                 URL = URL.Replace("https://stream.", "wss://stream.");
             }
 
-            //  TLS 1.0 endpoint
+            //  TLS 1.0 endpoint - Do not change this to TLS 1.2 endpoint since
+            //  users may need to use the TLS 1.0 endpoint because of different
+            //  platforms.
             else if (URL.StartsWith("http://stream-tls10."))
             {
-                URL = URL.Replace("http://stream-tls10.", "ws://stream.");
+                URL = URL.Replace("http://stream-tls10.", "ws://stream-tls10.");
             }
             else if (URL.StartsWith("https://stream-tls10."))
             {
-                URL = URL.Replace("https://stream-tls10.", "wss://stream.");
+                URL = URL.Replace("https://stream-tls10.", "wss://stream-tls10.");
             }
 
             //  Germany

--- a/Scripts/Connection/WSConnector.cs
+++ b/Scripts/Connection/WSConnector.cs
@@ -22,11 +22,8 @@ using IBM.Watson.DeveloperCloud.Logging;
 using IBM.Watson.DeveloperCloud.Utilities;
 using System.Collections;
 using System.Collections.Generic;
-using System.Threading;
-#if UNITY_2018_2_OR_NEWER
 using System.Security.Authentication;
-#endif
-
+using System.Threading;
 #if !NETFX_CORE
 using UnitySDK.WebSocketSharp;
 #else
@@ -205,11 +202,7 @@ namespace IBM.Watson.DeveloperCloud.Connection
 #if UNITY_2018_2_OR_NEWER
 #if NET_4_6
             //  Use standard endpoints since 2018.2 supports TLS 1.2
-            if (URL.StartsWith("http://stream."))
-            {
-                URL = URL.Replace("http://stream.", "ws://stream.");
-            }
-            else if (URL.StartsWith("https://stream."))
+            if (URL.StartsWith("https://stream."))
             {
                 URL = URL.Replace("https://stream.", "wss://stream.");
             }
@@ -217,87 +210,66 @@ namespace IBM.Watson.DeveloperCloud.Connection
             //  TLS 1.0 endpoint - Do not change this to TLS 1.2 endpoint since
             //  users may need to use the TLS 1.0 endpoint because of different
             //  platforms.
-            else if (URL.StartsWith("http://stream-tls10."))
-            {
-                URL = URL.Replace("http://stream-tls10.", "ws://stream-tls10.");
-            }
             else if (URL.StartsWith("https://stream-tls10."))
             {
                 URL = URL.Replace("https://stream-tls10.", "wss://stream-tls10.");
             }
-
             //  Germany
-            else if (URL.StartsWith("http://gateway-fra."))
-            {
-                URL = URL.Replace("http://gateway-fra.", "ws://stream-fra.");
-            }
             else if (URL.StartsWith("https://gateway-fra."))
             {
                 URL = URL.Replace("https://gateway-fra.", "wss://stream-fra.");
             }
-
             //  US East
-            else if (URL.StartsWith("http://gateway-wdc."))
-            {
-                URL = URL.Replace("http://gateway-wdc.", "ws://gateway-wdc.");
-            }
             else if (URL.StartsWith("https://gateway-wdc."))
             {
                 URL = URL.Replace("https://gateway-wdc.", "wss://gateway-wdc.");
             }
-
-
             //  Sydney
-            else if (URL.StartsWith("http://gateway-syd."))
-            {
-                URL = URL.Replace("http://gateway-syd.", "ws://gateway-syd.");
-            }
             else if (URL.StartsWith("https://gateway-syd."))
             {
                 URL = URL.Replace("https://gateway-syd.", "wss://gateway-syd.");
             }
-
             else
             {
-                Log.Warning("WSConnector", "No case for URL for wss://. Leaving URL unchanged.");
+                URL = URL.Replace("https://", "wss://");
+                Log.Warning("WSConnector", "No case for URL for wss://. Replacing https:// with wss://.");
             }
 #else
             //  Use TLS 1.0 endpoint if user is on .NET 3.5. US South is the 
             //  only region that supports this endpoint.
-            if (URL.StartsWith("http://stream."))
-            {
-                URL = URL.Replace("http://stream.", "ws://stream-tls10.");
-            }
-            else if (URL.StartsWith("https://stream."))
+            if (URL.StartsWith("https://stream."))
             {
                 URL = URL.Replace("https://stream.", "wss://stream-tls10.");
-            }
-            else if (URL.StartsWith("http://stream-tls10."))
-            {
-                URL = URL.Replace("http://stream-tls10.", "ws://stream-tls10.");
             }
             else if (URL.StartsWith("https://stream-tls10."))
             {
                 URL = URL.Replace("https://stream-tls10.", "wss://stream-tls10.");
+            }
+            else
+            {
+                URL = URL.Replace("https://", "wss://");
+                Log.Warning("WSConnector", "No case for URL for wss://. Replacing https:// with wss://.");
+                Log.Warning("WSConnector", "Streaming with TLS 1.0 is only available in US South. Please create your Speech to Text instance in US South. Alternatviely, use Unity 2018.2 with .NET 4.x Scripting Runtime Version enabled (File > Build Settings > Player Settings > Other Settings > Scripting Runtime Version).");
             }
 #endif
 #else
-            //  Redirect to TLS 1.0 endpoints. 
-            //  Note frankfurt endpoint does not support TLS 1.0.
-            if (URL.StartsWith("http://stream."))
-                URL = URL.Replace("http://stream.", "ws://stream-tls10.");
-            else if (URL.StartsWith("https://stream."))
+            //  Use TLS 1.0 endpoint if user is on .NET 3.5 or 4.6 if using Unity 2018.1 or older.
+            //  US South is the only region that supports this endpoint.
+            if (URL.StartsWith("https://stream."))
+            {
                 URL = URL.Replace("https://stream.", "wss://stream-tls10.");
-            else if (URL.StartsWith("http://stream-tls10."))
-                URL = URL.Replace("http://stream-tls10.", "ws://stream-tls10.");
+            }
             else if (URL.StartsWith("https://stream-tls10."))
+            {
                 URL = URL.Replace("https://stream-tls10.", "wss://stream-tls10.");
-            else if (URL.StartsWith("http://stream-fra."))
-                URL = URL.Replace("http://stream-fra.", "ws://stream-fra.");
-            else if (URL.StartsWith("https://stream-fra."))
-                URL = URL.Replace("https://stream-fra.", "wss://stream-fra.");
+            }
+            else
+            {
+                URL = URL.Replace("https://", "wss://");
+                Log.Warning("WSConnector", "No case for URL for wss://. Replacing https:// with wss://.");
+                Log.Warning("WSConnector", "Streaming with TLS 1.0 is only available in US South. Please create your Speech to Text instance in US South. Alternatviely, use Unity 2018.2 with .NET 4.x Scripting Runtime Version enabled (File > Build Settings > Player Settings > Other Settings > Scripting Runtime Version).");
+            }
 #endif
-
             return URL;
         }
 
@@ -330,7 +302,7 @@ namespace IBM.Watson.DeveloperCloud.Connection
             return connector;
         }
 
-        #region Public Functions
+#region Public Functions
         /// <summary>
         /// This function sends the given message object.
         /// </summary>
@@ -382,9 +354,9 @@ namespace IBM.Watson.DeveloperCloud.Connection
             // setting the state to closed will make the SendThread automatically exit.
             _connectionState = ConnectionState.CLOSED;
         }
-        #endregion
+#endregion
 
-        #region Private Functions
+#region Private Functions
         private IEnumerator ProcessReceiveQueue()
         {
             while (_connectionState == ConnectionState.CONNECTED
@@ -415,9 +387,9 @@ namespace IBM.Watson.DeveloperCloud.Connection
             if (OnClose != null)
                 OnClose(this);
         }
-        #endregion
+#endregion
 
-        #region Threaded Functions
+#region Threaded Functions
         // NOTE: All functions in this region are operating in a background thread, do NOT call any Unity functions!
 #if !NETFX_CORE
         private void SendMessages()
@@ -616,6 +588,6 @@ namespace IBM.Watson.DeveloperCloud.Connection
             }
         }
 #endif
-        #endregion
+#endregion
     }
 }

--- a/Scripts/UnitTests/TestDiscovery.cs
+++ b/Scripts/UnitTests/TestDiscovery.cs
@@ -69,7 +69,6 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
         private bool _deleteConfigurationTested = false;
         private bool _isEnvironmentReady = false;
         private bool _deleteUserDataTested = false;
-        private bool _readyToContinue = false;
 
         private bool _listCredentialsTested = false;
         private bool _createCredentialsTested = false;
@@ -332,7 +331,6 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
             while (!_isEnvironmentReady)
                 yield return null;
 
-            _readyToContinue = false;
             //  Delete Collection
             Log.Debug("TestDiscovery.RunTest()", "Attempting to delete collection {0}", _createdCollectionId);
             if (!_discovery.DeleteCollection(OnDeleteCollection, OnFail, _environmentId, _createdCollectionId))
@@ -345,7 +343,6 @@ namespace IBM.Watson.DeveloperCloud.UnitTests
             while (!_isEnvironmentReady)
                 yield return null;
 
-            _readyToContinue = false;
             //  Delete Configuration
             Log.Debug("TestDiscovery.RunTest()", "Attempting to delete configuration {0}", _createdConfigurationID);
             if (!_discovery.DeleteConfiguration(OnDeleteConfiguration, OnFail, _environmentId, _createdConfigurationID))


### PR DESCRIPTION
### Summary
This pull request adds changes for .NET 3.x support in Unity 2018.2 and above. Some platforms do not support .NET 4.x so we cannot push users to the TLS 1.2 endpoint if they are using Unity 2018.2. Additionally we only add TLS 1.1 and TLS 1.2 protocols if the user is using .NET 4.x there is no support for TLS 1.1 and 1.2 in .NET 3.x.