### PR TITLE
Null checks for required parameters

### DIFF
--- a/Scripts/Services/Assistant/v2/Assistant.cs
+++ b/Scripts/Services/Assistant/v2/Assistant.cs
@@ -126,9 +126,17 @@ namespace IBM.Watson.DeveloperCloud.Services.Assistant.v2
         public bool CreateSession(SuccessCallback<SessionResponse> successCallback, FailCallback failCallback, String assistantId, Dictionary<string, object> customData = null)
         {
             if (successCallback == null)
-                throw new ArgumentNullException("successCallback");
+            {
+                throw new ArgumentNullException("successCallback is required for CreateSession");
+            }
             if (failCallback == null)
-                throw new ArgumentNullException("failCallback");
+            {
+                throw new ArgumentNullException("failCallback is required for CreateSession");
+            }
+            if(string.IsNullOrEmpty(assistantId))
+            {
+                throw new ArgumentException("assistantId is required for CreateSession");
+            }
 
             CreateSessionRequestObj req = new CreateSessionRequestObj();
             req.SuccessCallback = successCallback;
@@ -229,9 +237,21 @@ namespace IBM.Watson.DeveloperCloud.Services.Assistant.v2
         public bool DeleteSession(SuccessCallback<object> successCallback, FailCallback failCallback, String assistantId, String sessionId, Dictionary<string, object> customData = null)
         {
             if (successCallback == null)
-                throw new ArgumentNullException("successCallback");
+            {
+                throw new ArgumentNullException("successCallback is required for DeleteSession");
+            }
             if (failCallback == null)
-                throw new ArgumentNullException("failCallback");
+            {
+                throw new ArgumentNullException("failCallback is required for DeleteSession");
+            }
+            if(string.IsNullOrEmpty(assistantId))
+            {
+                throw new ArgumentException("assistantId is required for DeleteSession");
+            }
+            if (string.IsNullOrEmpty(sessionId))
+            {
+                throw new ArgumentException("sessionId is required for DeleteSession");
+            }
 
             DeleteSessionRequestObj req = new DeleteSessionRequestObj();
             req.SuccessCallback = successCallback;
@@ -334,9 +354,21 @@ namespace IBM.Watson.DeveloperCloud.Services.Assistant.v2
         public bool Message(SuccessCallback<MessageResponse> successCallback, FailCallback failCallback, String assistantId, String sessionId, MessageRequest request = null, Dictionary<string, object> customData = null)
         {
             if (successCallback == null)
-                throw new ArgumentNullException("successCallback");
+            {
+                throw new ArgumentNullException("successCallback is required for Message");
+            }
             if (failCallback == null)
-                throw new ArgumentNullException("failCallback");
+            {
+                throw new ArgumentNullException("failCallback is required for Message");
+            }
+            if (string.IsNullOrEmpty(assistantId))
+            {
+                throw new ArgumentException("assistantId is required for Message");
+            }
+            if (string.IsNullOrEmpty(sessionId))
+            {
+                throw new ArgumentException("sessionId is required for Message");
+            }
 
             MessageRequestObj req = new MessageRequestObj();
             req.SuccessCallback = successCallback;


### PR DESCRIPTION
### Summary
Some null checks for required parameters were omitted when abstracting the Assistant V2 service. These were added in this pull request. Additionally a better error message is thrown on these null checks.