### PR TITLE
chore(logging): Corrected the wrongly-labelled method name.

### DIFF
--- a/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
@@ -243,7 +243,7 @@ public class ExampleStreaming : MonoBehaviour
         {
             foreach (SpeakerLabelsResult labelResult in result.speaker_labels)
             {
-                Log.Debug("ExampleStreaming.OnRecognize()", string.Format("speaker result: {0} | confidence: {3} | from: {1} | to: {2}", labelResult.speaker, labelResult.from, labelResult.to, labelResult.confidence));
+                Log.Debug("ExampleStreaming.OnRecognizeSpeaker()", string.Format("speaker result: {0} | confidence: {3} | from: {1} | to: {2}", labelResult.speaker, labelResult.from, labelResult.to, labelResult.confidence));
             }
         }
     }


### PR DESCRIPTION
### Summary

Changed `OnRecognize()` to `OnRecognizeSpeaker()`.

### Other Information

Caused confusion when searching for debug log messages of recognizing different speakers.


Thanks for contributing to the Watson Developer Cloud!