### PR TITLE
Added null check for workspaceId in Assistant V1 Message

### DIFF
--- a/Scripts/Services/Assistant/v1/Assistant.cs
+++ b/Scripts/Services/Assistant/v1/Assistant.cs
@@ -132,6 +132,8 @@ namespace IBM.Watson.DeveloperCloud.Services.Assistant.v1
                 throw new ArgumentNullException("successCallback");
             if (failCallback == null)
                 throw new ArgumentNullException("failCallback");
+            if (string.IsNullOrEmpty(workspaceId))
+                throw new ArgumentNullException("workspaceId");
 
             IDictionary<string, string> requestDict = new Dictionary<string, string>();
             if (request.Context != null)


### PR DESCRIPTION
### Summary

Added a `null` check for the `workspaceId` parameter of the `Message` method in the V1 Assistant.cs script, to help debug the following error message in the Unity console:

`ErrorCode: 400, Error: 400 Bad Request, Response: {"error":"URL workspaceid parameter 'message' is not a valid GUID.","code":400}`