### PR TITLE
fix(serialization): Added en-US culture to double parsing in MiniJSON third party library

### DIFF
--- a/ThirdParty/MiniJSON/MiniJSON.cs
+++ b/ThirdParty/MiniJSON/MiniJSON.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -289,7 +290,7 @@ namespace MiniJSON {
 
             object ParseNumber() {
                 string number = NextWord;
-
+                var culture = new CultureInfo("en-US");
                 if (number.IndexOf('.') == -1) {
                     long parsedInt;
                     Int64.TryParse(number, out parsedInt);
@@ -297,7 +298,7 @@ namespace MiniJSON {
                 }
 
                 double parsedDouble;
-                Double.TryParse(number, out parsedDouble);
+                Double.TryParse(number, NumberStyles.Any, culture, out parsedDouble);
                 return parsedDouble;
             }
 


### PR DESCRIPTION
### Summary

Issue #517 fix. I had to set the culture of the TryParse method when trying to parse a float in MiniJSON because of the non-us comma format (',' instead of '.').
