### PR TITLE
Text to speech default url

### DIFF
--- a/Examples/ServiceExamples/Scripts/ExampleCompareComplyV1.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleCompareComplyV1.cs
@@ -43,7 +43,6 @@ public class ExampleCompareComplyV1 : MonoBehaviour
     #endregion
 
     private CompareComply compareComply;
-    private fsSerializer _serializer = new fsSerializer();
     private bool convertToHtmlTested = false;
     private bool classifyElementsTested = false;
     private bool extractTablesTested = false;

--- a/Scripts/Services/TextToSpeech/v1/TextToSpeech.cs
+++ b/Scripts/Services/TextToSpeech/v1/TextToSpeech.cs
@@ -146,6 +146,11 @@ namespace IBM.Watson.DeveloperCloud.Services.TextToSpeech.v1
             if (credentials.HasCredentials() || credentials.HasWatsonAuthenticationToken() || credentials.HasIamTokenData())
             {
                 Credentials = credentials;
+
+                if (string.IsNullOrEmpty(credentials.Url))
+                {
+                    credentials.Url = Url;
+                }
             }
             else
             {


### PR DESCRIPTION
### Summary

This pull request revises the Text to Speech service abstraction to use the default US South URL if none is explicitly supplied. Additionally an unused fullserializer instance was removed in the Compare Comply example to address a warning in the editor.

fixes https://github.com/watson-developer-cloud/unity-sdk/issues/483