### PR TITLE
fix(Visual Recognition V3): Fixed example to not send null _classifierID. Revised service to send a proper filename

### DIFF
--- a/Examples/ServiceExamples/Scripts/ExampleVisualRecognition.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleVisualRecognition.cs
@@ -152,7 +152,7 @@ public class ExampleVisualRecognition : MonoBehaviour
         Log.Debug("ExampleVisualRecognition.Examples()", "Attempting to classify via image on file system");
         string imagesPath = Application.dataPath + "/Watson/Examples/ServiceExamples/TestData/visual-recognition-classifiers/giraffe_to_classify.jpg";
         string[] owners = { "IBM", "me" };
-        string[] classifierIDs = { "default", _classifierID };
+        string[] classifierIDs = { "default" };
         if (!_visualRecognition.Classify(OnClassifyPost, OnFail, imagesPath, owners, classifierIDs, 0.5f))
             Log.Debug("ExampleVisualRecognition.Classify()", "Classify image failed!");
 

--- a/Scripts/Services/VisualRecognition/v3/VisualRecognition.cs
+++ b/Scripts/Services/VisualRecognition/v3/VisualRecognition.cs
@@ -345,7 +345,7 @@ namespace IBM.Watson.DeveloperCloud.Services.VisualRecognition.v3
             if (imageData != null)
             {
                 req.Forms = new Dictionary<string, RESTConnector.Form>();
-                req.Forms.Add("images_file", new RESTConnector.Form(imageData, imageMimeType));
+                req.Forms.Add("images_file", new RESTConnector.Form(imageData, "image" + Utility.GetExtension(imageMimeType), imageMimeType));
             }
 
             return connector.Send(req);


### PR DESCRIPTION
### Summary

This pull request addresses an issue where the VisualRecognition example was classifying an image using a null classifierID. This was an artifact from when the example created a classifier. This was removed because the service would sometimes make "ghost classifiers" that could not be removed by the user.

Additionally the request was revised to send a proper filename. Previously it was sending the content type as the filename.