### PR TITLE
Move disabled from CreateDialogNode to DialogNode

### DIFF
--- a/Scripts/Services/Assistant/v1/Models/CreateDialogNode.cs
+++ b/Scripts/Services/Assistant/v1/Models/CreateDialogNode.cs
@@ -176,12 +176,6 @@ namespace IBM.Watson.DeveloperCloud.Services.Assistant.v1
         [fsProperty("context")]
         public object Context { get; set; }
         /// <summary>
-        /// Whether to consider the dialog node during runtime evaluation.  Set to `true` to ignore the 
-        /// dialog node.
-        /// </summary>
-        [fsProperty("disabled")]
-        public bool Disabled { get; set; }
-        /// <summary>
         /// The metadata for the dialog node.
         /// </summary>
         /// <value>The metadata for the dialog node.</value>

--- a/Scripts/Services/Assistant/v1/Models/DialogNode.cs
+++ b/Scripts/Services/Assistant/v1/Models/DialogNode.cs
@@ -213,6 +213,11 @@ namespace IBM.Watson.DeveloperCloud.Services.Assistant.v1
         [fsProperty("title")]
         public string Title { get; set; }
         /// <summary>
+        /// For internal use only.
+        /// </summary>
+        [fsProperty("disabled")]
+        public bool Disabled { get; set; }
+        /// <summary>
         /// The location in the dialog context where output is stored.
         /// </summary>
         /// <value>The location in the dialog context where output is stored.</value>


### PR DESCRIPTION
### Summary
This pull request moves the `disabled` field from `CreateDialogNode` to `DialogNode` since this field is only in the response.