### PR TITLE
Check for bad characters in username, password, apiKey and service url

### DIFF
--- a/Scripts/Utilities/Credentials.cs
+++ b/Scripts/Utilities/Credentials.cs
@@ -36,6 +36,9 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         private IamTokenData _iamTokenData;
         private string _iamApiKey;
         private string _userAcessToken;
+        private string url;
+        private string username;
+        private string password;
         private const string APIKEY_AS_USERNAME = "apikey";
         private const string ICP_PREFIX = "icp-";
         #endregion
@@ -44,11 +47,39 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         /// <summary>
         /// The user name.
         /// </summary>
-        public string Username { get; set; }
+        public string Username
+        {
+            get { return username; }
+            set
+            {
+                if (!Utility.HasBadFirstOrLastCharacter(value))
+                {
+                    username = value;
+                }
+                else
+                {
+                    throw new WatsonException("The username shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your username.");
+                }
+            }
+        }
         /// <summary>
         /// The password.
         /// </summary>
-        public string Password { get; set; }
+        public string Password
+        {
+            get { return password; }
+            set
+            {
+                if (!Utility.HasBadFirstOrLastCharacter(value))
+                {
+                    password = value;
+                }
+                else
+                {
+                    throw new WatsonException("The password shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your password.");
+                }
+            }
+        }
         /// <summary>
         /// The Api Key.
         /// </summary>
@@ -65,7 +96,21 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         /// <summary>
         /// The service endpoint.
         /// </summary>
-        public string Url { get; set; }
+        public string Url
+        {
+            get { return url; }
+            set
+            {
+                if (!Utility.HasBadFirstOrLastCharacter(value))
+                {
+                    url = value;
+                }
+                else
+                {
+                    throw new WatsonException("The service URL shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your service url.");
+                }
+            }
+        }
 
         /// <summary>
         /// The IAM access token.
@@ -645,8 +690,26 @@ namespace IBM.Watson.DeveloperCloud.Utilities
     [fsObject]
     public class TokenOptions
     {
+        private string iamApiKey;
         [fsProperty("iamApiKey")]
-        public string IamApiKey { get; set; }
+        public string IamApiKey
+        {
+            get
+            {
+                return iamApiKey;
+            }
+            set
+            {
+                if (!Utility.HasBadFirstOrLastCharacter(value))
+                {
+                    iamApiKey = value;
+                }
+                else
+                {
+                    throw new WatsonException("The credentials shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your credentials");
+                }
+            }
+        }
         [fsProperty("iamAcessToken")]
         public string IamAccessToken { get; set; }
         [fsProperty("iamUrl")]

--- a/Scripts/Utilities/Utility.cs
+++ b/Scripts/Utilities/Utility.cs
@@ -1254,7 +1254,7 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         }
         #endregion
 
-        #region
+        #region CreateAuthorization
         /// <summary>
         /// Create basic authentication header data for REST requests.
         /// </summary>
@@ -1264,6 +1264,13 @@ namespace IBM.Watson.DeveloperCloud.Utilities
         public static string CreateAuthorization(string username, string password)
         {
             return "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes(username + ":" + password));
+        }
+        #endregion
+
+        #region Has Bad First Character
+        public static bool HasBadFirstOrLastCharacter(string value)
+        {
+            return value.StartsWith("{") || value.StartsWith("\"") || value.EndsWith("}") || value.EndsWith("\"");
         }
         #endregion
     }


### PR DESCRIPTION
### Summary
This pull request throws an error if the username, password, apikey or service url has `{` or `"` in the beginning of the string or `}` or `"` at the end of the string. 