### PR TITLE
Refactor label for iam url in streaming example

### DIFF
--- a/Examples/ServiceExamples/ExampleStreaming.unity
+++ b/Examples/ServiceExamples/ExampleStreaming.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.496413, b: 0.5748175, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -145,7 +145,8 @@ MonoBehaviour:
   _username: 
   _password: 
   _iamApikey: 
-  _iamUrl: 
+  _iamTokenUrl: https://iam.bluemix.net/identity/token
+  _recognizeModel: 
 --- !u!4 &249853926
 Transform:
   m_ObjectHideFlags: 0
@@ -506,7 +507,7 @@ MonoBehaviour:
   _username: 
   _password: 
   _iamApikey: 
-  _iamUrl: 
+  _iamTokenUrl: https://iam.bluemix.net/identity/token
   _recognizeModel: 
 --- !u!4 &1646685151
 Transform:

--- a/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
@@ -46,7 +46,7 @@ public class ExampleStreaming : MonoBehaviour
     private string _iamApikey;
     [Tooltip("The IAM url used to authenticate the apikey (optional). This defaults to \"https://iam.bluemix.net/identity/token\".")]
     [SerializeField]
-    private string _iamUrl;
+    private string _iamTokenUrl;
 
     [Header("Parameters")]
     // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/curl.html?curl#get-model
@@ -85,7 +85,7 @@ public class ExampleStreaming : MonoBehaviour
             TokenOptions tokenOptions = new TokenOptions()
             {
                 IamApiKey = _iamApikey,
-                IamUrl = _iamUrl
+                IamUrl = _iamTokenUrl
             };
 
             credentials = new Credentials(tokenOptions, _serviceUrl);

--- a/Examples/ServiceExamples/Scripts/ExampleStreamingSplitSamples.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreamingSplitSamples.cs
@@ -50,6 +50,12 @@ public class ExampleStreamingSplitSamples : MonoBehaviour
     [Tooltip("The IAM url used to authenticate the apikey (optional). This defaults to \"https://iam.bluemix.net/identity/token\".")]
     [SerializeField]
     private string _iamUrl;
+
+    [Header("Parameters")]
+    // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/curl.html?curl#get-model
+    [Tooltip("The Model to use. This defaults to en-US_BroadbandModel")]
+    [SerializeField]
+    private string _recognizeModel;
     #endregion
 
     private int _recordingRoutine = 0;
@@ -113,6 +119,7 @@ public class ExampleStreamingSplitSamples : MonoBehaviour
         {
             if (value && !_service.IsListening)
             {
+                _service.RecognizeModel = (string.IsNullOrEmpty(_recognizeModel) ? "en-US_BroadbandModel" : _recognizeModel);
                 _service.DetectSilence = true;
                 _service.EnableWordConfidence = true;
                 _service.EnableTimestamps = true;

--- a/Examples/ServiceExamples/Scripts/ExampleStreamingSplitSamples.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreamingSplitSamples.cs
@@ -49,7 +49,7 @@ public class ExampleStreamingSplitSamples : MonoBehaviour
     private string _iamApikey;
     [Tooltip("The IAM url used to authenticate the apikey (optional). This defaults to \"https://iam.bluemix.net/identity/token\".")]
     [SerializeField]
-    private string _iamUrl;
+    private string _iamTokenUrl;
 
     [Header("Parameters")]
     // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/curl.html?curl#get-model
@@ -88,7 +88,7 @@ public class ExampleStreamingSplitSamples : MonoBehaviour
             TokenOptions tokenOptions = new TokenOptions()
             {
                 IamApiKey = _iamApikey,
-                IamUrl = _iamUrl
+                IamUrl = _iamTokenUrl
             };
 
             credentials = new Credentials(tokenOptions, _serviceUrl);


### PR DESCRIPTION
### Summary
Developers were getting confused between the service url and the iam url in the streaming example. This pull request refactors `_iamUrl` to `_iamTokenUrl` and adds the correct default value in the inspector. Additionally code to change language model that was added to the ExampleStreaming script was added to the ExampleStreamingSplitSamples script.