### PR TITLE
fix(Visual Recognition V3): Made acceptLanguage in DetectFaces optional

### DIFF
--- a/Scripts/Services/VisualRecognition/v3/VisualRecognition.cs
+++ b/Scripts/Services/VisualRecognition/v3/VisualRecognition.cs
@@ -472,7 +472,7 @@ namespace IBM.Watson.DeveloperCloud.Services.VisualRecognition.v3
         /// <param name="acceptLanguage">The language used for the value of `gender_label` in the response. (optional,
         /// default to en)</param>
         /// <param name="customData">Custom data.</param>
-        public bool DetectFaces(SuccessCallback<DetectedFaces> successCallback, FailCallback failCallback, string imagePath, string acceptLanguage, Dictionary<string, object> customData = null)
+        public bool DetectFaces(SuccessCallback<DetectedFaces> successCallback, FailCallback failCallback, string imagePath, string acceptLanguage = null, Dictionary<string, object> customData = null)
         {
             if (successCallback == null)
                 throw new ArgumentNullException("successCallback");


### PR DESCRIPTION
### Summary
Fixes https://github.com/watson-developer-cloud/unity-sdk/issues/525

This pull request makes the `acceptLanguage` parameter of one overload of `DetectFaces` optional. This will not introduce a breaking change.