### PR TITLE
Speech issues

### DIFF
--- a/Examples/ServiceExamples/Scripts/ExampleCustomHeaders.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleCustomHeaders.cs
@@ -182,7 +182,7 @@ public class ExampleCustomHeaders : MonoBehaviour
                 _speechToText.EnableWordConfidence = true;
                 _speechToText.EnableTimestamps = true;
                 _speechToText.SilenceThreshold = 0.01f;
-                _speechToText.MaxAlternatives = 0;
+                _speechToText.MaxAlternatives = 1;
                 _speechToText.EnableInterimResults = true;
                 _speechToText.OnError = OnError;
                 _speechToText.InactivityTimeout = -1;

--- a/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreaming.cs
@@ -102,7 +102,7 @@ public class ExampleStreaming : MonoBehaviour
                 _service.EnableWordConfidence = true;
                 _service.EnableTimestamps = true;
                 _service.SilenceThreshold = 0.01f;
-                _service.MaxAlternatives = 0;
+                _service.MaxAlternatives = 1;
                 _service.EnableInterimResults = true;
                 _service.OnError = OnError;
                 _service.InactivityTimeout = -1;

--- a/Examples/ServiceExamples/Scripts/ExampleStreamingSplitSamples.cs
+++ b/Examples/ServiceExamples/Scripts/ExampleStreamingSplitSamples.cs
@@ -108,7 +108,7 @@ public class ExampleStreamingSplitSamples : MonoBehaviour
                 _service.EnableWordConfidence = true;
                 _service.EnableTimestamps = true;
                 _service.SilenceThreshold = 0.01f;
-                _service.MaxAlternatives = 0;
+                _service.MaxAlternatives = 1;
                 _service.EnableInterimResults = true;
                 _service.OnError = OnError;
                 _service.InactivityTimeout = -1;

--- a/Scripts/Services/SpeechToText/v1/SpeechToText.cs
+++ b/Scripts/Services/SpeechToText/v1/SpeechToText.cs
@@ -1298,7 +1298,6 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
                             if (ialternative.Contains("word_confidence"))
                             {
                                 IList iconfidence = ialternative["word_confidence"] as IList;
-
                                 WordConfidence[] confidence = new WordConfidence[iconfidence.Count];
                                 for (int i = 0; i < iconfidence.Count; ++i)
                                 {
@@ -1308,7 +1307,9 @@ namespace IBM.Watson.DeveloperCloud.Services.SpeechToText.v1
 
                                     WordConfidence wc = new WordConfidence();
                                     wc.Word = (string)iwordconf[0];
-                                    wc.Confidence = (double)iwordconf[1];
+                                    string wordConf = iwordconf[1].ToString();
+                                    double.TryParse(wordConf, out double wordConfDouble);
+                                    wc.Confidence = wordConfDouble;
                                     confidence[i] = wc;
                                 }
 


### PR DESCRIPTION
### Summary
Fixes https://github.com/watson-developer-cloud/unity-sdk/issues/527
This pull request addresses changes the examples to set MaxAlternatives to 1 rather than 0. There is a bug in the Speech to Text service where an exception occurs if 0 is passed for MaxAlternatives. 

Additionally for WordConfidence we were getting casting errors when we get a `1` from the service. We now convert WordConfidence to string and parse that string into a double.