### PR TITLE
Remove custom data

### DIFF
--- a/Examples/ExampleAssistantV1.cs
+++ b/Examples/ExampleAssistantV1.cs
@@ -365,243 +365,243 @@ namespace IBM.Watson.Examples
             yield break;
         }
 
-        private void OnListMentions(DetailedResponse<EntityMentionCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListMentions(DetailedResponse<EntityMentionCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListMentions()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListMentions()", "Response: {0}", response.Response);
             listMentionsTested = true;
         }
 
-        private void OnDeleteWorkspace(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteWorkspace(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteWorkspace()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteWorkspace()", "Response: {0}", response.Response);
             deleteWorkspaceTested = true;
         }
 
-        private void OnDeleteIntent(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteIntent(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteIntent()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteIntent()", "Response: {0}", response.Response);
             deleteIntentTested = true;
         }
 
-        private void OnDeleteExample(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteExample(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteExample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteExample()", "Response: {0}", response.Response);
             deleteExampleTested = true;
         }
 
-        private void OnDeleteEntity(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteEntity(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteEntity()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteEntity()", "Response: {0}", response.Response);
             deleteEntityTested = true;
         }
 
-        private void OnDeleteValue(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteValue(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteValue()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteValue()", "Response: {0}", response.Response);
             deleteValueTested = true;
         }
 
-        private void OnDeleteSynonym(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteSynonym(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteSynonym()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteSynonym()", "Response: {0}", response.Response);
             deleteSynonymTested = true;
         }
 
-        private void OnDeleteDialogNode(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteDialogNode(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteDialogNode()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteDialogNode()", "Response: {0}", response.Response);
             deleteDialogNodeTested = true;
         }
 
-        private void OnDeleteCounterexample(DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData)
+        private void OnDeleteCounterexample(DetailedResponse<object> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnDeleteCounterexample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnDeleteCounterexample()", "Response: {0}", response.Response);
             deleteCounterexampleTested = true;
         }
 
-        private void OnUpdateCounterexample(DetailedResponse<Counterexample> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateCounterexample(DetailedResponse<Counterexample> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateCounterexample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateCounterexample()", "Response: {0}", response.Response);
             updateCounterexampleTested = true;
         }
 
-        private void OnGetCounterexample(DetailedResponse<Counterexample> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetCounterexample(DetailedResponse<Counterexample> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetCounterexample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetCounterexample()", "Response: {0}", response.Response);
             getCounterexampleTested = true;
         }
 
-        private void OnCreateCounterexample(DetailedResponse<Counterexample> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateCounterexample(DetailedResponse<Counterexample> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateCounterexample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateCounterexample()", "Response: {0}", response.Response);
             createCounterexampleTested = true;
         }
 
-        private void OnListCounterexamples(DetailedResponse<CounterexampleCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListCounterexamples(DetailedResponse<CounterexampleCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListCounterexamples()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListCounterexamples()", "Response: {0}", response.Response);
             listCounterexamplesTested = true;
         }
 
-        private void OnListAllLogs(DetailedResponse<LogCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListAllLogs(DetailedResponse<LogCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListAllLogs()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListAllLogs()", "Response: {0}", response.Response);
             listAllLogsTested = true;
         }
 
-        private void OnListLogs(DetailedResponse<LogCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListLogs(DetailedResponse<LogCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListLogs()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListLogs()", "Response: {0}", response.Response);
             listLogsInWorkspaceTested = true;
         }
 
-        private void OnUpdateDialogNode(DetailedResponse<DialogNode> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateDialogNode(DetailedResponse<DialogNode> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateDialogNode()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateDialogNode()", "Response: {0}", response.Response);
             updateDialogNodeTested = true;
         }
 
-        private void OnGetDialogNode(DetailedResponse<DialogNode> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetDialogNode(DetailedResponse<DialogNode> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetDialogNode()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetDialogNode()", "Response: {0}", response.Response);
             getDialogNodeTested = true;
         }
 
-        private void OnCreateDialogNode(DetailedResponse<DialogNode> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateDialogNode(DetailedResponse<DialogNode> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateDialogNode()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateDialogNode()", "Response: {0}", response.Response);
             createDialogNodeTested = true;
         }
 
-        private void OnListDialogNodes(DetailedResponse<DialogNodeCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListDialogNodes(DetailedResponse<DialogNodeCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListDialogNodes()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListDialogNodes()", "Response: {0}", response.Response);
             listDialogNodesTested = true;
         }
 
-        private void OnUpdateSynonym(DetailedResponse<Synonym> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateSynonym(DetailedResponse<Synonym> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateSynonym()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateSynonym()", "Response: {0}", response.Response);
             updateSynonymTested = true;
         }
 
-        private void OnGetSynonym(DetailedResponse<Synonym> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetSynonym(DetailedResponse<Synonym> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetSynonym()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetSynonym()", "Response: {0}", response.Response);
             getSynonymTested = true;
         }
 
-        private void OnCreateSynonym(DetailedResponse<Synonym> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateSynonym(DetailedResponse<Synonym> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateSynonym()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateSynonym()", "Response: {0}", response.Response);
             createSynonymTested = true;
         }
 
-        private void OnListSynonyms(DetailedResponse<SynonymCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListSynonyms(DetailedResponse<SynonymCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListSynonyms()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListSynonyms()", "Response: {0}", response.Response);
             listSynonymsTested = true;
         }
 
-        private void OnUpdateValue(DetailedResponse<Value> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateValue(DetailedResponse<Value> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateValue()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateValue()", "Response: {0}", response.Response);
             updateValueTested = true;
         }
 
-        private void OnGetValue(DetailedResponse<Value> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetValue(DetailedResponse<Value> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetValue()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetValue()", "Response: {0}", response.Response);
             getValueTested = true;
         }
 
-        private void OnCreateValue(DetailedResponse<Value> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateValue(DetailedResponse<Value> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateValue()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateValue()", "Response: {0}", response.Response);
             createValueTested = true;
         }
 
-        private void OnListValues(DetailedResponse<ValueCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListValues(DetailedResponse<ValueCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListValues()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListValues()", "Response: {0}", response.Response);
             listValuesTested = true;
         }
 
-        private void OnUpdateEntity(DetailedResponse<Entity> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateEntity(DetailedResponse<Entity> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateEntity()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateEntity()", "Response: {0}", response.Response);
             updateEntityTested = true;
         }
 
-        private void OnGetEntity(DetailedResponse<Entity> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetEntity(DetailedResponse<Entity> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetEntity()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetEntity()", "Response: {0}", response.Response);
             getEntityTested = true;
         }
 
-        private void OnCreateEntity(DetailedResponse<Entity> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateEntity(DetailedResponse<Entity> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateEntity()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateEntity()", "Response: {0}", response.Response);
             createEntityTested = true;
         }
 
-        private void OnListEntities(DetailedResponse<EntityCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListEntities(DetailedResponse<EntityCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListEntities()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListEntities()", "Response: {0}", response.Response);
             listEntitiesTested = true;
         }
 
-        private void OnUpdateExample(DetailedResponse<Example> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateExample(DetailedResponse<Example> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateExample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateExample()", "Response: {0}", response.Response);
             updateExampleTested = true;
         }
 
-        private void OnGetExample(DetailedResponse<Example> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetExample(DetailedResponse<Example> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetExample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetExample()", "Response: {0}", response.Response);
             getExampleTested = true;
         }
 
-        private void OnCreateExample(DetailedResponse<Example> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateExample(DetailedResponse<Example> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateExample()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateExample()", "Response: {0}", response.Response);
             createExampleTested = true;
         }
 
-        private void OnListExamples(DetailedResponse<ExampleCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListExamples(DetailedResponse<ExampleCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListExamples()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListExamples()", "Response: {0}", response.Response);
             listExamplesTested = true;
         }
 
-        private void OnUpdateIntent(DetailedResponse<Intent> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateIntent(DetailedResponse<Intent> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateIntent()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateIntent()", "Response: {0}", response.Response);
             updateIntentTested = true;
         }
 
-        private void OnGetIntent(DetailedResponse<Intent> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetIntent(DetailedResponse<Intent> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetIntent()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetIntent()", "Response: {0}", response.Response);
             getIntentTested = true;
         }
 
-        private void OnCreateIntent(DetailedResponse<Intent> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateIntent(DetailedResponse<Intent> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateIntent()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateIntent()", "Response: {0}", response.Response);
             createIntentTested = true;
         }
 
-        private void OnListIntents(DetailedResponse<IntentCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListIntents(DetailedResponse<IntentCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListIntents()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListIntents()", "Response: {0}", response.Response);
             listIntentsTested = true;
         }
 
-        private void OnMessage(DetailedResponse<Dictionary<string, object>> response, IBMError error, Dictionary<string, object> customData)
+        private void OnMessage(DetailedResponse<Dictionary<string, object>> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnMessage()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnMessage()", "Response: {0}", response.Response);
 
             context = response.Result["context"] as Dictionary<string, object>;
             ////  Convert resp to fsdata
@@ -639,28 +639,28 @@ namespace IBM.Watson.Examples
             messageTested = true;
         }
 
-        private void OnUpdateWorkspace(DetailedResponse<Workspace> response, IBMError error, Dictionary<string, object> customData)
+        private void OnUpdateWorkspace(DetailedResponse<Workspace> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnUpdateWorkspace()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnUpdateWorkspace()", "Response: {0}", response.Response);
             updateWorkspaceTested = true;
         }
 
-        private void OnGetWorkspace(DetailedResponse<Workspace> response, IBMError error, Dictionary<string, object> customData)
+        private void OnGetWorkspace(DetailedResponse<Workspace> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnGetWorkspace()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnGetWorkspace()", "Response: {0}", response.Response);
             getWorkspaceTested = true;
         }
 
-        private void OnCreateWorkspace(DetailedResponse<Workspace> response, IBMError error, Dictionary<string, object> customData)
+        private void OnCreateWorkspace(DetailedResponse<Workspace> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnCreateWorkspace()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnCreateWorkspace()", "Response: {0}", response.Response);
             createdWorkspaceId = response.Result.WorkspaceId;
             createWorkspaceTested = true;
         }
 
-        private void OnListWorkspaces(DetailedResponse<WorkspaceCollection> response, IBMError error, Dictionary<string, object> customData)
+        private void OnListWorkspaces(DetailedResponse<WorkspaceCollection> response, IBMError error)
         {
-            Log.Debug("ExampleAssistantV1.OnListWorkspaces()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExampleAssistantV1.OnListWorkspaces()", "Response: {0}", response.Response);
 
             foreach (Workspace workspace in response.Result.Workspaces)
             {

--- a/Examples/ExampleAssistantV2.cs
+++ b/Examples/ExampleAssistantV2.cs
@@ -214,37 +214,37 @@ namespace IBM.Watson.Examples
             Log.Debug("ExampleAssistantV2.Examples()", "Assistant examples complete.");
         }
 
-        private void OnDeleteSession(DetailedResponse<object> response, IBMError error, System.Collections.Generic.Dictionary<string, object> customData)
+        private void OnDeleteSession(DetailedResponse<object> response, IBMError error)
         {
             Log.Debug("ExampleAssistantV2.OnDeleteSession()", "Session deleted.");
             deleteSessionTested = true;
         }
 
-        private void OnMessage0(DetailedResponse<MessageResponse> response, IBMError error, System.Collections.Generic.Dictionary<string, object> customData)
+        private void OnMessage0(DetailedResponse<MessageResponse> response, IBMError error)
         {
             Log.Debug("ExampleAssistantV2.OnMessage0()", "response: {0}", response.Result.Output.Generic[0].Text);
             messageTested0 = true;
         }
 
-        private void OnMessage1(DetailedResponse<MessageResponse> response, IBMError error, System.Collections.Generic.Dictionary<string, object> customData)
+        private void OnMessage1(DetailedResponse<MessageResponse> response, IBMError error)
         {
             Log.Debug("ExampleAssistantV2.OnMessage1()", "response: {0}", response.Result.Output.Generic[0].Text);
 
             messageTested1 = true;
         }
 
-        private void OnMessage2(DetailedResponse<MessageResponse> response, IBMError error, System.Collections.Generic.Dictionary<string, object> customData)
+        private void OnMessage2(DetailedResponse<MessageResponse> response, IBMError error)
         {
             Log.Debug("ExampleAssistantV2.OnMessage2()", "response: {0}", response.Result.Output.Generic[0].Text);
             messageTested2 = true;
         }
 
-        private void OnMessage3(DetailedResponse<MessageResponse> response, IBMError error, System.Collections.Generic.Dictionary<string, object> customData)
+        private void OnMessage3(DetailedResponse<MessageResponse> response, IBMError error)
         {
             Log.Debug("ExampleAssistantV2.OnMessage3()", "response: {0}", response.Result.Output.Generic[0].Text);
             messageTested3 = true;
         }
-        private void OnMessage4(DetailedResponse<MessageResponse> response, IBMError error, System.Collections.Generic.Dictionary<string, object> customData)
+        private void OnMessage4(DetailedResponse<MessageResponse> response, IBMError error)
         {
             //object tempSkill = null;
             //(response.Result.Context.Skills as Dictionary<string, object>).TryGetValue("main skill", out tempSkill);
@@ -267,7 +267,7 @@ namespace IBM.Watson.Examples
             messageTested4 = true;
         }
 
-        private void OnCreateSession(DetailedResponse<SessionResponse> response, IBMError error, System.Collections.Generic.Dictionary<string, object> customData)
+        private void OnCreateSession(DetailedResponse<SessionResponse> response, IBMError error)
         {
             Log.Debug("ExampleAssistantV2.OnCreateSession()", "Session: {0}", response.Result.SessionId);
             sessionId = response.Result.SessionId;

--- a/Examples/ExamplePersonalityInsightsV3.cs
+++ b/Examples/ExamplePersonalityInsightsV3.cs
@@ -83,15 +83,15 @@ namespace IBM.Watson.Examples
         }
 
 
-        private void OnProfile(DetailedResponse<Profile> response, IBMError error, Dictionary<string, object> customData)
+        private void OnProfile(DetailedResponse<Profile> response, IBMError error)
         {
-            Log.Debug("ExamplePersonaltyInsightsV3.OnProfile()", "Response: {0}", customData["json"].ToString());
+            Log.Debug("ExamplePersonaltyInsightsV3.OnProfile()", "Response: {0}", response.Response);
             profileTested = true;
         }
 
-        private void OnProfileAsCsv(DetailedResponse<MemoryStream> response, IBMError error, Dictionary<string, object> customData)
+        private void OnProfileAsCsv(DetailedResponse<MemoryStream> response, IBMError error)
         {
-            //Log.Debug("ExamplePersonaltyInsightsV3.OnProfile()", "Response: {0}", customData["json"].ToString());
+            //Log.Debug("ExamplePersonaltyInsightsV3.OnProfile()", "Response: {0}", response.Response);
             profileAsCsvTested = true;
         }
     }

--- a/Examples/ExampleStreaming.cs
+++ b/Examples/ExampleStreaming.cs
@@ -205,7 +205,7 @@ namespace IBM.Watsson.Examples
             yield break;
         }
 
-        private void OnRecognize(SpeechRecognitionEvent result, Dictionary<string, object> customData)
+        private void OnRecognize(SpeechRecognitionEvent result)
         {
             if (result != null && result.results.Length > 0)
             {
@@ -239,7 +239,7 @@ namespace IBM.Watsson.Examples
             }
         }
 
-        private void OnRecognizeSpeaker(SpeakerRecognitionEvent result, Dictionary<string, object> customData)
+        private void OnRecognizeSpeaker(SpeakerRecognitionEvent result)
         {
             if (result != null)
             {

--- a/Examples/ExampleToneAnalyzerV3.cs
+++ b/Examples/ExampleToneAnalyzerV3.cs
@@ -118,7 +118,7 @@ namespace IBM.Watson.Examples
             Log.Debug("ExampleToneAnalyzerV3.Examples()", "Examples complete!");
         }
 
-        private void OnTone(DetailedResponse<ToneAnalysis> response, IBMError error, Dictionary<string, object> customData)
+        private void OnTone(DetailedResponse<ToneAnalysis> response, IBMError error)
         {
             if (error != null)
             {
@@ -126,13 +126,13 @@ namespace IBM.Watson.Examples
             }
             else
             {
-                Log.Debug("ExampleToneAnalyzerV3.OnTone()", "{0}", customData["json"].ToString());
+                Log.Debug("ExampleToneAnalyzerV3.OnTone()", "{0}", response.Response);
             }
 
             toneTested = true;
         }
 
-        private void OnToneChat(DetailedResponse<UtteranceAnalyses> response, IBMError error, Dictionary<string, object> customData)
+        private void OnToneChat(DetailedResponse<UtteranceAnalyses> response, IBMError error)
         {
             if (error != null)
             {
@@ -140,7 +140,7 @@ namespace IBM.Watson.Examples
             }
             else
             {
-                Log.Debug("ExampleToneAnalyzerV3.OnToneChat()", "{0}", customData["json"].ToString());
+                Log.Debug("ExampleToneAnalyzerV3.OnToneChat()", "{0}", response.Response);
             }
 
             toneChatTested = true;

--- a/Scripts/Services/Assistant/V1/AssistantService.cs
+++ b/Scripts/Services/Assistant/V1/AssistantService.cs
@@ -147,11 +147,8 @@ namespace IBM.Watson.Assistant.V1
         /// triggered, and messages from the log. (optional)</param>
         /// <param name="nodesVisitedDetails">Whether to include additional diagnostic information about the dialog
         /// nodes that were visited during processing of the message. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="MessageResponse" />MessageResponse</returns>
-        public bool Message(Callback<MessageResponse> callback, string workspaceId, Dictionary<string, object> customData = null, JObject input = null, List<JObject> intents = null, List<JObject> entities = null, bool? alternateIntents = null, JObject context = null, JObject output = null, bool? nodesVisitedDetails = null)
+        public bool Message(Callback<MessageResponse> callback, string workspaceId, JObject input = null, List<JObject> intents = null, List<JObject> entities = null, bool? alternateIntents = null, JObject context = null, JObject output = null, bool? nodesVisitedDetails = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Message`");
@@ -162,17 +159,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "Message"))
             {
@@ -262,11 +257,8 @@ namespace IBM.Watson.Assistant.V1
         /// (optional)</param>
         /// <param name="counterexamples">An array of objects defining input examples that have been marked as
         /// irrelevant input. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Workspace" />Workspace</returns>
-        public bool CreateWorkspace(Callback<Workspace> callback, Dictionary<string, object> customData = null, string name = null, string description = null, string language = null, Dictionary<string, object> metadata = null, bool? learningOptOut = null, WorkspaceSystemSettings systemSettings = null, List<CreateIntent> intents = null, List<CreateEntity> entities = null, List<DialogNode> dialogNodes = null, List<Counterexample> counterexamples = null)
+        public bool CreateWorkspace(Callback<Workspace> callback, string name = null, string description = null, string language = null, Dictionary<string, object> metadata = null, bool? learningOptOut = null, WorkspaceSystemSettings systemSettings = null, List<CreateIntent> intents = null, List<CreateEntity> entities = null, List<DialogNode> dialogNodes = null, List<Counterexample> counterexamples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateWorkspace`");
@@ -275,17 +267,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateWorkspace"))
             {
@@ -363,11 +353,8 @@ namespace IBM.Watson.Assistant.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteWorkspace(Callback<object> callback, string workspaceId, Dictionary<string, object> customData = null)
+        public bool DeleteWorkspace(Callback<object> callback, string workspaceId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteWorkspace`");
@@ -378,17 +365,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteWorkspace"))
             {
@@ -450,11 +435,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="sort">Indicates how the returned workspace data will be sorted. This parameter is valid only if
         /// **export**=`true`. Specify `sort=stable` to sort all workspace objects by unique identifier, in ascending
         /// alphabetical order. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Workspace" />Workspace</returns>
-        public bool GetWorkspace(Callback<Workspace> callback, string workspaceId, Dictionary<string, object> customData = null, bool? export = null, bool? includeAudit = null, string sort = null)
+        public bool GetWorkspace(Callback<Workspace> callback, string workspaceId, bool? export = null, bool? includeAudit = null, string sort = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetWorkspace`");
@@ -465,17 +447,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetWorkspace"))
             {
@@ -548,11 +528,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="WorkspaceCollection" />WorkspaceCollection</returns>
-        public bool ListWorkspaces(Callback<WorkspaceCollection> callback, Dictionary<string, object> customData = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListWorkspaces(Callback<WorkspaceCollection> callback, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListWorkspaces`");
@@ -561,17 +538,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListWorkspaces"))
             {
@@ -669,11 +644,8 @@ namespace IBM.Watson.Assistant.V1
         ///
         /// If **append**=`true`, existing elements are preserved, and the new elements are added. If any elements in
         /// the new data collide with existing elements, the update request fails. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Workspace" />Workspace</returns>
-        public bool UpdateWorkspace(Callback<Workspace> callback, string workspaceId, Dictionary<string, object> customData = null, string name = null, string description = null, string language = null, Dictionary<string, object> metadata = null, bool? learningOptOut = null, WorkspaceSystemSettings systemSettings = null, List<CreateIntent> intents = null, List<CreateEntity> entities = null, List<DialogNode> dialogNodes = null, List<Counterexample> counterexamples = null, bool? append = null)
+        public bool UpdateWorkspace(Callback<Workspace> callback, string workspaceId, string name = null, string description = null, string language = null, Dictionary<string, object> metadata = null, bool? learningOptOut = null, WorkspaceSystemSettings systemSettings = null, List<CreateIntent> intents = null, List<CreateEntity> entities = null, List<DialogNode> dialogNodes = null, List<Counterexample> counterexamples = null, bool? append = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateWorkspace`");
@@ -684,17 +656,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateWorkspace"))
             {
@@ -783,11 +753,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="description">The description of the intent. This string cannot contain carriage return,
         /// newline, or tab characters, and it must be no longer than 128 characters. (optional)</param>
         /// <param name="examples">An array of user input examples for the intent. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Intent" />Intent</returns>
-        public bool CreateIntent(Callback<Intent> callback, string workspaceId, string intent, Dictionary<string, object> customData = null, string description = null, List<Example> examples = null)
+        public bool CreateIntent(Callback<Intent> callback, string workspaceId, string intent, string description = null, List<Example> examples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateIntent`");
@@ -800,17 +767,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateIntent"))
             {
@@ -875,11 +840,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="intent">The intent name.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteIntent(Callback<object> callback, string workspaceId, string intent, Dictionary<string, object> customData = null)
+        public bool DeleteIntent(Callback<object> callback, string workspaceId, string intent)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteIntent`");
@@ -892,17 +854,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteIntent"))
             {
@@ -962,11 +922,8 @@ namespace IBM.Watson.Assistant.V1
         /// including subelements, is included. (optional, default to false)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Intent" />Intent</returns>
-        public bool GetIntent(Callback<Intent> callback, string workspaceId, string intent, Dictionary<string, object> customData = null, bool? export = null, bool? includeAudit = null)
+        public bool GetIntent(Callback<Intent> callback, string workspaceId, string intent, bool? export = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetIntent`");
@@ -979,17 +936,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetIntent"))
             {
@@ -1063,11 +1018,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="IntentCollection" />IntentCollection</returns>
-        public bool ListIntents(Callback<IntentCollection> callback, string workspaceId, Dictionary<string, object> customData = null, bool? export = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListIntents(Callback<IntentCollection> callback, string workspaceId, bool? export = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListIntents`");
@@ -1078,17 +1030,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListIntents"))
             {
@@ -1174,11 +1124,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="newDescription">The description of the intent. This string cannot contain carriage return,
         /// newline, or tab characters, and it must be no longer than 128 characters. (optional)</param>
         /// <param name="newExamples">An array of user input examples for the intent. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Intent" />Intent</returns>
-        public bool UpdateIntent(Callback<Intent> callback, string workspaceId, string intent, Dictionary<string, object> customData = null, string newIntent = null, string newDescription = null, List<Example> newExamples = null)
+        public bool UpdateIntent(Callback<Intent> callback, string workspaceId, string intent, string newIntent = null, string newDescription = null, List<Example> newExamples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateIntent`");
@@ -1191,17 +1138,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateIntent"))
             {
@@ -1272,11 +1217,8 @@ namespace IBM.Watson.Assistant.V1
         /// - It cannot consist of only whitespace characters.
         /// - It must be no longer than 1024 characters.</param>
         /// <param name="mentions">An array of contextual entity mentions. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Example" />Example</returns>
-        public bool CreateExample(Callback<Example> callback, string workspaceId, string intent, string text, Dictionary<string, object> customData = null, List<Mention> mentions = null)
+        public bool CreateExample(Callback<Example> callback, string workspaceId, string intent, string text, List<Mention> mentions = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateExample`");
@@ -1291,17 +1233,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateExample"))
             {
@@ -1365,11 +1305,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="intent">The intent name.</param>
         /// <param name="text">The text of the user input example.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteExample(Callback<object> callback, string workspaceId, string intent, string text, Dictionary<string, object> customData = null)
+        public bool DeleteExample(Callback<object> callback, string workspaceId, string intent, string text)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteExample`");
@@ -1384,17 +1321,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteExample"))
             {
@@ -1451,11 +1386,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="text">The text of the user input example.</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Example" />Example</returns>
-        public bool GetExample(Callback<Example> callback, string workspaceId, string intent, string text, Dictionary<string, object> customData = null, bool? includeAudit = null)
+        public bool GetExample(Callback<Example> callback, string workspaceId, string intent, string text, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetExample`");
@@ -1470,17 +1402,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetExample"))
             {
@@ -1547,11 +1477,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ExampleCollection" />ExampleCollection</returns>
-        public bool ListExamples(Callback<ExampleCollection> callback, string workspaceId, string intent, Dictionary<string, object> customData = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListExamples(Callback<ExampleCollection> callback, string workspaceId, string intent, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListExamples`");
@@ -1564,17 +1491,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListExamples"))
             {
@@ -1655,11 +1580,8 @@ namespace IBM.Watson.Assistant.V1
         /// - It cannot consist of only whitespace characters.
         /// - It must be no longer than 1024 characters. (optional)</param>
         /// <param name="newMentions">An array of contextual entity mentions. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Example" />Example</returns>
-        public bool UpdateExample(Callback<Example> callback, string workspaceId, string intent, string text, Dictionary<string, object> customData = null, string newText = null, List<Mention> newMentions = null)
+        public bool UpdateExample(Callback<Example> callback, string workspaceId, string intent, string text, string newText = null, List<Mention> newMentions = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateExample`");
@@ -1674,17 +1596,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateExample"))
             {
@@ -1752,11 +1672,8 @@ namespace IBM.Watson.Assistant.V1
         /// - It cannot contain carriage return, newline, or tab characters
         /// - It cannot consist of only whitespace characters
         /// - It must be no longer than 1024 characters.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Counterexample" />Counterexample</returns>
-        public bool CreateCounterexample(Callback<Counterexample> callback, string workspaceId, string text, Dictionary<string, object> customData = null)
+        public bool CreateCounterexample(Callback<Counterexample> callback, string workspaceId, string text)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateCounterexample`");
@@ -1769,17 +1686,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateCounterexample"))
             {
@@ -1841,11 +1756,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="text">The text of a user input counterexample (for example, `What are you wearing?`).</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteCounterexample(Callback<object> callback, string workspaceId, string text, Dictionary<string, object> customData = null)
+        public bool DeleteCounterexample(Callback<object> callback, string workspaceId, string text)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteCounterexample`");
@@ -1858,17 +1770,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteCounterexample"))
             {
@@ -1925,11 +1835,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="text">The text of a user input counterexample (for example, `What are you wearing?`).</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Counterexample" />Counterexample</returns>
-        public bool GetCounterexample(Callback<Counterexample> callback, string workspaceId, string text, Dictionary<string, object> customData = null, bool? includeAudit = null)
+        public bool GetCounterexample(Callback<Counterexample> callback, string workspaceId, string text, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetCounterexample`");
@@ -1942,17 +1849,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetCounterexample"))
             {
@@ -2019,11 +1924,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="CounterexampleCollection" />CounterexampleCollection</returns>
-        public bool ListCounterexamples(Callback<CounterexampleCollection> callback, string workspaceId, Dictionary<string, object> customData = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListCounterexamples(Callback<CounterexampleCollection> callback, string workspaceId, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListCounterexamples`");
@@ -2034,17 +1936,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListCounterexamples"))
             {
@@ -2124,11 +2024,8 @@ namespace IBM.Watson.Assistant.V1
         /// - It cannot contain carriage return, newline, or tab characters
         /// - It cannot consist of only whitespace characters
         /// - It must be no longer than 1024 characters. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Counterexample" />Counterexample</returns>
-        public bool UpdateCounterexample(Callback<Counterexample> callback, string workspaceId, string text, Dictionary<string, object> customData = null, string newText = null)
+        public bool UpdateCounterexample(Callback<Counterexample> callback, string workspaceId, string text, string newText = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateCounterexample`");
@@ -2141,17 +2038,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateCounterexample"))
             {
@@ -2222,11 +2117,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="metadata">Any metadata related to the entity. (optional)</param>
         /// <param name="fuzzyMatch">Whether to use fuzzy matching for the entity. (optional)</param>
         /// <param name="values">An array of objects describing the entity values. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Entity" />Entity</returns>
-        public bool CreateEntity(Callback<Entity> callback, string workspaceId, string entity, Dictionary<string, object> customData = null, string description = null, Dictionary<string, object> metadata = null, bool? fuzzyMatch = null, List<CreateValue> values = null)
+        public bool CreateEntity(Callback<Entity> callback, string workspaceId, string entity, string description = null, Dictionary<string, object> metadata = null, bool? fuzzyMatch = null, List<CreateValue> values = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateEntity`");
@@ -2239,17 +2131,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateEntity"))
             {
@@ -2318,11 +2208,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="entity">The name of the entity.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteEntity(Callback<object> callback, string workspaceId, string entity, Dictionary<string, object> customData = null)
+        public bool DeleteEntity(Callback<object> callback, string workspaceId, string entity)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteEntity`");
@@ -2335,17 +2222,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteEntity"))
             {
@@ -2405,11 +2290,8 @@ namespace IBM.Watson.Assistant.V1
         /// including subelements, is included. (optional, default to false)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Entity" />Entity</returns>
-        public bool GetEntity(Callback<Entity> callback, string workspaceId, string entity, Dictionary<string, object> customData = null, bool? export = null, bool? includeAudit = null)
+        public bool GetEntity(Callback<Entity> callback, string workspaceId, string entity, bool? export = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetEntity`");
@@ -2422,17 +2304,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetEntity"))
             {
@@ -2506,11 +2386,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="EntityCollection" />EntityCollection</returns>
-        public bool ListEntities(Callback<EntityCollection> callback, string workspaceId, Dictionary<string, object> customData = null, bool? export = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListEntities(Callback<EntityCollection> callback, string workspaceId, bool? export = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListEntities`");
@@ -2521,17 +2398,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListEntities"))
             {
@@ -2619,11 +2494,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="newMetadata">Any metadata related to the entity. (optional)</param>
         /// <param name="newFuzzyMatch">Whether to use fuzzy matching for the entity. (optional)</param>
         /// <param name="newValues">An array of objects describing the entity values. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Entity" />Entity</returns>
-        public bool UpdateEntity(Callback<Entity> callback, string workspaceId, string entity, Dictionary<string, object> customData = null, string newEntity = null, string newDescription = null, Dictionary<string, object> newMetadata = null, bool? newFuzzyMatch = null, List<CreateValue> newValues = null)
+        public bool UpdateEntity(Callback<Entity> callback, string workspaceId, string entity, string newEntity = null, string newDescription = null, Dictionary<string, object> newMetadata = null, bool? newFuzzyMatch = null, List<CreateValue> newValues = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateEntity`");
@@ -2636,17 +2508,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateEntity"))
             {
@@ -2721,11 +2591,8 @@ namespace IBM.Watson.Assistant.V1
         /// including subelements, is included. (optional, default to false)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="EntityMentionCollection" />EntityMentionCollection</returns>
-        public bool ListMentions(Callback<EntityMentionCollection> callback, string workspaceId, string entity, Dictionary<string, object> customData = null, bool? export = null, bool? includeAudit = null)
+        public bool ListMentions(Callback<EntityMentionCollection> callback, string workspaceId, string entity, bool? export = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListMentions`");
@@ -2738,17 +2605,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListMentions"))
             {
@@ -2826,11 +2691,8 @@ namespace IBM.Watson.Assistant.V1
         /// characters. For more information about how to specify a pattern, see the
         /// [documentation](https://cloud.ibm.com/docs/services/assistant/entities.html#entities-create-dictionary-based).
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Value" />Value</returns>
-        public bool CreateValue(Callback<Value> callback, string workspaceId, string entity, string value, Dictionary<string, object> customData = null, Dictionary<string, object> metadata = null, string valueType = null, List<string> synonyms = null, List<string> patterns = null)
+        public bool CreateValue(Callback<Value> callback, string workspaceId, string entity, string value, Dictionary<string, object> metadata = null, string valueType = null, List<string> synonyms = null, List<string> patterns = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateValue`");
@@ -2845,17 +2707,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateValue"))
             {
@@ -2925,11 +2785,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="entity">The name of the entity.</param>
         /// <param name="value">The text of the entity value.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteValue(Callback<object> callback, string workspaceId, string entity, string value, Dictionary<string, object> customData = null)
+        public bool DeleteValue(Callback<object> callback, string workspaceId, string entity, string value)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteValue`");
@@ -2944,17 +2801,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteValue"))
             {
@@ -3014,11 +2869,8 @@ namespace IBM.Watson.Assistant.V1
         /// including subelements, is included. (optional, default to false)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Value" />Value</returns>
-        public bool GetValue(Callback<Value> callback, string workspaceId, string entity, string value, Dictionary<string, object> customData = null, bool? export = null, bool? includeAudit = null)
+        public bool GetValue(Callback<Value> callback, string workspaceId, string entity, string value, bool? export = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetValue`");
@@ -3033,17 +2885,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetValue"))
             {
@@ -3117,11 +2967,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ValueCollection" />ValueCollection</returns>
-        public bool ListValues(Callback<ValueCollection> callback, string workspaceId, string entity, Dictionary<string, object> customData = null, bool? export = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListValues(Callback<ValueCollection> callback, string workspaceId, string entity, bool? export = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListValues`");
@@ -3134,17 +2981,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListValues"))
             {
@@ -3241,11 +3086,8 @@ namespace IBM.Watson.Assistant.V1
         /// characters. For more information about how to specify a pattern, see the
         /// [documentation](https://cloud.ibm.com/docs/services/assistant/entities.html#entities-create-dictionary-based).
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Value" />Value</returns>
-        public bool UpdateValue(Callback<Value> callback, string workspaceId, string entity, string value, Dictionary<string, object> customData = null, string newValue = null, Dictionary<string, object> newMetadata = null, string newValueType = null, List<string> newSynonyms = null, List<string> newPatterns = null)
+        public bool UpdateValue(Callback<Value> callback, string workspaceId, string entity, string value, string newValue = null, Dictionary<string, object> newMetadata = null, string newValueType = null, List<string> newSynonyms = null, List<string> newPatterns = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateValue`");
@@ -3260,17 +3102,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateValue"))
             {
@@ -3344,11 +3184,8 @@ namespace IBM.Watson.Assistant.V1
         /// - It cannot contain carriage return, newline, or tab characters.
         /// - It cannot consist of only whitespace characters.
         /// - It must be no longer than 64 characters.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Synonym" />Synonym</returns>
-        public bool CreateSynonym(Callback<Synonym> callback, string workspaceId, string entity, string value, string synonym, Dictionary<string, object> customData = null)
+        public bool CreateSynonym(Callback<Synonym> callback, string workspaceId, string entity, string value, string synonym)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateSynonym`");
@@ -3365,17 +3202,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateSynonym"))
             {
@@ -3438,11 +3273,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="entity">The name of the entity.</param>
         /// <param name="value">The text of the entity value.</param>
         /// <param name="synonym">The text of the synonym.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteSynonym(Callback<object> callback, string workspaceId, string entity, string value, string synonym, Dictionary<string, object> customData = null)
+        public bool DeleteSynonym(Callback<object> callback, string workspaceId, string entity, string value, string synonym)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteSynonym`");
@@ -3459,17 +3291,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteSynonym"))
             {
@@ -3527,11 +3357,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="synonym">The text of the synonym.</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Synonym" />Synonym</returns>
-        public bool GetSynonym(Callback<Synonym> callback, string workspaceId, string entity, string value, string synonym, Dictionary<string, object> customData = null, bool? includeAudit = null)
+        public bool GetSynonym(Callback<Synonym> callback, string workspaceId, string entity, string value, string synonym, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetSynonym`");
@@ -3548,17 +3375,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetSynonym"))
             {
@@ -3626,11 +3451,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="SynonymCollection" />SynonymCollection</returns>
-        public bool ListSynonyms(Callback<SynonymCollection> callback, string workspaceId, string entity, string value, Dictionary<string, object> customData = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListSynonyms(Callback<SynonymCollection> callback, string workspaceId, string entity, string value, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListSynonyms`");
@@ -3645,17 +3467,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListSynonyms"))
             {
@@ -3735,11 +3555,8 @@ namespace IBM.Watson.Assistant.V1
         /// - It cannot contain carriage return, newline, or tab characters.
         /// - It cannot consist of only whitespace characters.
         /// - It must be no longer than 64 characters. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Synonym" />Synonym</returns>
-        public bool UpdateSynonym(Callback<Synonym> callback, string workspaceId, string entity, string value, string synonym, Dictionary<string, object> customData = null, string newSynonym = null)
+        public bool UpdateSynonym(Callback<Synonym> callback, string workspaceId, string entity, string value, string synonym, string newSynonym = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateSynonym`");
@@ -3756,17 +3573,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateSynonym"))
             {
@@ -3860,11 +3675,8 @@ namespace IBM.Watson.Assistant.V1
         /// (optional)</param>
         /// <param name="userLabel">A label that can be displayed externally to describe the purpose of the node to
         /// users. This string must be no longer than 512 characters. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DialogNode" />DialogNode</returns>
-        public bool CreateDialogNode(Callback<DialogNode> callback, string workspaceId, string dialogNode, Dictionary<string, object> customData = null, string description = null, string conditions = null, string parent = null, string previousSibling = null, JObject output = null, Dictionary<string, object> context = null, Dictionary<string, object> metadata = null, DialogNodeNextStep nextStep = null, string title = null, string nodeType = null, string eventName = null, string variable = null, List<DialogNodeAction> actions = null, string digressIn = null, string digressOut = null, string digressOutSlots = null, string userLabel = null)
+        public bool CreateDialogNode(Callback<DialogNode> callback, string workspaceId, string dialogNode, string description = null, string conditions = null, string parent = null, string previousSibling = null, JObject output = null, Dictionary<string, object> context = null, Dictionary<string, object> metadata = null, DialogNodeNextStep nextStep = null, string title = null, string nodeType = null, string eventName = null, string variable = null, List<DialogNodeAction> actions = null, string digressIn = null, string digressOut = null, string digressOutSlots = null, string userLabel = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateDialogNode`");
@@ -3877,17 +3689,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "CreateDialogNode"))
             {
@@ -3982,11 +3792,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="dialogNode">The dialog node ID (for example, `get_order`).</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteDialogNode(Callback<object> callback, string workspaceId, string dialogNode, Dictionary<string, object> customData = null)
+        public bool DeleteDialogNode(Callback<object> callback, string workspaceId, string dialogNode)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteDialogNode`");
@@ -3999,17 +3806,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteDialogNode"))
             {
@@ -4065,11 +3870,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="dialogNode">The dialog node ID (for example, `get_order`).</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DialogNode" />DialogNode</returns>
-        public bool GetDialogNode(Callback<DialogNode> callback, string workspaceId, string dialogNode, Dictionary<string, object> customData = null, bool? includeAudit = null)
+        public bool GetDialogNode(Callback<DialogNode> callback, string workspaceId, string dialogNode, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetDialogNode`");
@@ -4082,17 +3884,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "GetDialogNode"))
             {
@@ -4158,11 +3958,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <param name="includeAudit">Whether to include the audit properties (`created` and `updated` timestamps) in
         /// the response. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DialogNodeCollection" />DialogNodeCollection</returns>
-        public bool ListDialogNodes(Callback<DialogNodeCollection> callback, string workspaceId, Dictionary<string, object> customData = null, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
+        public bool ListDialogNodes(Callback<DialogNodeCollection> callback, string workspaceId, long? pageLimit = null, bool? includeCount = null, string sort = null, string cursor = null, bool? includeAudit = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListDialogNodes`");
@@ -4173,17 +3970,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListDialogNodes"))
             {
@@ -4292,11 +4087,8 @@ namespace IBM.Watson.Assistant.V1
         /// (optional)</param>
         /// <param name="newUserLabel">A label that can be displayed externally to describe the purpose of the node to
         /// users. This string must be no longer than 512 characters. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DialogNode" />DialogNode</returns>
-        public bool UpdateDialogNode(Callback<DialogNode> callback, string workspaceId, string dialogNode, Dictionary<string, object> customData = null, string newDialogNode = null, string newDescription = null, string newConditions = null, string newParent = null, string newPreviousSibling = null, JObject newOutput = null, Dictionary<string, object> newContext = null, Dictionary<string, object> newMetadata = null, DialogNodeNextStep newNextStep = null, string newTitle = null, string newNodeType = null, string newEventName = null, string newVariable = null, List<DialogNodeAction> newActions = null, string newDigressIn = null, string newDigressOut = null, string newDigressOutSlots = null, string newUserLabel = null)
+        public bool UpdateDialogNode(Callback<DialogNode> callback, string workspaceId, string dialogNode, string newDialogNode = null, string newDescription = null, string newConditions = null, string newParent = null, string newPreviousSibling = null, JObject newOutput = null, Dictionary<string, object> newContext = null, Dictionary<string, object> newMetadata = null, DialogNodeNextStep newNextStep = null, string newTitle = null, string newNodeType = null, string newEventName = null, string newVariable = null, List<DialogNodeAction> newActions = null, string newDigressIn = null, string newDigressOut = null, string newDigressOutSlots = null, string newUserLabel = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateDialogNode`");
@@ -4309,17 +4101,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "UpdateDialogNode"))
             {
@@ -4423,11 +4213,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
         /// 100)</param>
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="LogCollection" />LogCollection</returns>
-        public bool ListAllLogs(Callback<LogCollection> callback, string filter, Dictionary<string, object> customData = null, string sort = null, long? pageLimit = null, string cursor = null)
+        public bool ListAllLogs(Callback<LogCollection> callback, string filter, string sort = null, long? pageLimit = null, string cursor = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListAllLogs`");
@@ -4438,17 +4225,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListAllLogs"))
             {
@@ -4528,11 +4313,8 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
         /// 100)</param>
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="LogCollection" />LogCollection</returns>
-        public bool ListLogs(Callback<LogCollection> callback, string workspaceId, Dictionary<string, object> customData = null, string sort = null, string filter = null, long? pageLimit = null, string cursor = null)
+        public bool ListLogs(Callback<LogCollection> callback, string workspaceId, string sort = null, string filter = null, long? pageLimit = null, string cursor = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListLogs`");
@@ -4543,17 +4325,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "ListLogs"))
             {
@@ -4625,11 +4405,8 @@ namespace IBM.Watson.Assistant.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customerId">The customer ID for which all data is to be deleted.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteUserData(Callback<object> callback, string customerId, Dictionary<string, object> customData = null)
+        public bool DeleteUserData(Callback<object> callback, string customerId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteUserData`");
@@ -4640,17 +4417,15 @@ namespace IBM.Watson.Assistant.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V1", "DeleteUserData"))
             {

--- a/Scripts/Services/Assistant/V1/AssistantService.cs
+++ b/Scripts/Services/Assistant/V1/AssistantService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.Assistant.V1
 {
-    public class AssistantService : BaseService
+    public partial class AssistantService : BaseService
     {
         private const string serviceId = "conversation";
         private const string defaultUrl = "https://gateway.watsonplatform.net/assistant/api";
@@ -216,7 +216,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnMessageResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<MessageResponse> response = new DetailedResponse<MessageResponse>();
-            Dictionary<string, object> customData = ((RequestObject<MessageResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -227,14 +226,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<MessageResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -243,7 +235,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<MessageResponse>)req).Callback != null)
-                ((RequestObject<MessageResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<MessageResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create workspace.
@@ -341,7 +333,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateWorkspaceResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Workspace> response = new DetailedResponse<Workspace>();
-            Dictionary<string, object> customData = ((RequestObject<Workspace>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -352,14 +343,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Workspace>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -368,7 +352,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Workspace>)req).Callback != null)
-                ((RequestObject<Workspace>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Workspace>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete workspace.
@@ -427,7 +411,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteWorkspaceResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -438,14 +421,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -454,7 +430,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get information about a workspace.
@@ -534,7 +510,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetWorkspaceResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Workspace> response = new DetailedResponse<Workspace>();
-            Dictionary<string, object> customData = ((RequestObject<Workspace>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -545,14 +520,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Workspace>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -561,7 +529,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Workspace>)req).Callback != null)
-                ((RequestObject<Workspace>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Workspace>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List workspaces.
@@ -646,7 +614,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListWorkspacesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<WorkspaceCollection> response = new DetailedResponse<WorkspaceCollection>();
-            Dictionary<string, object> customData = ((RequestObject<WorkspaceCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -657,14 +624,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<WorkspaceCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -673,7 +633,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<WorkspaceCollection>)req).Callback != null)
-                ((RequestObject<WorkspaceCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<WorkspaceCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update workspace.
@@ -786,7 +746,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateWorkspaceResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Workspace> response = new DetailedResponse<Workspace>();
-            Dictionary<string, object> customData = ((RequestObject<Workspace>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -797,14 +756,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Workspace>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -813,7 +765,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Workspace>)req).Callback != null)
-                ((RequestObject<Workspace>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Workspace>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create intent.
@@ -892,7 +844,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateIntentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Intent> response = new DetailedResponse<Intent>();
-            Dictionary<string, object> customData = ((RequestObject<Intent>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -903,14 +854,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Intent>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -919,7 +863,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Intent>)req).Callback != null)
-                ((RequestObject<Intent>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Intent>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete intent.
@@ -981,7 +925,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteIntentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -992,14 +935,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1008,7 +944,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get intent.
@@ -1084,7 +1020,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetIntentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Intent> response = new DetailedResponse<Intent>();
-            Dictionary<string, object> customData = ((RequestObject<Intent>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1095,14 +1030,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Intent>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1111,7 +1039,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Intent>)req).Callback != null)
-                ((RequestObject<Intent>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Intent>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List intents.
@@ -1207,7 +1135,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListIntentsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<IntentCollection> response = new DetailedResponse<IntentCollection>();
-            Dictionary<string, object> customData = ((RequestObject<IntentCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1218,14 +1145,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<IntentCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1234,7 +1154,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<IntentCollection>)req).Callback != null)
-                ((RequestObject<IntentCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<IntentCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update intent.
@@ -1315,7 +1235,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateIntentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Intent> response = new DetailedResponse<Intent>();
-            Dictionary<string, object> customData = ((RequestObject<Intent>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1326,14 +1245,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Intent>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1342,7 +1254,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Intent>)req).Callback != null)
-                ((RequestObject<Intent>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Intent>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create user input example.
@@ -1421,7 +1333,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Example> response = new DetailedResponse<Example>();
-            Dictionary<string, object> customData = ((RequestObject<Example>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1432,14 +1343,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Example>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1448,7 +1352,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Example>)req).Callback != null)
-                ((RequestObject<Example>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Example>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete user input example.
@@ -1513,7 +1417,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1524,14 +1427,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1540,7 +1436,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get user input example.
@@ -1611,7 +1507,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Example> response = new DetailedResponse<Example>();
-            Dictionary<string, object> customData = ((RequestObject<Example>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1622,14 +1517,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Example>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1638,7 +1526,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Example>)req).Callback != null)
-                ((RequestObject<Example>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Example>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List user input examples.
@@ -1729,7 +1617,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListExamplesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ExampleCollection> response = new DetailedResponse<ExampleCollection>();
-            Dictionary<string, object> customData = ((RequestObject<ExampleCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1740,14 +1627,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ExampleCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1756,7 +1636,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<ExampleCollection>)req).Callback != null)
-                ((RequestObject<ExampleCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ExampleCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update user input example.
@@ -1836,7 +1716,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Example> response = new DetailedResponse<Example>();
-            Dictionary<string, object> customData = ((RequestObject<Example>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1847,14 +1726,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Example>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1863,7 +1735,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Example>)req).Callback != null)
-                ((RequestObject<Example>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Example>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create counterexample.
@@ -1937,7 +1809,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateCounterexampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Counterexample> response = new DetailedResponse<Counterexample>();
-            Dictionary<string, object> customData = ((RequestObject<Counterexample>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1948,14 +1819,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Counterexample>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1964,7 +1828,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Counterexample>)req).Callback != null)
-                ((RequestObject<Counterexample>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Counterexample>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete counterexample.
@@ -2027,7 +1891,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteCounterexampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2038,14 +1901,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2054,7 +1910,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get counterexample.
@@ -2123,7 +1979,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetCounterexampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Counterexample> response = new DetailedResponse<Counterexample>();
-            Dictionary<string, object> customData = ((RequestObject<Counterexample>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2134,14 +1989,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Counterexample>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2150,7 +1998,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Counterexample>)req).Callback != null)
-                ((RequestObject<Counterexample>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Counterexample>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List counterexamples.
@@ -2239,7 +2087,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListCounterexamplesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<CounterexampleCollection> response = new DetailedResponse<CounterexampleCollection>();
-            Dictionary<string, object> customData = ((RequestObject<CounterexampleCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2250,14 +2097,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<CounterexampleCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2266,7 +2106,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<CounterexampleCollection>)req).Callback != null)
-                ((RequestObject<CounterexampleCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<CounterexampleCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update counterexample.
@@ -2341,7 +2181,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateCounterexampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Counterexample> response = new DetailedResponse<Counterexample>();
-            Dictionary<string, object> customData = ((RequestObject<Counterexample>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2352,14 +2191,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Counterexample>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2368,7 +2200,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Counterexample>)req).Callback != null)
-                ((RequestObject<Counterexample>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Counterexample>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create entity.
@@ -2455,7 +2287,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateEntityResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Entity> response = new DetailedResponse<Entity>();
-            Dictionary<string, object> customData = ((RequestObject<Entity>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2466,14 +2297,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Entity>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2482,7 +2306,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Entity>)req).Callback != null)
-                ((RequestObject<Entity>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Entity>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete entity.
@@ -2544,7 +2368,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteEntityResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2555,14 +2378,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2571,7 +2387,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get entity.
@@ -2647,7 +2463,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetEntityResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Entity> response = new DetailedResponse<Entity>();
-            Dictionary<string, object> customData = ((RequestObject<Entity>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2658,14 +2473,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Entity>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2674,7 +2482,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Entity>)req).Callback != null)
-                ((RequestObject<Entity>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Entity>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List entities.
@@ -2770,7 +2578,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListEntitiesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<EntityCollection> response = new DetailedResponse<EntityCollection>();
-            Dictionary<string, object> customData = ((RequestObject<EntityCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2781,14 +2588,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<EntityCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2797,7 +2597,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<EntityCollection>)req).Callback != null)
-                ((RequestObject<EntityCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<EntityCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update entity.
@@ -2884,7 +2684,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateEntityResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Entity> response = new DetailedResponse<Entity>();
-            Dictionary<string, object> customData = ((RequestObject<Entity>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2895,14 +2694,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Entity>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2911,7 +2703,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Entity>)req).Callback != null)
-                ((RequestObject<Entity>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Entity>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List entity mentions.
@@ -2987,7 +2779,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListMentionsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<EntityMentionCollection> response = new DetailedResponse<EntityMentionCollection>();
-            Dictionary<string, object> customData = ((RequestObject<EntityMentionCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2998,14 +2789,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<EntityMentionCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3014,7 +2798,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<EntityMentionCollection>)req).Callback != null)
-                ((RequestObject<EntityMentionCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<EntityMentionCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create entity value.
@@ -3109,7 +2893,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateValueResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Value> response = new DetailedResponse<Value>();
-            Dictionary<string, object> customData = ((RequestObject<Value>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3120,14 +2903,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Value>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3136,7 +2912,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Value>)req).Callback != null)
-                ((RequestObject<Value>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Value>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete entity value.
@@ -3201,7 +2977,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteValueResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3212,14 +2987,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3228,7 +2996,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get entity value.
@@ -3306,7 +3074,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetValueResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Value> response = new DetailedResponse<Value>();
-            Dictionary<string, object> customData = ((RequestObject<Value>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3317,14 +3084,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Value>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3333,7 +3093,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Value>)req).Callback != null)
-                ((RequestObject<Value>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Value>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List entity values.
@@ -3431,7 +3191,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListValuesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ValueCollection> response = new DetailedResponse<ValueCollection>();
-            Dictionary<string, object> customData = ((RequestObject<ValueCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3442,14 +3201,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ValueCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3458,7 +3210,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<ValueCollection>)req).Callback != null)
-                ((RequestObject<ValueCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ValueCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update entity value.
@@ -3556,7 +3308,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateValueResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Value> response = new DetailedResponse<Value>();
-            Dictionary<string, object> customData = ((RequestObject<Value>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3567,14 +3318,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Value>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3583,7 +3327,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Value>)req).Callback != null)
-                ((RequestObject<Value>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Value>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create entity value synonym.
@@ -3661,7 +3405,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateSynonymResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Synonym> response = new DetailedResponse<Synonym>();
-            Dictionary<string, object> customData = ((RequestObject<Synonym>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3672,14 +3415,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Synonym>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3688,7 +3424,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Synonym>)req).Callback != null)
-                ((RequestObject<Synonym>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Synonym>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete entity value synonym.
@@ -3756,7 +3492,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteSynonymResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3767,14 +3502,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3783,7 +3511,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get entity value synonym.
@@ -3857,7 +3585,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetSynonymResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Synonym> response = new DetailedResponse<Synonym>();
-            Dictionary<string, object> customData = ((RequestObject<Synonym>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3868,14 +3595,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Synonym>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3884,7 +3604,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Synonym>)req).Callback != null)
-                ((RequestObject<Synonym>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Synonym>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List entity value synonyms.
@@ -3978,7 +3698,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListSynonymsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<SynonymCollection> response = new DetailedResponse<SynonymCollection>();
-            Dictionary<string, object> customData = ((RequestObject<SynonymCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3989,14 +3708,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<SynonymCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4005,7 +3717,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<SynonymCollection>)req).Callback != null)
-                ((RequestObject<SynonymCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<SynonymCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update entity value synonym.
@@ -4084,7 +3796,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateSynonymResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Synonym> response = new DetailedResponse<Synonym>();
-            Dictionary<string, object> customData = ((RequestObject<Synonym>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4095,14 +3806,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Synonym>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4111,7 +3815,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<Synonym>)req).Callback != null)
-                ((RequestObject<Synonym>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Synonym>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create dialog node.
@@ -4247,7 +3951,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnCreateDialogNodeResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DialogNode> response = new DetailedResponse<DialogNode>();
-            Dictionary<string, object> customData = ((RequestObject<DialogNode>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4258,14 +3961,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DialogNode>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4274,7 +3970,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<DialogNode>)req).Callback != null)
-                ((RequestObject<DialogNode>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DialogNode>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete dialog node.
@@ -4336,7 +4032,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteDialogNodeResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4347,14 +4042,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4363,7 +4051,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get dialog node.
@@ -4431,7 +4119,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnGetDialogNodeResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DialogNode> response = new DetailedResponse<DialogNode>();
-            Dictionary<string, object> customData = ((RequestObject<DialogNode>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4442,14 +4129,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DialogNode>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4458,7 +4138,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<DialogNode>)req).Callback != null)
-                ((RequestObject<DialogNode>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DialogNode>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List dialog nodes.
@@ -4546,7 +4226,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListDialogNodesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DialogNodeCollection> response = new DetailedResponse<DialogNodeCollection>();
-            Dictionary<string, object> customData = ((RequestObject<DialogNodeCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4557,14 +4236,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DialogNodeCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4573,7 +4245,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<DialogNodeCollection>)req).Callback != null)
-                ((RequestObject<DialogNodeCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DialogNodeCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update dialog node.
@@ -4711,7 +4383,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnUpdateDialogNodeResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DialogNode> response = new DetailedResponse<DialogNode>();
-            Dictionary<string, object> customData = ((RequestObject<DialogNode>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4722,14 +4393,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DialogNode>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4738,7 +4402,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<DialogNode>)req).Callback != null)
-                ((RequestObject<DialogNode>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DialogNode>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List log events in all workspaces.
@@ -4823,7 +4487,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListAllLogsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<LogCollection> response = new DetailedResponse<LogCollection>();
-            Dictionary<string, object> customData = ((RequestObject<LogCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4834,14 +4497,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<LogCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4850,7 +4506,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<LogCollection>)req).Callback != null)
-                ((RequestObject<LogCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<LogCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List log events in a workspace.
@@ -4936,7 +4592,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnListLogsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<LogCollection> response = new DetailedResponse<LogCollection>();
-            Dictionary<string, object> customData = ((RequestObject<LogCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4947,14 +4602,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<LogCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4963,7 +4611,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<LogCollection>)req).Callback != null)
-                ((RequestObject<LogCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<LogCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete labeled data.
@@ -5029,7 +4677,6 @@ namespace IBM.Watson.Assistant.V1
         private void OnDeleteUserDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5040,14 +4687,7 @@ namespace IBM.Watson.Assistant.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5056,7 +4696,7 @@ namespace IBM.Watson.Assistant.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/Assistant/V2/AssistantService.cs
+++ b/Scripts/Services/Assistant/V2/AssistantService.cs
@@ -138,11 +138,8 @@ namespace IBM.Watson.Assistant.V2
         /// [documentation](https://console.bluemix.net/docs/services/assistant/assistant-add.html#assistant-add-task).
         ///
         /// **Note:** Currently, the v2 API does not support creating assistants.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="SessionResponse" />SessionResponse</returns>
-        public bool CreateSession(Callback<SessionResponse> callback, string assistantId, Dictionary<string, object> customData = null)
+        public bool CreateSession(Callback<SessionResponse> callback, string assistantId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateSession`");
@@ -153,17 +150,15 @@ namespace IBM.Watson.Assistant.V2
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V2", "CreateSession"))
             {
@@ -219,11 +214,8 @@ namespace IBM.Watson.Assistant.V2
         ///
         /// **Note:** Currently, the v2 API does not support creating assistants.</param>
         /// <param name="sessionId">Unique identifier of the session.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteSession(Callback<object> callback, string assistantId, string sessionId, Dictionary<string, object> customData = null)
+        public bool DeleteSession(Callback<object> callback, string assistantId, string sessionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteSession`");
@@ -236,17 +228,15 @@ namespace IBM.Watson.Assistant.V2
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V2", "DeleteSession"))
             {
@@ -308,11 +298,8 @@ namespace IBM.Watson.Assistant.V2
         /// <param name="context">State information for the conversation. The context is stored by the assistant on a
         /// per-session basis. You can use this property to set or modify context variables, which can also be accessed
         /// by dialog nodes. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="MessageResponse" />MessageResponse</returns>
-        public bool Message(Callback<MessageResponse> callback, string assistantId, string sessionId, Dictionary<string, object> customData = null, MessageInput input = null, MessageContext context = null)
+        public bool Message(Callback<MessageResponse> callback, string assistantId, string sessionId, MessageInput input = null, MessageContext context = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Message`");
@@ -325,17 +312,15 @@ namespace IBM.Watson.Assistant.V2
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("conversation", "V2", "Message"))
             {

--- a/Scripts/Services/Assistant/V2/AssistantService.cs
+++ b/Scripts/Services/Assistant/V2/AssistantService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.Assistant.V2
 {
-    public class AssistantService : BaseService
+    public partial class AssistantService : BaseService
     {
         private const string serviceId = "conversation";
         private const string defaultUrl = "https://gateway.watsonplatform.net/assistant/api";
@@ -186,7 +186,6 @@ namespace IBM.Watson.Assistant.V2
         private void OnCreateSessionResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<SessionResponse> response = new DetailedResponse<SessionResponse>();
-            Dictionary<string, object> customData = ((RequestObject<SessionResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -197,14 +196,7 @@ namespace IBM.Watson.Assistant.V2
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<SessionResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -213,7 +205,7 @@ namespace IBM.Watson.Assistant.V2
             }
 
             if (((RequestObject<SessionResponse>)req).Callback != null)
-                ((RequestObject<SessionResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<SessionResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete session.
@@ -277,7 +269,6 @@ namespace IBM.Watson.Assistant.V2
         private void OnDeleteSessionResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -288,14 +279,7 @@ namespace IBM.Watson.Assistant.V2
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -304,7 +288,7 @@ namespace IBM.Watson.Assistant.V2
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Send user input to assistant.
@@ -383,7 +367,6 @@ namespace IBM.Watson.Assistant.V2
         private void OnMessageResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<MessageResponse> response = new DetailedResponse<MessageResponse>();
-            Dictionary<string, object> customData = ((RequestObject<MessageResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -394,14 +377,7 @@ namespace IBM.Watson.Assistant.V2
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<MessageResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -410,7 +386,7 @@ namespace IBM.Watson.Assistant.V2
             }
 
             if (((RequestObject<MessageResponse>)req).Callback != null)
-                ((RequestObject<MessageResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<MessageResponse>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/CompareComply/V1/CompareComplyService.cs
+++ b/Scripts/Services/CompareComply/V1/CompareComplyService.cs
@@ -138,11 +138,8 @@ namespace IBM.Watson.CompareComply.V1
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="HTMLReturn" />HTMLReturn</returns>
-        public bool ConvertToHtml(Callback<HTMLReturn> callback, System.IO.FileStream file, Dictionary<string, object> customData = null, string modelId = null, string fileContentType = null)
+        public bool ConvertToHtml(Callback<HTMLReturn> callback, System.IO.FileStream file, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ConvertToHtml`");
@@ -153,17 +150,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "ConvertToHtml"))
             {
@@ -228,11 +223,8 @@ namespace IBM.Watson.CompareComply.V1
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ClassifyReturn" />ClassifyReturn</returns>
-        public bool ClassifyElements(Callback<ClassifyReturn> callback, System.IO.FileStream file, Dictionary<string, object> customData = null, string modelId = null, string fileContentType = null)
+        public bool ClassifyElements(Callback<ClassifyReturn> callback, System.IO.FileStream file, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ClassifyElements`");
@@ -243,17 +235,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "ClassifyElements"))
             {
@@ -318,11 +308,8 @@ namespace IBM.Watson.CompareComply.V1
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TableReturn" />TableReturn</returns>
-        public bool ExtractTables(Callback<TableReturn> callback, System.IO.FileStream file, Dictionary<string, object> customData = null, string modelId = null, string fileContentType = null)
+        public bool ExtractTables(Callback<TableReturn> callback, System.IO.FileStream file, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ExtractTables`");
@@ -333,17 +320,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "ExtractTables"))
             {
@@ -412,11 +397,8 @@ namespace IBM.Watson.CompareComply.V1
         /// (optional)</param>
         /// <param name="file1ContentType">The content type of file1. (optional)</param>
         /// <param name="file2ContentType">The content type of file2. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="CompareReturn" />CompareReturn</returns>
-        public bool CompareDocuments(Callback<CompareReturn> callback, System.IO.FileStream file1, System.IO.FileStream file2, Dictionary<string, object> customData = null, string file1Label = null, string file2Label = null, string modelId = null, string file1ContentType = null, string file2ContentType = null)
+        public bool CompareDocuments(Callback<CompareReturn> callback, System.IO.FileStream file1, System.IO.FileStream file2, string file1Label = null, string file2Label = null, string modelId = null, string file1ContentType = null, string file2ContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CompareDocuments`");
@@ -429,17 +411,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "CompareDocuments"))
             {
@@ -516,11 +496,8 @@ namespace IBM.Watson.CompareComply.V1
         /// <param name="feedbackData">Feedback data for submission.</param>
         /// <param name="userId">An optional string identifying the user. (optional)</param>
         /// <param name="comment">An optional comment on or description of the feedback. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="FeedbackReturn" />FeedbackReturn</returns>
-        public bool AddFeedback(Callback<FeedbackReturn> callback, FeedbackDataInput feedbackData, Dictionary<string, object> customData = null, string userId = null, string comment = null)
+        public bool AddFeedback(Callback<FeedbackReturn> callback, FeedbackDataInput feedbackData, string userId = null, string comment = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddFeedback`");
@@ -531,17 +508,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "AddFeedback"))
             {
@@ -605,11 +580,8 @@ namespace IBM.Watson.CompareComply.V1
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="FeedbackDeleted" />FeedbackDeleted</returns>
-        public bool DeleteFeedback(Callback<FeedbackDeleted> callback, string feedbackId, Dictionary<string, object> customData = null, string modelId = null)
+        public bool DeleteFeedback(Callback<FeedbackDeleted> callback, string feedbackId, string modelId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteFeedback`");
@@ -620,17 +592,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "DeleteFeedback"))
             {
@@ -687,11 +657,8 @@ namespace IBM.Watson.CompareComply.V1
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="GetFeedback" />GetFeedback</returns>
-        public bool GetFeedback(Callback<GetFeedback> callback, string feedbackId, Dictionary<string, object> customData = null, string modelId = null)
+        public bool GetFeedback(Callback<GetFeedback> callback, string feedbackId, string modelId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetFeedback`");
@@ -702,17 +669,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "GetFeedback"))
             {
@@ -804,11 +769,8 @@ namespace IBM.Watson.CompareComply.V1
         /// `document_title`. (optional)</param>
         /// <param name="includeTotal">An optional boolean value. If specified as `true`, the `pagination` object in the
         /// output includes a value called `total` that gives the total count of feedback created. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="FeedbackList" />FeedbackList</returns>
-        public bool ListFeedback(Callback<FeedbackList> callback, Dictionary<string, object> customData = null, string feedbackType = null, DateTime? before = null, DateTime? after = null, string documentTitle = null, string modelId = null, string modelVersion = null, string categoryRemoved = null, string categoryAdded = null, string categoryNotChanged = null, string typeRemoved = null, string typeAdded = null, string typeNotChanged = null, long? pageLimit = null, string cursor = null, string sort = null, bool? includeTotal = null)
+        public bool ListFeedback(Callback<FeedbackList> callback, string feedbackType = null, DateTime? before = null, DateTime? after = null, string documentTitle = null, string modelId = null, string modelVersion = null, string categoryRemoved = null, string categoryAdded = null, string categoryNotChanged = null, string typeRemoved = null, string typeAdded = null, string typeNotChanged = null, long? pageLimit = null, string cursor = null, string sort = null, bool? includeTotal = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListFeedback`");
@@ -817,17 +779,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "ListFeedback"))
             {
@@ -964,11 +924,8 @@ namespace IBM.Watson.CompareComply.V1
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="BatchStatus" />BatchStatus</returns>
-        public bool CreateBatch(Callback<BatchStatus> callback, string function, System.IO.FileStream inputCredentialsFile, string inputBucketLocation, string inputBucketName, System.IO.FileStream outputCredentialsFile, string outputBucketLocation, string outputBucketName, Dictionary<string, object> customData = null, string modelId = null)
+        public bool CreateBatch(Callback<BatchStatus> callback, string function, System.IO.FileStream inputCredentialsFile, string inputBucketLocation, string inputBucketName, System.IO.FileStream outputCredentialsFile, string outputBucketLocation, string outputBucketName, string modelId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateBatch`");
@@ -991,17 +948,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "CreateBatch"))
             {
@@ -1085,11 +1040,8 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="batchId">The ID of the batch-processing request whose information you want to retrieve.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="BatchStatus" />BatchStatus</returns>
-        public bool GetBatch(Callback<BatchStatus> callback, string batchId, Dictionary<string, object> customData = null)
+        public bool GetBatch(Callback<BatchStatus> callback, string batchId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetBatch`");
@@ -1100,17 +1052,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "GetBatch"))
             {
@@ -1160,11 +1110,8 @@ namespace IBM.Watson.CompareComply.V1
         /// List the batch-processing jobs submitted by users.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Batches" />Batches</returns>
-        public bool ListBatches(Callback<Batches> callback, Dictionary<string, object> customData = null)
+        public bool ListBatches(Callback<Batches> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListBatches`");
@@ -1173,17 +1120,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "ListBatches"))
             {
@@ -1240,11 +1185,8 @@ namespace IBM.Watson.CompareComply.V1
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="BatchStatus" />BatchStatus</returns>
-        public bool UpdateBatch(Callback<BatchStatus> callback, string batchId, string action, Dictionary<string, object> customData = null, string modelId = null)
+        public bool UpdateBatch(Callback<BatchStatus> callback, string batchId, string action, string modelId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateBatch`");
@@ -1257,17 +1199,15 @@ namespace IBM.Watson.CompareComply.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("compare-comply", "V1", "UpdateBatch"))
             {

--- a/Scripts/Services/CompareComply/V1/CompareComplyService.cs
+++ b/Scripts/Services/CompareComply/V1/CompareComplyService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.CompareComply.V1
 {
-    public class CompareComplyService : BaseService
+    public partial class CompareComplyService : BaseService
     {
         private const string serviceId = "compare-comply";
         private const string defaultUrl = "https://gateway.watsonplatform.net/compare-comply/api";
@@ -195,7 +195,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnConvertToHtmlResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<HTMLReturn> response = new DetailedResponse<HTMLReturn>();
-            Dictionary<string, object> customData = ((RequestObject<HTMLReturn>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -206,14 +205,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<HTMLReturn>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -222,7 +214,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<HTMLReturn>)req).Callback != null)
-                ((RequestObject<HTMLReturn>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<HTMLReturn>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Classify the elements of a document.
@@ -293,7 +285,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnClassifyElementsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ClassifyReturn> response = new DetailedResponse<ClassifyReturn>();
-            Dictionary<string, object> customData = ((RequestObject<ClassifyReturn>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -304,14 +295,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ClassifyReturn>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -320,7 +304,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<ClassifyReturn>)req).Callback != null)
-                ((RequestObject<ClassifyReturn>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ClassifyReturn>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Extract a document's tables.
@@ -391,7 +375,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnExtractTablesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TableReturn> response = new DetailedResponse<TableReturn>();
-            Dictionary<string, object> customData = ((RequestObject<TableReturn>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -402,14 +385,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TableReturn>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -418,7 +394,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<TableReturn>)req).Callback != null)
-                ((RequestObject<TableReturn>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TableReturn>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Compare two documents.
@@ -507,7 +483,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnCompareDocumentsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<CompareReturn> response = new DetailedResponse<CompareReturn>();
-            Dictionary<string, object> customData = ((RequestObject<CompareReturn>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -518,14 +493,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<CompareReturn>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -534,7 +502,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<CompareReturn>)req).Callback != null)
-                ((RequestObject<CompareReturn>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<CompareReturn>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add feedback.
@@ -607,7 +575,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnAddFeedbackResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<FeedbackReturn> response = new DetailedResponse<FeedbackReturn>();
-            Dictionary<string, object> customData = ((RequestObject<FeedbackReturn>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -618,14 +585,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<FeedbackReturn>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -634,7 +594,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<FeedbackReturn>)req).Callback != null)
-                ((RequestObject<FeedbackReturn>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<FeedbackReturn>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Deletes a specified feedback entry.
@@ -697,7 +657,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnDeleteFeedbackResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<FeedbackDeleted> response = new DetailedResponse<FeedbackDeleted>();
-            Dictionary<string, object> customData = ((RequestObject<FeedbackDeleted>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -708,14 +667,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<FeedbackDeleted>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -724,7 +676,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<FeedbackDeleted>)req).Callback != null)
-                ((RequestObject<FeedbackDeleted>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<FeedbackDeleted>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List a specified feedback entry.
@@ -787,7 +739,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnGetFeedbackResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<GetFeedback> response = new DetailedResponse<GetFeedback>();
-            Dictionary<string, object> customData = ((RequestObject<GetFeedback>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -798,14 +749,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<GetFeedback>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -814,7 +758,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<GetFeedback>)req).Callback != null)
-                ((RequestObject<GetFeedback>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<GetFeedback>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List the feedback in documents.
@@ -970,7 +914,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnListFeedbackResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<FeedbackList> response = new DetailedResponse<FeedbackList>();
-            Dictionary<string, object> customData = ((RequestObject<FeedbackList>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -981,14 +924,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<FeedbackList>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -997,7 +933,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<FeedbackList>)req).Callback != null)
-                ((RequestObject<FeedbackList>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<FeedbackList>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Submit a batch-processing request.
@@ -1121,7 +1057,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnCreateBatchResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<BatchStatus> response = new DetailedResponse<BatchStatus>();
-            Dictionary<string, object> customData = ((RequestObject<BatchStatus>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1132,14 +1067,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<BatchStatus>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1148,7 +1076,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<BatchStatus>)req).Callback != null)
-                ((RequestObject<BatchStatus>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<BatchStatus>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get information about a specific batch-processing request.
@@ -1205,7 +1133,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnGetBatchResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<BatchStatus> response = new DetailedResponse<BatchStatus>();
-            Dictionary<string, object> customData = ((RequestObject<BatchStatus>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1216,14 +1143,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<BatchStatus>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1232,7 +1152,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<BatchStatus>)req).Callback != null)
-                ((RequestObject<BatchStatus>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<BatchStatus>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List submitted batch-processing jobs.
@@ -1286,7 +1206,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnListBatchesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Batches> response = new DetailedResponse<Batches>();
-            Dictionary<string, object> customData = ((RequestObject<Batches>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1297,14 +1216,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Batches>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1313,7 +1225,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<Batches>)req).Callback != null)
-                ((RequestObject<Batches>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Batches>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update a pending or active batch-processing request.
@@ -1386,7 +1298,6 @@ namespace IBM.Watson.CompareComply.V1
         private void OnUpdateBatchResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<BatchStatus> response = new DetailedResponse<BatchStatus>();
-            Dictionary<string, object> customData = ((RequestObject<BatchStatus>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1397,14 +1308,7 @@ namespace IBM.Watson.CompareComply.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<BatchStatus>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1413,7 +1317,7 @@ namespace IBM.Watson.CompareComply.V1
             }
 
             if (((RequestObject<BatchStatus>)req).Callback != null)
-                ((RequestObject<BatchStatus>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<BatchStatus>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/Discovery/V1/DiscoveryService.cs
+++ b/Scripts/Services/Discovery/V1/DiscoveryService.cs
@@ -140,11 +140,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="description">Description of the environment. (optional)</param>
         /// <param name="size">Size of the environment. In the Lite plan the default and only accepted value is `LT`, in
         /// all other plans the default is `S`. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ModelEnvironment" />ModelEnvironment</returns>
-        public bool CreateEnvironment(Callback<ModelEnvironment> callback, string name, Dictionary<string, object> customData = null, string description = null, string size = null)
+        public bool CreateEnvironment(Callback<ModelEnvironment> callback, string name, string description = null, string size = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateEnvironment`");
@@ -155,17 +152,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateEnvironment"))
             {
@@ -225,11 +220,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DeleteEnvironmentResponse" />DeleteEnvironmentResponse</returns>
-        public bool DeleteEnvironment(Callback<DeleteEnvironmentResponse> callback, string environmentId, Dictionary<string, object> customData = null)
+        public bool DeleteEnvironment(Callback<DeleteEnvironmentResponse> callback, string environmentId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteEnvironment`");
@@ -240,17 +232,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteEnvironment"))
             {
@@ -299,11 +289,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ModelEnvironment" />ModelEnvironment</returns>
-        public bool GetEnvironment(Callback<ModelEnvironment> callback, string environmentId, Dictionary<string, object> customData = null)
+        public bool GetEnvironment(Callback<ModelEnvironment> callback, string environmentId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetEnvironment`");
@@ -314,17 +301,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetEnvironment"))
             {
@@ -375,11 +360,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="name">Show only the environment with the given name. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ListEnvironmentsResponse" />ListEnvironmentsResponse</returns>
-        public bool ListEnvironments(Callback<ListEnvironmentsResponse> callback, Dictionary<string, object> customData = null, string name = null)
+        public bool ListEnvironments(Callback<ListEnvironmentsResponse> callback, string name = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListEnvironments`");
@@ -388,17 +370,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListEnvironments"))
             {
@@ -454,11 +434,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionIds">A comma-separated list of collection IDs to be queried against.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ListCollectionFieldsResponse" />ListCollectionFieldsResponse</returns>
-        public bool ListFields(Callback<ListCollectionFieldsResponse> callback, string environmentId, List<string> collectionIds, Dictionary<string, object> customData = null)
+        public bool ListFields(Callback<ListCollectionFieldsResponse> callback, string environmentId, List<string> collectionIds)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListFields`");
@@ -471,17 +448,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListFields"))
             {
@@ -541,11 +516,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="description">Description of the environment. (optional)</param>
         /// <param name="size">Size that the environment should be increased to. Environment size cannot be modified
         /// when using a Lite plan. Environment size can only increased and not decreased. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ModelEnvironment" />ModelEnvironment</returns>
-        public bool UpdateEnvironment(Callback<ModelEnvironment> callback, string environmentId, Dictionary<string, object> customData = null, string name = null, string description = null, string size = null)
+        public bool UpdateEnvironment(Callback<ModelEnvironment> callback, string environmentId, string name = null, string description = null, string size = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateEnvironment`");
@@ -556,17 +528,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "UpdateEnvironment"))
             {
@@ -643,11 +613,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="normalizations">Defines operations that can be used to transform the final output JSON into a
         /// normalized form. Operations are executed in the order that they appear in the array. (optional)</param>
         /// <param name="source">Object containing source parameters for the configuration. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Configuration" />Configuration</returns>
-        public bool CreateConfiguration(Callback<Configuration> callback, string environmentId, string name, Dictionary<string, object> customData = null, string description = null, Conversions conversions = null, List<Enrichment> enrichments = null, List<NormalizationOperation> normalizations = null, Source source = null)
+        public bool CreateConfiguration(Callback<Configuration> callback, string environmentId, string name, string description = null, Conversions conversions = null, List<Enrichment> enrichments = null, List<NormalizationOperation> normalizations = null, Source source = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateConfiguration`");
@@ -660,17 +627,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateConfiguration"))
             {
@@ -742,11 +707,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="configurationId">The ID of the configuration.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DeleteConfigurationResponse" />DeleteConfigurationResponse</returns>
-        public bool DeleteConfiguration(Callback<DeleteConfigurationResponse> callback, string environmentId, string configurationId, Dictionary<string, object> customData = null)
+        public bool DeleteConfiguration(Callback<DeleteConfigurationResponse> callback, string environmentId, string configurationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteConfiguration`");
@@ -759,17 +721,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteConfiguration"))
             {
@@ -819,11 +779,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="configurationId">The ID of the configuration.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Configuration" />Configuration</returns>
-        public bool GetConfiguration(Callback<Configuration> callback, string environmentId, string configurationId, Dictionary<string, object> customData = null)
+        public bool GetConfiguration(Callback<Configuration> callback, string environmentId, string configurationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetConfiguration`");
@@ -836,17 +793,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetConfiguration"))
             {
@@ -898,11 +853,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="name">Find configurations with the given name. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ListConfigurationsResponse" />ListConfigurationsResponse</returns>
-        public bool ListConfigurations(Callback<ListConfigurationsResponse> callback, string environmentId, Dictionary<string, object> customData = null, string name = null)
+        public bool ListConfigurations(Callback<ListConfigurationsResponse> callback, string environmentId, string name = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListConfigurations`");
@@ -913,17 +865,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListConfigurations"))
             {
@@ -993,11 +943,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="normalizations">Defines operations that can be used to transform the final output JSON into a
         /// normalized form. Operations are executed in the order that they appear in the array. (optional)</param>
         /// <param name="source">Object containing source parameters for the configuration. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Configuration" />Configuration</returns>
-        public bool UpdateConfiguration(Callback<Configuration> callback, string environmentId, string configurationId, string name, Dictionary<string, object> customData = null, string description = null, Conversions conversions = null, List<Enrichment> enrichments = null, List<NormalizationOperation> normalizations = null, Source source = null)
+        public bool UpdateConfiguration(Callback<Configuration> callback, string environmentId, string configurationId, string name, string description = null, Conversions conversions = null, List<Enrichment> enrichments = null, List<NormalizationOperation> normalizations = null, Source source = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateConfiguration`");
@@ -1012,17 +959,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "UpdateConfiguration"))
             {
@@ -1112,11 +1057,8 @@ namespace IBM.Watson.Discovery.V1
         /// **configuration** form part is also provided (both are present at the same time), then the request will be
         /// rejected. (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TestDocument" />TestDocument</returns>
-        public bool TestConfigurationInEnvironment(Callback<TestDocument> callback, string environmentId, Dictionary<string, object> customData = null, string configuration = null, System.IO.FileStream file = null, string metadata = null, string step = null, string configurationId = null, string fileContentType = null)
+        public bool TestConfigurationInEnvironment(Callback<TestDocument> callback, string environmentId, string configuration = null, System.IO.FileStream file = null, string metadata = null, string step = null, string configurationId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `TestConfigurationInEnvironment`");
@@ -1127,17 +1069,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "TestConfigurationInEnvironment"))
             {
@@ -1213,11 +1153,8 @@ namespace IBM.Watson.Discovery.V1
         /// (optional)</param>
         /// <param name="language">The language of the documents stored in the collection, in the form of an ISO 639-1
         /// language code. (optional, default to en)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Collection" />Collection</returns>
-        public bool CreateCollection(Callback<Collection> callback, string environmentId, string name, Dictionary<string, object> customData = null, string description = null, string configurationId = null, string language = null)
+        public bool CreateCollection(Callback<Collection> callback, string environmentId, string name, string description = null, string configurationId = null, string language = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateCollection`");
@@ -1230,17 +1167,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateCollection"))
             {
@@ -1303,11 +1238,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DeleteCollectionResponse" />DeleteCollectionResponse</returns>
-        public bool DeleteCollection(Callback<DeleteCollectionResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool DeleteCollection(Callback<DeleteCollectionResponse> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteCollection`");
@@ -1320,17 +1252,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteCollection"))
             {
@@ -1380,11 +1310,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Collection" />Collection</returns>
-        public bool GetCollection(Callback<Collection> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool GetCollection(Callback<Collection> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetCollection`");
@@ -1397,17 +1324,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetCollection"))
             {
@@ -1459,11 +1384,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ListCollectionFieldsResponse" />ListCollectionFieldsResponse</returns>
-        public bool ListCollectionFields(Callback<ListCollectionFieldsResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool ListCollectionFields(Callback<ListCollectionFieldsResponse> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListCollectionFields`");
@@ -1476,17 +1398,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListCollectionFields"))
             {
@@ -1538,11 +1458,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="name">Find collections with the given name. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ListCollectionsResponse" />ListCollectionsResponse</returns>
-        public bool ListCollections(Callback<ListCollectionsResponse> callback, string environmentId, Dictionary<string, object> customData = null, string name = null)
+        public bool ListCollections(Callback<ListCollectionsResponse> callback, string environmentId, string name = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListCollections`");
@@ -1553,17 +1470,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListCollections"))
             {
@@ -1621,11 +1536,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="description">A description of the collection. (optional)</param>
         /// <param name="configurationId">The ID of the configuration in which the collection is to be updated.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Collection" />Collection</returns>
-        public bool UpdateCollection(Callback<Collection> callback, string environmentId, string collectionId, string name, Dictionary<string, object> customData = null, string description = null, string configurationId = null)
+        public bool UpdateCollection(Callback<Collection> callback, string environmentId, string collectionId, string name, string description = null, string configurationId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateCollection`");
@@ -1638,17 +1550,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "UpdateCollection"))
             {
@@ -1726,11 +1636,8 @@ namespace IBM.Watson.Discovery.V1
         ///  To create a uni-directional expansion, specify both an array of **input_terms** and an array of
         /// **expanded_terms**. When items in the **input_terms** array are present in a query, they are expanded using
         /// the items listed in the **expanded_terms** array.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Expansions" />Expansions</returns>
-        public bool CreateExpansions(Callback<Expansions> callback, string environmentId, string collectionId, List<Expansion> expansions, Dictionary<string, object> customData = null)
+        public bool CreateExpansions(Callback<Expansions> callback, string environmentId, string collectionId, List<Expansion> expansions)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateExpansions`");
@@ -1745,17 +1652,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateExpansions"))
             {
@@ -1815,11 +1720,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="stopwordFile">The content of the stopword list to ingest.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TokenDictStatusResponse" />TokenDictStatusResponse</returns>
-        public bool CreateStopwordList(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, System.IO.FileStream stopwordFile, Dictionary<string, object> customData = null)
+        public bool CreateStopwordList(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, System.IO.FileStream stopwordFile)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateStopwordList`");
@@ -1834,17 +1736,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateStopwordList"))
             {
@@ -1904,11 +1804,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="tokenizationRules">An array of tokenization rules. Each rule contains, the original `text`
         /// string, component `tokens`, any alternate character set `readings`, and which `part_of_speech` the text is
         /// from. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TokenDictStatusResponse" />TokenDictStatusResponse</returns>
-        public bool CreateTokenizationDictionary(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null, List<TokenDictRule> tokenizationRules = null)
+        public bool CreateTokenizationDictionary(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, List<TokenDictRule> tokenizationRules = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateTokenizationDictionary`");
@@ -1921,17 +1818,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateTokenizationDictionary"))
             {
@@ -1991,11 +1886,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteExpansions(Callback<object> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool DeleteExpansions(Callback<object> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteExpansions`");
@@ -2008,17 +1900,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteExpansions"))
             {
@@ -2071,11 +1961,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteStopwordList(Callback<object> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool DeleteStopwordList(Callback<object> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteStopwordList`");
@@ -2088,17 +1975,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteStopwordList"))
             {
@@ -2150,11 +2035,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteTokenizationDictionary(Callback<object> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool DeleteTokenizationDictionary(Callback<object> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteTokenizationDictionary`");
@@ -2167,17 +2049,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteTokenizationDictionary"))
             {
@@ -2229,11 +2109,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TokenDictStatusResponse" />TokenDictStatusResponse</returns>
-        public bool GetStopwordListStatus(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool GetStopwordListStatus(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetStopwordListStatus`");
@@ -2246,17 +2123,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetStopwordListStatus"))
             {
@@ -2308,11 +2183,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TokenDictStatusResponse" />TokenDictStatusResponse</returns>
-        public bool GetTokenizationDictionaryStatus(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool GetTokenizationDictionaryStatus(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetTokenizationDictionaryStatus`");
@@ -2325,17 +2197,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetTokenizationDictionaryStatus"))
             {
@@ -2388,11 +2258,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Expansions" />Expansions</returns>
-        public bool ListExpansions(Callback<Expansions> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool ListExpansions(Callback<Expansions> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListExpansions`");
@@ -2405,17 +2272,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListExpansions"))
             {
@@ -2496,11 +2361,8 @@ namespace IBM.Watson.Discovery.V1
         ///   "Subject": "Apples"
         /// } ```. (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DocumentAccepted" />DocumentAccepted</returns>
-        public bool AddDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null, System.IO.FileStream file = null, string metadata = null, string fileContentType = null)
+        public bool AddDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, System.IO.FileStream file = null, string metadata = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddDocument`");
@@ -2513,17 +2375,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "AddDocument"))
             {
@@ -2586,11 +2446,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="documentId">The ID of the document.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DeleteDocumentResponse" />DeleteDocumentResponse</returns>
-        public bool DeleteDocument(Callback<DeleteDocumentResponse> callback, string environmentId, string collectionId, string documentId, Dictionary<string, object> customData = null)
+        public bool DeleteDocument(Callback<DeleteDocumentResponse> callback, string environmentId, string collectionId, string documentId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteDocument`");
@@ -2605,17 +2462,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteDocument"))
             {
@@ -2670,11 +2525,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="documentId">The ID of the document.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DocumentStatus" />DocumentStatus</returns>
-        public bool GetDocumentStatus(Callback<DocumentStatus> callback, string environmentId, string collectionId, string documentId, Dictionary<string, object> customData = null)
+        public bool GetDocumentStatus(Callback<DocumentStatus> callback, string environmentId, string collectionId, string documentId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetDocumentStatus`");
@@ -2689,17 +2541,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetDocumentStatus"))
             {
@@ -2762,11 +2612,8 @@ namespace IBM.Watson.Discovery.V1
         ///   "Subject": "Apples"
         /// } ```. (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DocumentAccepted" />DocumentAccepted</returns>
-        public bool UpdateDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, string documentId, Dictionary<string, object> customData = null, System.IO.FileStream file = null, string metadata = null, string fileContentType = null)
+        public bool UpdateDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, string documentId, System.IO.FileStream file = null, string metadata = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateDocument`");
@@ -2781,17 +2628,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "UpdateDocument"))
             {
@@ -2913,11 +2758,8 @@ namespace IBM.Watson.Discovery.V1
         /// parameter. (optional)</param>
         /// <param name="loggingOptOut">If `true`, queries are not stored in the Discovery **Logs** endpoint. (optional,
         /// default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="QueryResponse" />QueryResponse</returns>
-        public bool FederatedQuery(Callback<QueryResponse> callback, string environmentId, Dictionary<string, object> customData = null, string filter = null, string query = null, string naturalLanguageQuery = null, bool? passages = null, string aggregation = null, long? count = null, string returnFields = null, long? offset = null, string sort = null, bool? highlight = null, string passagesFields = null, long? passagesCount = null, long? passagesCharacters = null, bool? deduplicate = null, string deduplicateField = null, string collectionIds = null, bool? similar = null, string similarDocumentIds = null, string similarFields = null, string bias = null, bool? loggingOptOut = null)
+        public bool FederatedQuery(Callback<QueryResponse> callback, string environmentId, string filter = null, string query = null, string naturalLanguageQuery = null, bool? passages = null, string aggregation = null, long? count = null, string returnFields = null, long? offset = null, string sort = null, bool? highlight = null, string passagesFields = null, long? passagesCount = null, long? passagesCharacters = null, bool? deduplicate = null, string deduplicateField = null, string collectionIds = null, bool? similar = null, string similarDocumentIds = null, string similarFields = null, string bias = null, bool? loggingOptOut = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `FederatedQuery`");
@@ -2928,17 +2770,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "FederatedQuery"))
             {
@@ -3079,11 +2919,8 @@ namespace IBM.Watson.Discovery.V1
         /// subsequently applied and reduce the scope. (optional)</param>
         /// <param name="similarFields">A comma-separated list of field names that are used as a basis for comparison to
         /// identify similar documents. If not specified, the entire document is used for comparison. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="QueryNoticesResponse" />QueryNoticesResponse</returns>
-        public bool FederatedQueryNotices(Callback<QueryNoticesResponse> callback, string environmentId, List<string> collectionIds, Dictionary<string, object> customData = null, string filter = null, string query = null, string naturalLanguageQuery = null, string aggregation = null, long? count = null, List<string> returnFields = null, long? offset = null, List<string> sort = null, bool? highlight = null, string deduplicateField = null, bool? similar = null, List<string> similarDocumentIds = null, List<string> similarFields = null)
+        public bool FederatedQueryNotices(Callback<QueryNoticesResponse> callback, string environmentId, List<string> collectionIds, string filter = null, string query = null, string naturalLanguageQuery = null, string aggregation = null, long? count = null, List<string> returnFields = null, long? offset = null, List<string> sort = null, bool? highlight = null, string deduplicateField = null, bool? similar = null, List<string> similarDocumentIds = null, List<string> similarFields = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `FederatedQueryNotices`");
@@ -3096,17 +2933,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "FederatedQueryNotices"))
             {
@@ -3276,11 +3111,8 @@ namespace IBM.Watson.Discovery.V1
         /// parameter. (optional)</param>
         /// <param name="loggingOptOut">If `true`, queries are not stored in the Discovery **Logs** endpoint. (optional,
         /// default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="QueryResponse" />QueryResponse</returns>
-        public bool Query(Callback<QueryResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null, string filter = null, string query = null, string naturalLanguageQuery = null, bool? passages = null, string aggregation = null, long? count = null, string returnFields = null, long? offset = null, string sort = null, bool? highlight = null, string passagesFields = null, long? passagesCount = null, long? passagesCharacters = null, bool? deduplicate = null, string deduplicateField = null, string collectionIds = null, bool? similar = null, string similarDocumentIds = null, string similarFields = null, string bias = null, bool? loggingOptOut = null)
+        public bool Query(Callback<QueryResponse> callback, string environmentId, string collectionId, string filter = null, string query = null, string naturalLanguageQuery = null, bool? passages = null, string aggregation = null, long? count = null, string returnFields = null, long? offset = null, string sort = null, bool? highlight = null, string passagesFields = null, long? passagesCount = null, long? passagesCharacters = null, bool? deduplicate = null, string deduplicateField = null, string collectionIds = null, bool? similar = null, string similarDocumentIds = null, string similarFields = null, string bias = null, bool? loggingOptOut = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Query`");
@@ -3293,17 +3125,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "Query"))
             {
@@ -3416,11 +3246,8 @@ namespace IBM.Watson.Discovery.V1
         /// (optional)</param>
         /// <param name="evidenceCount">The number of evidence items to return for each result. The default is `0`. The
         /// maximum number of evidence items per query is 10,000. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="QueryEntitiesResponse" />QueryEntitiesResponse</returns>
-        public bool QueryEntities(Callback<QueryEntitiesResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null, string feature = null, QueryEntitiesEntity entity = null, QueryEntitiesContext context = null, long? count = null, long? evidenceCount = null)
+        public bool QueryEntities(Callback<QueryEntitiesResponse> callback, string environmentId, string collectionId, string feature = null, QueryEntitiesEntity entity = null, QueryEntitiesContext context = null, long? count = null, long? evidenceCount = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `QueryEntities`");
@@ -3433,17 +3260,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "QueryEntities"))
             {
@@ -3557,11 +3382,8 @@ namespace IBM.Watson.Discovery.V1
         /// subsequently applied and reduce the scope. (optional)</param>
         /// <param name="similarFields">A comma-separated list of field names that are used as a basis for comparison to
         /// identify similar documents. If not specified, the entire document is used for comparison. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="QueryNoticesResponse" />QueryNoticesResponse</returns>
-        public bool QueryNotices(Callback<QueryNoticesResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null, string filter = null, string query = null, string naturalLanguageQuery = null, bool? passages = null, string aggregation = null, long? count = null, List<string> returnFields = null, long? offset = null, List<string> sort = null, bool? highlight = null, List<string> passagesFields = null, long? passagesCount = null, long? passagesCharacters = null, string deduplicateField = null, bool? similar = null, List<string> similarDocumentIds = null, List<string> similarFields = null)
+        public bool QueryNotices(Callback<QueryNoticesResponse> callback, string environmentId, string collectionId, string filter = null, string query = null, string naturalLanguageQuery = null, bool? passages = null, string aggregation = null, long? count = null, List<string> returnFields = null, long? offset = null, List<string> sort = null, bool? highlight = null, List<string> passagesFields = null, long? passagesCount = null, long? passagesCharacters = null, string deduplicateField = null, bool? similar = null, List<string> similarDocumentIds = null, List<string> similarFields = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `QueryNotices`");
@@ -3574,17 +3396,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "QueryNotices"))
             {
@@ -3717,11 +3537,8 @@ namespace IBM.Watson.Discovery.V1
         /// (optional)</param>
         /// <param name="evidenceCount">The number of evidence items to return for each result. The default is `0`. The
         /// maximum number of evidence items per query is 10,000. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="QueryRelationsResponse" />QueryRelationsResponse</returns>
-        public bool QueryRelations(Callback<QueryRelationsResponse> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null, List<QueryRelationsEntity> entities = null, QueryEntitiesContext context = null, string sort = null, QueryRelationsFilter filter = null, long? count = null, long? evidenceCount = null)
+        public bool QueryRelations(Callback<QueryRelationsResponse> callback, string environmentId, string collectionId, List<QueryRelationsEntity> entities = null, QueryEntitiesContext context = null, string sort = null, QueryRelationsFilter filter = null, long? count = null, long? evidenceCount = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `QueryRelations`");
@@ -3734,17 +3551,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "QueryRelations"))
             {
@@ -3818,11 +3633,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="filter">The filter used on the collection before the **natural_language_query** is applied.
         /// (optional)</param>
         /// <param name="examples">Array of training examples. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TrainingQuery" />TrainingQuery</returns>
-        public bool AddTrainingData(Callback<TrainingQuery> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null, string naturalLanguageQuery = null, string filter = null, List<TrainingExample> examples = null)
+        public bool AddTrainingData(Callback<TrainingQuery> callback, string environmentId, string collectionId, string naturalLanguageQuery = null, string filter = null, List<TrainingExample> examples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddTrainingData`");
@@ -3835,17 +3647,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "AddTrainingData"))
             {
@@ -3912,11 +3722,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="documentId">The document ID associated with this training example. (optional)</param>
         /// <param name="crossReference">The cross reference associated with this training example. (optional)</param>
         /// <param name="relevance">The relevance of the training example. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TrainingExample" />TrainingExample</returns>
-        public bool CreateTrainingExample(Callback<TrainingExample> callback, string environmentId, string collectionId, string queryId, Dictionary<string, object> customData = null, string documentId = null, string crossReference = null, long? relevance = null)
+        public bool CreateTrainingExample(Callback<TrainingExample> callback, string environmentId, string collectionId, string queryId, string documentId = null, string crossReference = null, long? relevance = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateTrainingExample`");
@@ -3931,17 +3738,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateTrainingExample"))
             {
@@ -4004,11 +3809,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteAllTrainingData(Callback<object> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool DeleteAllTrainingData(Callback<object> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteAllTrainingData`");
@@ -4021,17 +3823,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteAllTrainingData"))
             {
@@ -4084,11 +3884,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="queryId">The ID of the query used for training.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteTrainingData(Callback<object> callback, string environmentId, string collectionId, string queryId, Dictionary<string, object> customData = null)
+        public bool DeleteTrainingData(Callback<object> callback, string environmentId, string collectionId, string queryId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteTrainingData`");
@@ -4103,17 +3900,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteTrainingData"))
             {
@@ -4167,11 +3962,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="queryId">The ID of the query used for training.</param>
         /// <param name="exampleId">The ID of the document as it is indexed.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteTrainingExample(Callback<object> callback, string environmentId, string collectionId, string queryId, string exampleId, Dictionary<string, object> customData = null)
+        public bool DeleteTrainingExample(Callback<object> callback, string environmentId, string collectionId, string queryId, string exampleId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteTrainingExample`");
@@ -4188,17 +3980,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteTrainingExample"))
             {
@@ -4251,11 +4041,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="queryId">The ID of the query used for training.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TrainingQuery" />TrainingQuery</returns>
-        public bool GetTrainingData(Callback<TrainingQuery> callback, string environmentId, string collectionId, string queryId, Dictionary<string, object> customData = null)
+        public bool GetTrainingData(Callback<TrainingQuery> callback, string environmentId, string collectionId, string queryId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetTrainingData`");
@@ -4270,17 +4057,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetTrainingData"))
             {
@@ -4334,11 +4119,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="queryId">The ID of the query used for training.</param>
         /// <param name="exampleId">The ID of the document as it is indexed.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TrainingExample" />TrainingExample</returns>
-        public bool GetTrainingExample(Callback<TrainingExample> callback, string environmentId, string collectionId, string queryId, string exampleId, Dictionary<string, object> customData = null)
+        public bool GetTrainingExample(Callback<TrainingExample> callback, string environmentId, string collectionId, string queryId, string exampleId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetTrainingExample`");
@@ -4355,17 +4137,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetTrainingExample"))
             {
@@ -4417,11 +4197,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TrainingDataSet" />TrainingDataSet</returns>
-        public bool ListTrainingData(Callback<TrainingDataSet> callback, string environmentId, string collectionId, Dictionary<string, object> customData = null)
+        public bool ListTrainingData(Callback<TrainingDataSet> callback, string environmentId, string collectionId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListTrainingData`");
@@ -4434,17 +4211,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListTrainingData"))
             {
@@ -4497,11 +4272,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="queryId">The ID of the query used for training.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TrainingExampleList" />TrainingExampleList</returns>
-        public bool ListTrainingExamples(Callback<TrainingExampleList> callback, string environmentId, string collectionId, string queryId, Dictionary<string, object> customData = null)
+        public bool ListTrainingExamples(Callback<TrainingExampleList> callback, string environmentId, string collectionId, string queryId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListTrainingExamples`");
@@ -4516,17 +4288,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListTrainingExamples"))
             {
@@ -4582,11 +4352,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="exampleId">The ID of the document as it is indexed.</param>
         /// <param name="crossReference">The example to add. (optional)</param>
         /// <param name="relevance">The relevance value for this example. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TrainingExample" />TrainingExample</returns>
-        public bool UpdateTrainingExample(Callback<TrainingExample> callback, string environmentId, string collectionId, string queryId, string exampleId, Dictionary<string, object> customData = null, string crossReference = null, long? relevance = null)
+        public bool UpdateTrainingExample(Callback<TrainingExample> callback, string environmentId, string collectionId, string queryId, string exampleId, string crossReference = null, long? relevance = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateTrainingExample`");
@@ -4603,17 +4370,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "UpdateTrainingExample"))
             {
@@ -4678,11 +4443,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customerId">The customer ID for which all data is to be deleted.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteUserData(Callback<object> callback, string customerId, Dictionary<string, object> customData = null)
+        public bool DeleteUserData(Callback<object> callback, string customerId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteUserData`");
@@ -4693,17 +4455,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteUserData"))
             {
@@ -4760,11 +4520,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="type">The event type to be created.</param>
         /// <param name="data">Query event data object.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="CreateEventResponse" />CreateEventResponse</returns>
-        public bool CreateEvent(Callback<CreateEventResponse> callback, string type, EventData data, Dictionary<string, object> customData = null)
+        public bool CreateEvent(Callback<CreateEventResponse> callback, string type, EventData data)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateEvent`");
@@ -4777,17 +4534,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateEvent"))
             {
@@ -4853,11 +4608,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="endTime">Metric is computed from data recorded before this timestamp; must be in
         /// `YYYY-MM-DDThh:mm:ssZ` format. (optional)</param>
         /// <param name="resultType">The type of result to consider when calculating the metric. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="MetricResponse" />MetricResponse</returns>
-        public bool GetMetricsEventRate(Callback<MetricResponse> callback, Dictionary<string, object> customData = null, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
+        public bool GetMetricsEventRate(Callback<MetricResponse> callback, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetMetricsEventRate`");
@@ -4866,17 +4618,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetMetricsEventRate"))
             {
@@ -4943,11 +4693,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="endTime">Metric is computed from data recorded before this timestamp; must be in
         /// `YYYY-MM-DDThh:mm:ssZ` format. (optional)</param>
         /// <param name="resultType">The type of result to consider when calculating the metric. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="MetricResponse" />MetricResponse</returns>
-        public bool GetMetricsQuery(Callback<MetricResponse> callback, Dictionary<string, object> customData = null, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
+        public bool GetMetricsQuery(Callback<MetricResponse> callback, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetMetricsQuery`");
@@ -4956,17 +4703,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetMetricsQuery"))
             {
@@ -5035,11 +4780,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="endTime">Metric is computed from data recorded before this timestamp; must be in
         /// `YYYY-MM-DDThh:mm:ssZ` format. (optional)</param>
         /// <param name="resultType">The type of result to consider when calculating the metric. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="MetricResponse" />MetricResponse</returns>
-        public bool GetMetricsQueryEvent(Callback<MetricResponse> callback, Dictionary<string, object> customData = null, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
+        public bool GetMetricsQueryEvent(Callback<MetricResponse> callback, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetMetricsQueryEvent`");
@@ -5048,17 +4790,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetMetricsQueryEvent"))
             {
@@ -5126,11 +4866,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="endTime">Metric is computed from data recorded before this timestamp; must be in
         /// `YYYY-MM-DDThh:mm:ssZ` format. (optional)</param>
         /// <param name="resultType">The type of result to consider when calculating the metric. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="MetricResponse" />MetricResponse</returns>
-        public bool GetMetricsQueryNoResults(Callback<MetricResponse> callback, Dictionary<string, object> customData = null, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
+        public bool GetMetricsQueryNoResults(Callback<MetricResponse> callback, DateTime? startTime = null, DateTime? endTime = null, string resultType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetMetricsQueryNoResults`");
@@ -5139,17 +4876,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetMetricsQueryNoResults"))
             {
@@ -5214,11 +4949,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="count">Number of results to return. (optional, default to 10)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="MetricTokenResponse" />MetricTokenResponse</returns>
-        public bool GetMetricsQueryTokenEvent(Callback<MetricTokenResponse> callback, Dictionary<string, object> customData = null, long? count = null)
+        public bool GetMetricsQueryTokenEvent(Callback<MetricTokenResponse> callback, long? count = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetMetricsQueryTokenEvent`");
@@ -5227,17 +4959,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetMetricsQueryTokenEvent"))
             {
@@ -5305,11 +5035,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="sort">A comma-separated list of fields in the document to sort on. You can optionally specify a
         /// sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default
         /// sort direction if no prefix is specified. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="LogQueryResponse" />LogQueryResponse</returns>
-        public bool QueryLog(Callback<LogQueryResponse> callback, Dictionary<string, object> customData = null, string filter = null, string query = null, long? count = null, long? offset = null, List<string> sort = null)
+        public bool QueryLog(Callback<LogQueryResponse> callback, string filter = null, string query = null, long? count = null, long? offset = null, List<string> sort = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `QueryLog`");
@@ -5318,17 +5045,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "QueryLog"))
             {
@@ -5412,11 +5137,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="credentialDetails">Object containing details of the stored credentials.
         ///
         /// Obtain credentials for your source from the administrator of the source. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ModelCredentials" />ModelCredentials</returns>
-        public bool CreateCredentials(Callback<ModelCredentials> callback, string environmentId, Dictionary<string, object> customData = null, string sourceType = null, CredentialDetails credentialDetails = null)
+        public bool CreateCredentials(Callback<ModelCredentials> callback, string environmentId, string sourceType = null, CredentialDetails credentialDetails = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateCredentials`");
@@ -5427,17 +5149,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateCredentials"))
             {
@@ -5498,11 +5218,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="credentialId">The unique identifier for a set of source credentials.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DeleteCredentials" />DeleteCredentials</returns>
-        public bool DeleteCredentials(Callback<DeleteCredentials> callback, string environmentId, string credentialId, Dictionary<string, object> customData = null)
+        public bool DeleteCredentials(Callback<DeleteCredentials> callback, string environmentId, string credentialId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteCredentials`");
@@ -5515,17 +5232,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteCredentials"))
             {
@@ -5580,11 +5295,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="credentialId">The unique identifier for a set of source credentials.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ModelCredentials" />ModelCredentials</returns>
-        public bool GetCredentials(Callback<ModelCredentials> callback, string environmentId, string credentialId, Dictionary<string, object> customData = null)
+        public bool GetCredentials(Callback<ModelCredentials> callback, string environmentId, string credentialId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetCredentials`");
@@ -5597,17 +5309,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetCredentials"))
             {
@@ -5660,11 +5370,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="CredentialsList" />CredentialsList</returns>
-        public bool ListCredentials(Callback<CredentialsList> callback, string environmentId, Dictionary<string, object> customData = null)
+        public bool ListCredentials(Callback<CredentialsList> callback, string environmentId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListCredentials`");
@@ -5675,17 +5382,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListCredentials"))
             {
@@ -5749,11 +5454,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="credentialDetails">Object containing details of the stored credentials.
         ///
         /// Obtain credentials for your source from the administrator of the source. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ModelCredentials" />ModelCredentials</returns>
-        public bool UpdateCredentials(Callback<ModelCredentials> callback, string environmentId, string credentialId, Dictionary<string, object> customData = null, string sourceType = null, CredentialDetails credentialDetails = null)
+        public bool UpdateCredentials(Callback<ModelCredentials> callback, string environmentId, string credentialId, string sourceType = null, CredentialDetails credentialDetails = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateCredentials`");
@@ -5766,17 +5468,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "UpdateCredentials"))
             {
@@ -5837,11 +5537,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="name">User-defined name. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Gateway" />Gateway</returns>
-        public bool CreateGateway(Callback<Gateway> callback, string environmentId, Dictionary<string, object> customData = null, string name = null)
+        public bool CreateGateway(Callback<Gateway> callback, string environmentId, string name = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateGateway`");
@@ -5852,17 +5549,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "CreateGateway"))
             {
@@ -5921,11 +5616,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="gatewayId">The requested gateway ID.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="GatewayDelete" />GatewayDelete</returns>
-        public bool DeleteGateway(Callback<GatewayDelete> callback, string environmentId, string gatewayId, Dictionary<string, object> customData = null)
+        public bool DeleteGateway(Callback<GatewayDelete> callback, string environmentId, string gatewayId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteGateway`");
@@ -5938,17 +5630,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "DeleteGateway"))
             {
@@ -6000,11 +5690,8 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="gatewayId">The requested gateway ID.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Gateway" />Gateway</returns>
-        public bool GetGateway(Callback<Gateway> callback, string environmentId, string gatewayId, Dictionary<string, object> customData = null)
+        public bool GetGateway(Callback<Gateway> callback, string environmentId, string gatewayId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetGateway`");
@@ -6017,17 +5704,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "GetGateway"))
             {
@@ -6078,11 +5763,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="GatewayList" />GatewayList</returns>
-        public bool ListGateways(Callback<GatewayList> callback, string environmentId, Dictionary<string, object> customData = null)
+        public bool ListGateways(Callback<GatewayList> callback, string environmentId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListGateways`");
@@ -6093,17 +5775,15 @@ namespace IBM.Watson.Discovery.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("discovery", "V1", "ListGateways"))
             {

--- a/Scripts/Services/Discovery/V1/DiscoveryService.cs
+++ b/Scripts/Services/Discovery/V1/DiscoveryService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.Discovery.V1
 {
-    public class DiscoveryService : BaseService
+    public partial class DiscoveryService : BaseService
     {
         private const string serviceId = "discovery";
         private const string defaultUrl = "https://gateway.watsonplatform.net/discovery/api";
@@ -199,7 +199,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateEnvironmentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ModelEnvironment> response = new DetailedResponse<ModelEnvironment>();
-            Dictionary<string, object> customData = ((RequestObject<ModelEnvironment>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -210,14 +209,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ModelEnvironment>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -226,7 +218,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ModelEnvironment>)req).Callback != null)
-                ((RequestObject<ModelEnvironment>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ModelEnvironment>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete environment.
@@ -281,7 +273,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteEnvironmentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DeleteEnvironmentResponse> response = new DetailedResponse<DeleteEnvironmentResponse>();
-            Dictionary<string, object> customData = ((RequestObject<DeleteEnvironmentResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -292,14 +283,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DeleteEnvironmentResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -308,7 +292,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DeleteEnvironmentResponse>)req).Callback != null)
-                ((RequestObject<DeleteEnvironmentResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DeleteEnvironmentResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get environment info.
@@ -363,7 +347,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetEnvironmentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ModelEnvironment> response = new DetailedResponse<ModelEnvironment>();
-            Dictionary<string, object> customData = ((RequestObject<ModelEnvironment>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -374,14 +357,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ModelEnvironment>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -390,7 +366,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ModelEnvironment>)req).Callback != null)
-                ((RequestObject<ModelEnvironment>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ModelEnvironment>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List environments.
@@ -449,7 +425,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListEnvironmentsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ListEnvironmentsResponse> response = new DetailedResponse<ListEnvironmentsResponse>();
-            Dictionary<string, object> customData = ((RequestObject<ListEnvironmentsResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -460,14 +435,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ListEnvironmentsResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -476,7 +444,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ListEnvironmentsResponse>)req).Callback != null)
-                ((RequestObject<ListEnvironmentsResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ListEnvironmentsResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List fields across collections.
@@ -540,7 +508,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListFieldsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ListCollectionFieldsResponse> response = new DetailedResponse<ListCollectionFieldsResponse>();
-            Dictionary<string, object> customData = ((RequestObject<ListCollectionFieldsResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -551,14 +518,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ListCollectionFieldsResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -567,7 +527,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ListCollectionFieldsResponse>)req).Callback != null)
-                ((RequestObject<ListCollectionFieldsResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ListCollectionFieldsResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update an environment.
@@ -640,7 +600,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnUpdateEnvironmentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ModelEnvironment> response = new DetailedResponse<ModelEnvironment>();
-            Dictionary<string, object> customData = ((RequestObject<ModelEnvironment>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -651,14 +610,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ModelEnvironment>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -667,7 +619,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ModelEnvironment>)req).Callback != null)
-                ((RequestObject<ModelEnvironment>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ModelEnvironment>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add configuration.
@@ -758,7 +710,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateConfigurationResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Configuration> response = new DetailedResponse<Configuration>();
-            Dictionary<string, object> customData = ((RequestObject<Configuration>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -769,14 +720,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Configuration>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -785,7 +729,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Configuration>)req).Callback != null)
-                ((RequestObject<Configuration>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Configuration>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a configuration.
@@ -848,7 +792,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteConfigurationResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DeleteConfigurationResponse> response = new DetailedResponse<DeleteConfigurationResponse>();
-            Dictionary<string, object> customData = ((RequestObject<DeleteConfigurationResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -859,14 +802,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DeleteConfigurationResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -875,7 +811,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DeleteConfigurationResponse>)req).Callback != null)
-                ((RequestObject<DeleteConfigurationResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DeleteConfigurationResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get configuration details.
@@ -933,7 +869,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetConfigurationResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Configuration> response = new DetailedResponse<Configuration>();
-            Dictionary<string, object> customData = ((RequestObject<Configuration>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -944,14 +879,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Configuration>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -960,7 +888,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Configuration>)req).Callback != null)
-                ((RequestObject<Configuration>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Configuration>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List configurations.
@@ -1022,7 +950,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListConfigurationsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ListConfigurationsResponse> response = new DetailedResponse<ListConfigurationsResponse>();
-            Dictionary<string, object> customData = ((RequestObject<ListConfigurationsResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1033,14 +960,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ListConfigurationsResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1049,7 +969,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ListConfigurationsResponse>)req).Callback != null)
-                ((RequestObject<ListConfigurationsResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ListConfigurationsResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update a configuration.
@@ -1142,7 +1062,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnUpdateConfigurationResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Configuration> response = new DetailedResponse<Configuration>();
-            Dictionary<string, object> customData = ((RequestObject<Configuration>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1153,14 +1072,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Configuration>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1169,7 +1081,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Configuration>)req).Callback != null)
-                ((RequestObject<Configuration>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Configuration>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Test configuration.
@@ -1269,7 +1181,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnTestConfigurationInEnvironmentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TestDocument> response = new DetailedResponse<TestDocument>();
-            Dictionary<string, object> customData = ((RequestObject<TestDocument>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1280,14 +1191,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TestDocument>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1296,7 +1200,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TestDocument>)req).Callback != null)
-                ((RequestObject<TestDocument>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TestDocument>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create a collection.
@@ -1372,7 +1276,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateCollectionResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Collection> response = new DetailedResponse<Collection>();
-            Dictionary<string, object> customData = ((RequestObject<Collection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1383,14 +1286,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Collection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1399,7 +1295,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Collection>)req).Callback != null)
-                ((RequestObject<Collection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Collection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a collection.
@@ -1457,7 +1353,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteCollectionResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DeleteCollectionResponse> response = new DetailedResponse<DeleteCollectionResponse>();
-            Dictionary<string, object> customData = ((RequestObject<DeleteCollectionResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1468,14 +1363,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DeleteCollectionResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1484,7 +1372,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DeleteCollectionResponse>)req).Callback != null)
-                ((RequestObject<DeleteCollectionResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DeleteCollectionResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get collection details.
@@ -1542,7 +1430,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetCollectionResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Collection> response = new DetailedResponse<Collection>();
-            Dictionary<string, object> customData = ((RequestObject<Collection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1553,14 +1440,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Collection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1569,7 +1449,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Collection>)req).Callback != null)
-                ((RequestObject<Collection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Collection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List collection fields.
@@ -1629,7 +1509,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListCollectionFieldsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ListCollectionFieldsResponse> response = new DetailedResponse<ListCollectionFieldsResponse>();
-            Dictionary<string, object> customData = ((RequestObject<ListCollectionFieldsResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1640,14 +1519,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ListCollectionFieldsResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1656,7 +1528,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ListCollectionFieldsResponse>)req).Callback != null)
-                ((RequestObject<ListCollectionFieldsResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ListCollectionFieldsResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List collections.
@@ -1718,7 +1590,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListCollectionsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ListCollectionsResponse> response = new DetailedResponse<ListCollectionsResponse>();
-            Dictionary<string, object> customData = ((RequestObject<ListCollectionsResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1729,14 +1600,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ListCollectionsResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1745,7 +1609,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ListCollectionsResponse>)req).Callback != null)
-                ((RequestObject<ListCollectionsResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ListCollectionsResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update a collection.
@@ -1818,7 +1682,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnUpdateCollectionResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Collection> response = new DetailedResponse<Collection>();
-            Dictionary<string, object> customData = ((RequestObject<Collection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1829,14 +1692,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Collection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1845,7 +1701,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Collection>)req).Callback != null)
-                ((RequestObject<Collection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Collection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create or update expansion list.
@@ -1929,7 +1785,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateExpansionsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Expansions> response = new DetailedResponse<Expansions>();
-            Dictionary<string, object> customData = ((RequestObject<Expansions>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1940,14 +1795,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Expansions>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1956,7 +1804,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Expansions>)req).Callback != null)
-                ((RequestObject<Expansions>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Expansions>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create stopword list.
@@ -2024,7 +1872,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateStopwordListResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TokenDictStatusResponse> response = new DetailedResponse<TokenDictStatusResponse>();
-            Dictionary<string, object> customData = ((RequestObject<TokenDictStatusResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2035,14 +1882,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TokenDictStatusResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2051,7 +1891,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TokenDictStatusResponse>)req).Callback != null)
-                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create tokenization dictionary.
@@ -2121,7 +1961,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateTokenizationDictionaryResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TokenDictStatusResponse> response = new DetailedResponse<TokenDictStatusResponse>();
-            Dictionary<string, object> customData = ((RequestObject<TokenDictStatusResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2132,14 +1971,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TokenDictStatusResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2148,7 +1980,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TokenDictStatusResponse>)req).Callback != null)
-                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete the expansion list.
@@ -2209,7 +2041,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteExpansionsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2220,14 +2051,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2236,7 +2060,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a custom stopword list.
@@ -2297,7 +2121,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteStopwordListResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2308,14 +2131,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2324,7 +2140,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete tokenization dictionary.
@@ -2384,7 +2200,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteTokenizationDictionaryResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2395,14 +2210,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2411,7 +2219,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get stopword list status.
@@ -2471,7 +2279,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetStopwordListStatusResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TokenDictStatusResponse> response = new DetailedResponse<TokenDictStatusResponse>();
-            Dictionary<string, object> customData = ((RequestObject<TokenDictStatusResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2482,14 +2289,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TokenDictStatusResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2498,7 +2298,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TokenDictStatusResponse>)req).Callback != null)
-                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get tokenization dictionary status.
@@ -2558,7 +2358,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetTokenizationDictionaryStatusResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TokenDictStatusResponse> response = new DetailedResponse<TokenDictStatusResponse>();
-            Dictionary<string, object> customData = ((RequestObject<TokenDictStatusResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2569,14 +2368,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TokenDictStatusResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2585,7 +2377,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TokenDictStatusResponse>)req).Callback != null)
-                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TokenDictStatusResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get the expansion list.
@@ -2646,7 +2438,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListExpansionsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Expansions> response = new DetailedResponse<Expansions>();
-            Dictionary<string, object> customData = ((RequestObject<Expansions>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2657,14 +2448,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Expansions>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2673,7 +2457,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Expansions>)req).Callback != null)
-                ((RequestObject<Expansions>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Expansions>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add a document.
@@ -2771,7 +2555,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnAddDocumentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DocumentAccepted> response = new DetailedResponse<DocumentAccepted>();
-            Dictionary<string, object> customData = ((RequestObject<DocumentAccepted>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2782,14 +2565,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DocumentAccepted>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2798,7 +2574,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DocumentAccepted>)req).Callback != null)
-                ((RequestObject<DocumentAccepted>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DocumentAccepted>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a document.
@@ -2862,7 +2638,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteDocumentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DeleteDocumentResponse> response = new DetailedResponse<DeleteDocumentResponse>();
-            Dictionary<string, object> customData = ((RequestObject<DeleteDocumentResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2873,14 +2648,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DeleteDocumentResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2889,7 +2657,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DeleteDocumentResponse>)req).Callback != null)
-                ((RequestObject<DeleteDocumentResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DeleteDocumentResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get document details.
@@ -2954,7 +2722,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetDocumentStatusResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DocumentStatus> response = new DetailedResponse<DocumentStatus>();
-            Dictionary<string, object> customData = ((RequestObject<DocumentStatus>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2965,14 +2732,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DocumentStatus>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2981,7 +2741,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DocumentStatus>)req).Callback != null)
-                ((RequestObject<DocumentStatus>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DocumentStatus>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update a document.
@@ -3063,7 +2823,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnUpdateDocumentResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DocumentAccepted> response = new DetailedResponse<DocumentAccepted>();
-            Dictionary<string, object> customData = ((RequestObject<DocumentAccepted>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3074,14 +2833,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DocumentAccepted>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3090,14 +2842,15 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DocumentAccepted>)req).Callback != null)
-                ((RequestObject<DocumentAccepted>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DocumentAccepted>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Long environment queries.
         ///
         /// Complex queries might be too long for a standard method query. By using this method, you can construct
         /// longer queries. However, these queries may take longer to complete than the standard method. For details,
-        /// see the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html).
+        /// see the [Discovery service
+        /// documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
@@ -3258,7 +3011,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnFederatedQueryResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<QueryResponse> response = new DetailedResponse<QueryResponse>();
-            Dictionary<string, object> customData = ((RequestObject<QueryResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3269,14 +3021,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<QueryResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3285,15 +3030,15 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<QueryResponse>)req).Callback != null)
-                ((RequestObject<QueryResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<QueryResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Query multiple collection system notices.
         ///
         /// Queries for notices (errors or warnings) that might have been generated by the system. Notices are generated
         /// when ingesting documents and performing relevance training. See the [Discovery service
-        /// documentation](https://console.bluemix.net/docs/services/discovery/using.html) for more details on the query
-        /// language.
+        /// documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts)
+        /// for more details on the query language.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
@@ -3440,7 +3185,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnFederatedQueryNoticesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<QueryNoticesResponse> response = new DetailedResponse<QueryNoticesResponse>();
-            Dictionary<string, object> customData = ((RequestObject<QueryNoticesResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3451,14 +3195,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<QueryNoticesResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3467,14 +3204,15 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<QueryNoticesResponse>)req).Callback != null)
-                ((RequestObject<QueryNoticesResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<QueryNoticesResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Long collection queries.
         ///
         /// Complex queries might be too long for a standard method query. By using this method, you can construct
         /// longer queries. However, these queries may take longer to complete than the standard method. For details,
-        /// see the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html).
+        /// see the [Discovery service
+        /// documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
@@ -3638,7 +3376,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnQueryResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<QueryResponse> response = new DetailedResponse<QueryResponse>();
-            Dictionary<string, object> customData = ((RequestObject<QueryResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3649,14 +3386,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<QueryResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3665,13 +3395,13 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<QueryResponse>)req).Callback != null)
-                ((RequestObject<QueryResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<QueryResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Knowledge Graph entity query.
         ///
-        /// See the [Knowledge Graph
-        /// documentation](https://console.bluemix.net/docs/services/discovery/building-kg.html) for more details.
+        /// See the [Knowledge Graph documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-kg#kg)
+        /// for more details.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
@@ -3751,7 +3481,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnQueryEntitiesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<QueryEntitiesResponse> response = new DetailedResponse<QueryEntitiesResponse>();
-            Dictionary<string, object> customData = ((RequestObject<QueryEntitiesResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3762,14 +3491,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<QueryEntitiesResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3778,15 +3500,15 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<QueryEntitiesResponse>)req).Callback != null)
-                ((RequestObject<QueryEntitiesResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<QueryEntitiesResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Query system notices.
         ///
         /// Queries for notices (errors or warnings) that might have been generated by the system. Notices are generated
         /// when ingesting documents and performing relevance training. See the [Discovery service
-        /// documentation](https://console.bluemix.net/docs/services/discovery/using.html) for more details on the query
-        /// language.
+        /// documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts)
+        /// for more details on the query language.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
@@ -3953,7 +3675,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnQueryNoticesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<QueryNoticesResponse> response = new DetailedResponse<QueryNoticesResponse>();
-            Dictionary<string, object> customData = ((RequestObject<QueryNoticesResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3964,14 +3685,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<QueryNoticesResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3980,13 +3694,13 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<QueryNoticesResponse>)req).Callback != null)
-                ((RequestObject<QueryNoticesResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<QueryNoticesResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Knowledge Graph relationship query.
         ///
-        /// See the [Knowledge Graph
-        /// documentation](https://console.bluemix.net/docs/services/discovery/building-kg.html) for more details.
+        /// See the [Knowledge Graph documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-kg#kg)
+        /// for more details.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
@@ -4070,7 +3784,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnQueryRelationsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<QueryRelationsResponse> response = new DetailedResponse<QueryRelationsResponse>();
-            Dictionary<string, object> customData = ((RequestObject<QueryRelationsResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4081,14 +3794,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<QueryRelationsResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4097,7 +3803,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<QueryRelationsResponse>)req).Callback != null)
-                ((RequestObject<QueryRelationsResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<QueryRelationsResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add query to training data.
@@ -4173,7 +3879,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnAddTrainingDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TrainingQuery> response = new DetailedResponse<TrainingQuery>();
-            Dictionary<string, object> customData = ((RequestObject<TrainingQuery>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4184,14 +3889,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TrainingQuery>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4200,7 +3898,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TrainingQuery>)req).Callback != null)
-                ((RequestObject<TrainingQuery>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TrainingQuery>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add example to training data query.
@@ -4277,7 +3975,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateTrainingExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TrainingExample> response = new DetailedResponse<TrainingExample>();
-            Dictionary<string, object> customData = ((RequestObject<TrainingExample>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4288,14 +3985,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TrainingExample>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4304,7 +3994,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TrainingExample>)req).Callback != null)
-                ((RequestObject<TrainingExample>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TrainingExample>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete all training data.
@@ -4364,7 +4054,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteAllTrainingDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4375,14 +4064,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4391,7 +4073,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a training data query.
@@ -4454,7 +4136,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteTrainingDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4465,14 +4146,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4481,7 +4155,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete example for training data query.
@@ -4547,7 +4221,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteTrainingExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4558,14 +4231,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4574,7 +4240,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get details about a query.
@@ -4637,7 +4303,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetTrainingDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TrainingQuery> response = new DetailedResponse<TrainingQuery>();
-            Dictionary<string, object> customData = ((RequestObject<TrainingQuery>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4648,14 +4313,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TrainingQuery>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4664,7 +4322,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TrainingQuery>)req).Callback != null)
-                ((RequestObject<TrainingQuery>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TrainingQuery>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get details for training data example.
@@ -4730,7 +4388,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetTrainingExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TrainingExample> response = new DetailedResponse<TrainingExample>();
-            Dictionary<string, object> customData = ((RequestObject<TrainingExample>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4741,14 +4398,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TrainingExample>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4757,7 +4407,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TrainingExample>)req).Callback != null)
-                ((RequestObject<TrainingExample>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TrainingExample>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List training data.
@@ -4817,7 +4467,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListTrainingDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TrainingDataSet> response = new DetailedResponse<TrainingDataSet>();
-            Dictionary<string, object> customData = ((RequestObject<TrainingDataSet>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4828,14 +4477,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TrainingDataSet>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4844,7 +4486,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TrainingDataSet>)req).Callback != null)
-                ((RequestObject<TrainingDataSet>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TrainingDataSet>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List examples for a training data query.
@@ -4907,7 +4549,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListTrainingExamplesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TrainingExampleList> response = new DetailedResponse<TrainingExampleList>();
-            Dictionary<string, object> customData = ((RequestObject<TrainingExampleList>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4918,14 +4559,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TrainingExampleList>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4934,7 +4568,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TrainingExampleList>)req).Callback != null)
-                ((RequestObject<TrainingExampleList>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TrainingExampleList>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Change label or cross reference for example.
@@ -5011,7 +4645,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnUpdateTrainingExampleResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TrainingExample> response = new DetailedResponse<TrainingExample>();
-            Dictionary<string, object> customData = ((RequestObject<TrainingExample>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5022,14 +4655,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TrainingExample>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5038,7 +4664,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<TrainingExample>)req).Callback != null)
-                ((RequestObject<TrainingExample>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TrainingExample>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete labeled data.
@@ -5048,7 +4674,7 @@ namespace IBM.Watson.Discovery.V1
         ///
         /// You associate a customer ID with data by passing the **X-Watson-Metadata** header with a request that passes
         /// data. For more information about personal data and customer IDs, see [Information
-        /// security](https://console.bluemix.net/docs/services/discovery/information-security.html).
+        /// security](https://cloud.ibm.com/docs/services/discovery?topic=discovery-information-security#information-security).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customerId">The customer ID for which all data is to be deleted.</param>
@@ -5104,7 +4730,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteUserDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5115,14 +4740,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5131,7 +4749,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create event.
@@ -5201,7 +4819,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateEventResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<CreateEventResponse> response = new DetailedResponse<CreateEventResponse>();
-            Dictionary<string, object> customData = ((RequestObject<CreateEventResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5212,14 +4829,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<CreateEventResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5228,7 +4838,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<CreateEventResponse>)req).Callback != null)
-                ((RequestObject<CreateEventResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<CreateEventResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Percentage of queries with an associated event.
@@ -5301,7 +4911,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetMetricsEventRateResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<MetricResponse> response = new DetailedResponse<MetricResponse>();
-            Dictionary<string, object> customData = ((RequestObject<MetricResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5312,14 +4921,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<MetricResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5328,7 +4930,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<MetricResponse>)req).Callback != null)
-                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Number of queries over time.
@@ -5399,7 +5001,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetMetricsQueryResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<MetricResponse> response = new DetailedResponse<MetricResponse>();
-            Dictionary<string, object> customData = ((RequestObject<MetricResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5410,14 +5011,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<MetricResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5426,7 +5020,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<MetricResponse>)req).Callback != null)
-                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Number of queries with an event over time.
@@ -5499,7 +5093,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetMetricsQueryEventResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<MetricResponse> response = new DetailedResponse<MetricResponse>();
-            Dictionary<string, object> customData = ((RequestObject<MetricResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5510,14 +5103,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<MetricResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5526,7 +5112,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<MetricResponse>)req).Callback != null)
-                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Number of queries with no search results over time.
@@ -5598,7 +5184,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetMetricsQueryNoResultsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<MetricResponse> response = new DetailedResponse<MetricResponse>();
-            Dictionary<string, object> customData = ((RequestObject<MetricResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5609,14 +5194,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<MetricResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5625,7 +5203,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<MetricResponse>)req).Callback != null)
-                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<MetricResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Most frequent query tokens with an event.
@@ -5686,7 +5264,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetMetricsQueryTokenEventResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<MetricTokenResponse> response = new DetailedResponse<MetricTokenResponse>();
-            Dictionary<string, object> customData = ((RequestObject<MetricTokenResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5697,14 +5274,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<MetricTokenResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5713,7 +5283,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<MetricTokenResponse>)req).Callback != null)
-                ((RequestObject<MetricTokenResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<MetricTokenResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Search the query and event log.
@@ -5801,7 +5371,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnQueryLogResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<LogQueryResponse> response = new DetailedResponse<LogQueryResponse>();
-            Dictionary<string, object> customData = ((RequestObject<LogQueryResponse>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5812,14 +5381,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<LogQueryResponse>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5828,7 +5390,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<LogQueryResponse>)req).Callback != null)
-                ((RequestObject<LogQueryResponse>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<LogQueryResponse>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create credentials.
@@ -5844,7 +5406,9 @@ namespace IBM.Watson.Discovery.V1
         /// -  `box` indicates the credentials are used to connect an instance of Enterprise Box.
         /// -  `salesforce` indicates the credentials are used to connect to Salesforce.
         /// -  `sharepoint` indicates the credentials are used to connect to Microsoft SharePoint Online.
-        /// -  `web_crawl` indicates the credentials are used to perform a web crawl. (optional)</param>
+        /// -  `web_crawl` indicates the credentials are used to perform a web crawl.
+        /// =  `cloud_object_storage` indicates the credentials are used to connect to an IBM Cloud Object Store.
+        /// (optional)</param>
         /// <param name="credentialDetails">Object containing details of the stored credentials.
         ///
         /// Obtain credentials for your source from the administrator of the source. (optional)</param>
@@ -5905,7 +5469,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateCredentialsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ModelCredentials> response = new DetailedResponse<ModelCredentials>();
-            Dictionary<string, object> customData = ((RequestObject<ModelCredentials>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5916,14 +5479,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ModelCredentials>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5932,7 +5488,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ModelCredentials>)req).Callback != null)
-                ((RequestObject<ModelCredentials>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ModelCredentials>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete credentials.
@@ -5992,7 +5548,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteCredentialsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DeleteCredentials> response = new DetailedResponse<DeleteCredentials>();
-            Dictionary<string, object> customData = ((RequestObject<DeleteCredentials>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6003,14 +5558,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DeleteCredentials>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6019,7 +5567,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<DeleteCredentials>)req).Callback != null)
-                ((RequestObject<DeleteCredentials>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DeleteCredentials>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// View Credentials.
@@ -6082,7 +5630,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetCredentialsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ModelCredentials> response = new DetailedResponse<ModelCredentials>();
-            Dictionary<string, object> customData = ((RequestObject<ModelCredentials>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6093,14 +5640,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ModelCredentials>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6109,7 +5649,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ModelCredentials>)req).Callback != null)
-                ((RequestObject<ModelCredentials>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ModelCredentials>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List credentials.
@@ -6168,7 +5708,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListCredentialsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<CredentialsList> response = new DetailedResponse<CredentialsList>();
-            Dictionary<string, object> customData = ((RequestObject<CredentialsList>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6179,14 +5718,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<CredentialsList>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6195,7 +5727,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<CredentialsList>)req).Callback != null)
-                ((RequestObject<CredentialsList>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<CredentialsList>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update credentials.
@@ -6211,7 +5743,9 @@ namespace IBM.Watson.Discovery.V1
         /// -  `box` indicates the credentials are used to connect an instance of Enterprise Box.
         /// -  `salesforce` indicates the credentials are used to connect to Salesforce.
         /// -  `sharepoint` indicates the credentials are used to connect to Microsoft SharePoint Online.
-        /// -  `web_crawl` indicates the credentials are used to perform a web crawl. (optional)</param>
+        /// -  `web_crawl` indicates the credentials are used to perform a web crawl.
+        /// =  `cloud_object_storage` indicates the credentials are used to connect to an IBM Cloud Object Store.
+        /// (optional)</param>
         /// <param name="credentialDetails">Object containing details of the stored credentials.
         ///
         /// Obtain credentials for your source from the administrator of the source. (optional)</param>
@@ -6274,7 +5808,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnUpdateCredentialsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ModelCredentials> response = new DetailedResponse<ModelCredentials>();
-            Dictionary<string, object> customData = ((RequestObject<ModelCredentials>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6285,14 +5818,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ModelCredentials>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6301,7 +5827,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<ModelCredentials>)req).Callback != null)
-                ((RequestObject<ModelCredentials>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ModelCredentials>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create Gateway.
@@ -6366,7 +5892,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnCreateGatewayResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Gateway> response = new DetailedResponse<Gateway>();
-            Dictionary<string, object> customData = ((RequestObject<Gateway>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6377,14 +5902,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Gateway>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6393,7 +5911,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Gateway>)req).Callback != null)
-                ((RequestObject<Gateway>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Gateway>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete Gateway.
@@ -6453,7 +5971,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnDeleteGatewayResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<GatewayDelete> response = new DetailedResponse<GatewayDelete>();
-            Dictionary<string, object> customData = ((RequestObject<GatewayDelete>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6464,14 +5981,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<GatewayDelete>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6480,7 +5990,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<GatewayDelete>)req).Callback != null)
-                ((RequestObject<GatewayDelete>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<GatewayDelete>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List Gateway Details.
@@ -6540,7 +6050,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnGetGatewayResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Gateway> response = new DetailedResponse<Gateway>();
-            Dictionary<string, object> customData = ((RequestObject<Gateway>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6551,14 +6060,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Gateway>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6567,7 +6069,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<Gateway>)req).Callback != null)
-                ((RequestObject<Gateway>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Gateway>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List Gateways.
@@ -6624,7 +6126,6 @@ namespace IBM.Watson.Discovery.V1
         private void OnListGatewaysResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<GatewayList> response = new DetailedResponse<GatewayList>();
-            Dictionary<string, object> customData = ((RequestObject<GatewayList>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -6635,14 +6136,7 @@ namespace IBM.Watson.Discovery.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<GatewayList>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -6651,7 +6145,7 @@ namespace IBM.Watson.Discovery.V1
             }
 
             if (((RequestObject<GatewayList>)req).Callback != null)
-                ((RequestObject<GatewayList>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<GatewayList>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/Discovery/V1/Model/CredentialDetails.cs
+++ b/Scripts/Services/Discovery/V1/Model/CredentialDetails.cs
@@ -34,7 +34,8 @@ namespace IBM.Watson.Discovery.V1.Model
         /// -  `\"source_type\": \"salesforce\"` - valid `credential_type`s: `username_password`
         /// -  `\"source_type\": \"sharepoint\"` - valid `credential_type`s: `saml` with **source_version** of `online`,
         /// or `ntml_v1` with **source_version** of `2016`
-        /// -  `\"source_type\": \"web_crawl\"` - valid `credential_type`s: `noauth` or `basic`.
+        /// -  `\"source_type\": \"web_crawl\"` - valid `credential_type`s: `noauth` or `basic`
+        /// -  \"source_type\": \"cloud_object_storage\"` - valid `credential_type`s: `aws4_hmac`.
         /// </summary>
         public class CredentialTypeValue
         {
@@ -62,6 +63,10 @@ namespace IBM.Watson.Discovery.V1.Model
             /// Constant NTML_V1 for ntml_v1
             /// </summary>
             public const string NTML_V1 = "ntml_v1";
+            /// <summary>
+            /// Constant AWS4_HMAC for aws4_hmac
+            /// </summary>
+            public const string AWS4_HMAC = "aws4_hmac";
             
         }
 
@@ -86,7 +91,8 @@ namespace IBM.Watson.Discovery.V1.Model
         /// -  `\"source_type\": \"salesforce\"` - valid `credential_type`s: `username_password`
         /// -  `\"source_type\": \"sharepoint\"` - valid `credential_type`s: `saml` with **source_version** of `online`,
         /// or `ntml_v1` with **source_version** of `2016`
-        /// -  `\"source_type\": \"web_crawl\"` - valid `credential_type`s: `noauth` or `basic`.
+        /// -  `\"source_type\": \"web_crawl\"` - valid `credential_type`s: `noauth` or `basic`
+        /// -  \"source_type\": \"cloud_object_storage\"` - valid `credential_type`s: `aws4_hmac`.
         /// Constants for possible values can be found using CredentialDetails.CredentialTypeValue
         /// </summary>
         [JsonProperty("credential_type", NullValueHandling = NullValueHandling.Ignore)]
@@ -190,5 +196,26 @@ namespace IBM.Watson.Discovery.V1.Model
         /// </summary>
         [JsonProperty("domain", NullValueHandling = NullValueHandling.Ignore)]
         public string Domain { get; set; }
+        /// <summary>
+        /// The endpoint associated with the cloud object store that your are connecting to. Only valid, and required,
+        /// with a **credential_type** of `aws4_hmac`.
+        /// </summary>
+        [JsonProperty("endpoint", NullValueHandling = NullValueHandling.Ignore)]
+        public string Endpoint { get; set; }
+        /// <summary>
+        /// The access key ID associated with the cloud object store. Only valid, and required, with a
+        /// **credential_type** of `aws4_hmac`. For more infomation, see the [cloud object store
+        /// documentation](https://cloud.ibm.com/docs/services/cloud-object-storage?topic=cloud-object-storage-using-hmac-credentials#using-hmac-credentials).
+        /// </summary>
+        [JsonProperty("access_key_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string AccessKeyId { get; set; }
+        /// <summary>
+        /// The secret access key associated with the cloud object store. Only valid, and required, with a
+        /// **credential_type** of `aws4_hmac`. This value is never returned and is only used when creating or modifying
+        /// **credentials**. For more infomation, see the [cloud object store
+        /// documentation](https://cloud.ibm.com/docs/services/cloud-object-storage?topic=cloud-object-storage-using-hmac-credentials#using-hmac-credentials).
+        /// </summary>
+        [JsonProperty("secret_access_key", NullValueHandling = NullValueHandling.Ignore)]
+        public string SecretAccessKey { get; set; }
     }
 }

--- a/Scripts/Services/Discovery/V1/Model/DocumentSnapshot.cs
+++ b/Scripts/Services/Discovery/V1/Model/DocumentSnapshot.cs
@@ -15,6 +15,7 @@
 *
 */
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace IBM.Watson.Discovery.V1.Model
@@ -66,6 +67,6 @@ namespace IBM.Watson.Discovery.V1.Model
         /// Snapshot of the conversion.
         /// </summary>
         [JsonProperty("snapshot", NullValueHandling = NullValueHandling.Ignore)]
-        public object Snapshot { get; set; }
+        public Dictionary<string, object> Snapshot { get; set; }
     }
 }

--- a/Scripts/Services/Discovery/V1/Model/Enrichment.cs
+++ b/Scripts/Services/Discovery/V1/Model/Enrichment.cs
@@ -55,7 +55,7 @@ namespace IBM.Watson.Discovery.V1.Model
         ///  When using `elements` the **options** object must contain Element Classification options. Additionally,
         /// when using the `elements` enrichment the configuration specified and files ingested must meet all the
         /// criteria specified in [the
-        /// documentation](https://console.bluemix.net/docs/services/discovery/element-classification.html)
+        /// documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-element-classification#element-classification)
         ///
         ///
         ///

--- a/Scripts/Services/Discovery/V1/Model/ModelCredentials.cs
+++ b/Scripts/Services/Discovery/V1/Model/ModelCredentials.cs
@@ -30,6 +30,7 @@ namespace IBM.Watson.Discovery.V1.Model
         /// -  `salesforce` indicates the credentials are used to connect to Salesforce.
         /// -  `sharepoint` indicates the credentials are used to connect to Microsoft SharePoint Online.
         /// -  `web_crawl` indicates the credentials are used to perform a web crawl.
+        /// =  `cloud_object_storage` indicates the credentials are used to connect to an IBM Cloud Object Store.
         /// </summary>
         public class SourceTypeValue
         {
@@ -49,6 +50,10 @@ namespace IBM.Watson.Discovery.V1.Model
             /// Constant WEB_CRAWL for web_crawl
             /// </summary>
             public const string WEB_CRAWL = "web_crawl";
+            /// <summary>
+            /// Constant CLOUD_OBJECT_STORAGE for cloud_object_storage
+            /// </summary>
+            public const string CLOUD_OBJECT_STORAGE = "cloud_object_storage";
             
         }
 
@@ -58,6 +63,7 @@ namespace IBM.Watson.Discovery.V1.Model
         /// -  `salesforce` indicates the credentials are used to connect to Salesforce.
         /// -  `sharepoint` indicates the credentials are used to connect to Microsoft SharePoint Online.
         /// -  `web_crawl` indicates the credentials are used to perform a web crawl.
+        /// =  `cloud_object_storage` indicates the credentials are used to connect to an IBM Cloud Object Store.
         /// Constants for possible values can be found using ModelCredentials.SourceTypeValue
         /// </summary>
         [JsonProperty("source_type", NullValueHandling = NullValueHandling.Ignore)]

--- a/Scripts/Services/Discovery/V1/Model/NluEnrichmentFeatures.cs
+++ b/Scripts/Services/Discovery/V1/Model/NluEnrichmentFeatures.cs
@@ -16,6 +16,7 @@
 */
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace IBM.Watson.Discovery.V1.Model
 {
@@ -48,7 +49,7 @@ namespace IBM.Watson.Discovery.V1.Model
         /// An object that indicates the Categories enrichment will be applied to the specified field.
         /// </summary>
         [JsonProperty("categories", NullValueHandling = NullValueHandling.Ignore)]
-        public NluEnrichmentCategories Categories { get; set; }
+        public JObject Categories { get; set; }
         /// <summary>
         /// An object specifiying the semantic roles enrichment and related parameters.
         /// </summary>

--- a/Scripts/Services/Discovery/V1/Model/QueryNoticesResult.cs
+++ b/Scripts/Services/Discovery/V1/Model/QueryNoticesResult.cs
@@ -69,7 +69,7 @@ namespace IBM.Watson.Discovery.V1.Model
         /// Metadata of the document.
         /// </summary>
         [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
-        public object Metadata { get; set; }
+        public Dictionary<string, object> Metadata { get; set; }
         /// <summary>
         /// The collection ID of the collection containing the document for this result.
         /// </summary>

--- a/Scripts/Services/Discovery/V1/Model/QueryResponse.cs
+++ b/Scripts/Services/Discovery/V1/Model/QueryResponse.cs
@@ -42,7 +42,7 @@ namespace IBM.Watson.Discovery.V1.Model
         [JsonProperty("aggregations", NullValueHandling = NullValueHandling.Ignore)]
         public List<QueryAggregation> Aggregations { get; set; }
         /// <summary>
-        /// Gets or Sets Passages
+        /// Array of passage results for the query.
         /// </summary>
         [JsonProperty("passages", NullValueHandling = NullValueHandling.Ignore)]
         public List<QueryPassages> Passages { get; set; }

--- a/Scripts/Services/Discovery/V1/Model/QueryResult.cs
+++ b/Scripts/Services/Discovery/V1/Model/QueryResult.cs
@@ -15,6 +15,7 @@
 *
 */
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace IBM.Watson.Discovery.V1.Model
@@ -38,7 +39,7 @@ namespace IBM.Watson.Discovery.V1.Model
         /// Metadata of the document.
         /// </summary>
         [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
-        public object Metadata { get; set; }
+        public Dictionary<string, object> Metadata { get; set; }
         /// <summary>
         /// The collection ID of the collection containing the document for this result.
         /// </summary>

--- a/Scripts/Services/Discovery/V1/Model/Source.cs
+++ b/Scripts/Services/Discovery/V1/Model/Source.cs
@@ -30,6 +30,7 @@ namespace IBM.Watson.Discovery.V1.Model
         /// -  `salesforce` indicates the configuration is to connect to Salesforce.
         /// -  `sharepoint` indicates the configuration is to connect to Microsoft SharePoint Online.
         /// -  `web_crawl` indicates the configuration is to perform a web page crawl.
+        /// -  `cloud_object_storage` indicates the configuration is to connect to a cloud object store.
         /// </summary>
         public class TypeValue
         {
@@ -49,6 +50,10 @@ namespace IBM.Watson.Discovery.V1.Model
             /// Constant WEB_CRAWL for web_crawl
             /// </summary>
             public const string WEB_CRAWL = "web_crawl";
+            /// <summary>
+            /// Constant CLOUD_OBJECT_STORAGE for cloud_object_storage
+            /// </summary>
+            public const string CLOUD_OBJECT_STORAGE = "cloud_object_storage";
             
         }
 
@@ -58,6 +63,7 @@ namespace IBM.Watson.Discovery.V1.Model
         /// -  `salesforce` indicates the configuration is to connect to Salesforce.
         /// -  `sharepoint` indicates the configuration is to connect to Microsoft SharePoint Online.
         /// -  `web_crawl` indicates the configuration is to perform a web page crawl.
+        /// -  `cloud_object_storage` indicates the configuration is to connect to a cloud object store.
         /// Constants for possible values can be found using Source.TypeValue
         /// </summary>
         [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]

--- a/Scripts/Services/Discovery/V1/Model/SourceOptions.cs
+++ b/Scripts/Services/Discovery/V1/Model/SourceOptions.cs
@@ -49,5 +49,18 @@ namespace IBM.Watson.Discovery.V1.Model
         /// </summary>
         [JsonProperty("urls", NullValueHandling = NullValueHandling.Ignore)]
         public List<SourceOptionsWebCrawl> Urls { get; set; }
+        /// <summary>
+        /// Array of cloud object store buckets to begin crawling. Only valid and required when the **type** field of
+        /// the **source** object is set to `cloud_object_store`, and the **crawl_all_buckets** field is `false` or not
+        /// specified.
+        /// </summary>
+        [JsonProperty("buckets", NullValueHandling = NullValueHandling.Ignore)]
+        public List<SourceOptionsBuckets> Buckets { get; set; }
+        /// <summary>
+        /// When `true`, all buckets in the specified cloud object store are crawled. If set to `true`, the **buckets**
+        /// array must not be specified.
+        /// </summary>
+        [JsonProperty("crawl_all_buckets", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? CrawlAllBuckets { get; set; }
     }
 }

--- a/Scripts/Services/Discovery/V1/Model/SourceOptionsBuckets.cs
+++ b/Scripts/Services/Discovery/V1/Model/SourceOptionsBuckets.cs
@@ -1,0 +1,39 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Newtonsoft.Json;
+
+namespace IBM.Watson.Discovery.V1.Model
+{
+    /// <summary>
+    /// Object defining a cloud object store bucket to crawl.
+    /// </summary>
+    public class SourceOptionsBuckets
+    {
+        /// <summary>
+        /// The name of the cloud object store bucket to crawl.
+        /// </summary>
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
+        /// <summary>
+        /// The number of documents to crawl from this cloud object store bucket. If not specified, all documents in the
+        /// bucket are crawled.
+        /// </summary>
+        [JsonProperty("limit", NullValueHandling = NullValueHandling.Ignore)]
+        public long? Limit { get; set; }
+    }
+}

--- a/Scripts/Services/Discovery/V1/Model/SourceOptionsBuckets.cs.meta
+++ b/Scripts/Services/Discovery/V1/Model/SourceOptionsBuckets.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c0f9748f9bbe9c4ab498ec12c1768f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
+++ b/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.LanguageTranslator.V3
 {
-    public class LanguageTranslatorService : BaseService
+    public partial class LanguageTranslatorService : BaseService
     {
         private const string serviceId = "language_translator";
         private const string defaultUrl = "https://gateway.watsonplatform.net/language-translator/api";
@@ -199,7 +199,6 @@ namespace IBM.Watson.LanguageTranslator.V3
         private void OnTranslateResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TranslationResult> response = new DetailedResponse<TranslationResult>();
-            Dictionary<string, object> customData = ((RequestObject<TranslationResult>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -210,14 +209,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TranslationResult>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -226,7 +218,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             }
 
             if (((RequestObject<TranslationResult>)req).Callback != null)
-                ((RequestObject<TranslationResult>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TranslationResult>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Identify language.
@@ -286,7 +278,6 @@ namespace IBM.Watson.LanguageTranslator.V3
         private void OnIdentifyResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<IdentifiedLanguages> response = new DetailedResponse<IdentifiedLanguages>();
-            Dictionary<string, object> customData = ((RequestObject<IdentifiedLanguages>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -297,14 +288,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<IdentifiedLanguages>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -313,7 +297,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             }
 
             if (((RequestObject<IdentifiedLanguages>)req).Callback != null)
-                ((RequestObject<IdentifiedLanguages>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<IdentifiedLanguages>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List identifiable languages.
@@ -368,7 +352,6 @@ namespace IBM.Watson.LanguageTranslator.V3
         private void OnListIdentifiableLanguagesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<IdentifiableLanguages> response = new DetailedResponse<IdentifiableLanguages>();
-            Dictionary<string, object> customData = ((RequestObject<IdentifiableLanguages>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -379,14 +362,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<IdentifiableLanguages>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -395,7 +371,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             }
 
             if (((RequestObject<IdentifiableLanguages>)req).Callback != null)
-                ((RequestObject<IdentifiableLanguages>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<IdentifiableLanguages>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create model.
@@ -493,7 +469,6 @@ namespace IBM.Watson.LanguageTranslator.V3
         private void OnCreateModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TranslationModel> response = new DetailedResponse<TranslationModel>();
-            Dictionary<string, object> customData = ((RequestObject<TranslationModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -504,14 +479,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TranslationModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -520,7 +488,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             }
 
             if (((RequestObject<TranslationModel>)req).Callback != null)
-                ((RequestObject<TranslationModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TranslationModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete model.
@@ -577,7 +545,6 @@ namespace IBM.Watson.LanguageTranslator.V3
         private void OnDeleteModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DeleteModelResult> response = new DetailedResponse<DeleteModelResult>();
-            Dictionary<string, object> customData = ((RequestObject<DeleteModelResult>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -588,14 +555,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DeleteModelResult>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -604,7 +564,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             }
 
             if (((RequestObject<DeleteModelResult>)req).Callback != null)
-                ((RequestObject<DeleteModelResult>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DeleteModelResult>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get model details.
@@ -663,7 +623,6 @@ namespace IBM.Watson.LanguageTranslator.V3
         private void OnGetModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TranslationModel> response = new DetailedResponse<TranslationModel>();
-            Dictionary<string, object> customData = ((RequestObject<TranslationModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -674,14 +633,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TranslationModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -690,7 +642,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             }
 
             if (((RequestObject<TranslationModel>)req).Callback != null)
-                ((RequestObject<TranslationModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TranslationModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List models.
@@ -762,7 +714,6 @@ namespace IBM.Watson.LanguageTranslator.V3
         private void OnListModelsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<TranslationModels> response = new DetailedResponse<TranslationModels>();
-            Dictionary<string, object> customData = ((RequestObject<TranslationModels>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -773,14 +724,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<TranslationModels>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -789,7 +733,7 @@ namespace IBM.Watson.LanguageTranslator.V3
             }
 
             if (((RequestObject<TranslationModels>)req).Callback != null)
-                ((RequestObject<TranslationModels>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<TranslationModels>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
+++ b/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
@@ -138,11 +138,8 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// translation. (optional)</param>
         /// <param name="source">Translation source language code. (optional)</param>
         /// <param name="target">Translation target language code. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TranslationResult" />TranslationResult</returns>
-        public bool Translate(Callback<TranslationResult> callback, List<string> text, Dictionary<string, object> customData = null, string modelId = null, string source = null, string target = null)
+        public bool Translate(Callback<TranslationResult> callback, List<string> text, string modelId = null, string source = null, string target = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Translate`");
@@ -153,17 +150,15 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("language_translator", "V3", "Translate"))
             {
@@ -227,11 +222,8 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="text">Input text in UTF-8 format.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="IdentifiedLanguages" />IdentifiedLanguages</returns>
-        public bool Identify(Callback<IdentifiedLanguages> callback, string text, Dictionary<string, object> customData = null)
+        public bool Identify(Callback<IdentifiedLanguages> callback, string text)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Identify`");
@@ -242,17 +234,15 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("language_translator", "V3", "Identify"))
             {
@@ -306,11 +296,8 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// or `es` for Spanish) and name of each language.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="IdentifiableLanguages" />IdentifiableLanguages</returns>
-        public bool ListIdentifiableLanguages(Callback<IdentifiableLanguages> callback, Dictionary<string, object> customData = null)
+        public bool ListIdentifiableLanguages(Callback<IdentifiableLanguages> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListIdentifiableLanguages`");
@@ -319,17 +306,15 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("language_translator", "V3", "ListIdentifiableLanguages"))
             {
@@ -404,11 +389,8 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// <param name="name">An optional model name that you can use to identify the model. Valid characters are
         /// letters, numbers, dashes, underscores, spaces and apostrophes. The maximum length is 32 characters.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TranslationModel" />TranslationModel</returns>
-        public bool CreateModel(Callback<TranslationModel> callback, string baseModelId, Dictionary<string, object> customData = null, System.IO.FileStream forcedGlossary = null, System.IO.FileStream parallelCorpus = null, string name = null)
+        public bool CreateModel(Callback<TranslationModel> callback, string baseModelId, System.IO.FileStream forcedGlossary = null, System.IO.FileStream parallelCorpus = null, string name = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateModel`");
@@ -419,17 +401,15 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("language_translator", "V3", "CreateModel"))
             {
@@ -497,11 +477,8 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="modelId">Model ID of the model to delete.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DeleteModelResult" />DeleteModelResult</returns>
-        public bool DeleteModel(Callback<DeleteModelResult> callback, string modelId, Dictionary<string, object> customData = null)
+        public bool DeleteModel(Callback<DeleteModelResult> callback, string modelId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteModel`");
@@ -512,17 +489,15 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("language_translator", "V3", "DeleteModel"))
             {
@@ -575,11 +550,8 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="modelId">Model ID of the model to get.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TranslationModel" />TranslationModel</returns>
-        public bool GetModel(Callback<TranslationModel> callback, string modelId, Dictionary<string, object> customData = null)
+        public bool GetModel(Callback<TranslationModel> callback, string modelId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetModel`");
@@ -590,17 +562,15 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("language_translator", "V3", "GetModel"))
             {
@@ -656,11 +626,8 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// (default and non-default) for each language pair. To return only default models, set this to `true`. To
         /// return only non-default models, set this to `false`. There is exactly one default model per language pair,
         /// the IBM provided base model. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="TranslationModels" />TranslationModels</returns>
-        public bool ListModels(Callback<TranslationModels> callback, Dictionary<string, object> customData = null, string source = null, string target = null, bool? defaultModels = null)
+        public bool ListModels(Callback<TranslationModels> callback, string source = null, string target = null, bool? defaultModels = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListModels`");
@@ -669,17 +636,15 @@ namespace IBM.Watson.LanguageTranslator.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("language_translator", "V3", "ListModels"))
             {

--- a/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
+++ b/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
@@ -117,11 +117,8 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">Classifier ID to use.</param>
         /// <param name="text">The submitted phrase. The maximum length is 2048 characters.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Classification" />Classification</returns>
-        public bool Classify(Callback<Classification> callback, string classifierId, string text, Dictionary<string, object> customData = null)
+        public bool Classify(Callback<Classification> callback, string classifierId, string text)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Classify`");
@@ -134,17 +131,15 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural_language_classifier", "V1", "Classify"))
             {
@@ -205,11 +200,8 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">Classifier ID to use.</param>
         /// <param name="collection">The submitted phrases.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ClassificationCollection" />ClassificationCollection</returns>
-        public bool ClassifyCollection(Callback<ClassificationCollection> callback, string classifierId, List<ClassifyInput> collection, Dictionary<string, object> customData = null)
+        public bool ClassifyCollection(Callback<ClassificationCollection> callback, string classifierId, List<ClassifyInput> collection)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ClassifyCollection`");
@@ -222,17 +214,15 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural_language_classifier", "V1", "ClassifyCollection"))
             {
@@ -297,11 +287,8 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         /// <param name="trainingData">Training data in CSV format. Each text value must have at least one class. The
         /// data can include up to 3,000 classes and 20,000 records. For details, see [Data
         /// preparation](https://cloud.ibm.com/docs/services/natural-language-classifier/using-your-data.html).</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool CreateClassifier(Callback<Classifier> callback, System.IO.FileStream metadata, System.IO.FileStream trainingData, Dictionary<string, object> customData = null)
+        public bool CreateClassifier(Callback<Classifier> callback, System.IO.FileStream metadata, System.IO.FileStream trainingData)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateClassifier`");
@@ -314,17 +301,15 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural_language_classifier", "V1", "CreateClassifier"))
             {
@@ -381,11 +366,8 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">Classifier ID to delete.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteClassifier(Callback<object> callback, string classifierId, Dictionary<string, object> customData = null)
+        public bool DeleteClassifier(Callback<object> callback, string classifierId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteClassifier`");
@@ -396,17 +378,15 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural_language_classifier", "V1", "DeleteClassifier"))
             {
@@ -456,11 +436,8 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">Classifier ID to query.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool GetClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, object> customData = null)
+        public bool GetClassifier(Callback<Classifier> callback, string classifierId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetClassifier`");
@@ -471,17 +448,15 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural_language_classifier", "V1", "GetClassifier"))
             {
@@ -530,11 +505,8 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         /// Returns an empty array if no classifiers are available.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ClassifierList" />ClassifierList</returns>
-        public bool ListClassifiers(Callback<ClassifierList> callback, Dictionary<string, object> customData = null)
+        public bool ListClassifiers(Callback<ClassifierList> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListClassifiers`");
@@ -543,17 +515,15 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural_language_classifier", "V1", "ListClassifiers"))
             {

--- a/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
+++ b/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.NaturalLanguageClassifier.V1
 {
-    public class NaturalLanguageClassifierService : BaseService
+    public partial class NaturalLanguageClassifierService : BaseService
     {
         private const string serviceId = "natural_language_classifier";
         private const string defaultUrl = "https://gateway.watsonplatform.net/natural-language-classifier/api";
@@ -173,7 +173,6 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         private void OnClassifyResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Classification> response = new DetailedResponse<Classification>();
-            Dictionary<string, object> customData = ((RequestObject<Classification>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -184,14 +183,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Classification>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -200,7 +192,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             }
 
             if (((RequestObject<Classification>)req).Callback != null)
-                ((RequestObject<Classification>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Classification>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Classify multiple phrases.
@@ -269,7 +261,6 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         private void OnClassifyCollectionResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ClassificationCollection> response = new DetailedResponse<ClassificationCollection>();
-            Dictionary<string, object> customData = ((RequestObject<ClassificationCollection>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -280,14 +271,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ClassificationCollection>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -296,7 +280,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             }
 
             if (((RequestObject<ClassificationCollection>)req).Callback != null)
-                ((RequestObject<ClassificationCollection>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ClassificationCollection>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create classifier.
@@ -371,7 +355,6 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         private void OnCreateClassifierResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Classifier> response = new DetailedResponse<Classifier>();
-            Dictionary<string, object> customData = ((RequestObject<Classifier>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -382,14 +365,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Classifier>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -398,7 +374,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             }
 
             if (((RequestObject<Classifier>)req).Callback != null)
-                ((RequestObject<Classifier>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Classifier>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete classifier.
@@ -452,7 +428,6 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         private void OnDeleteClassifierResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -463,14 +438,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -479,7 +447,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get information about a classifier.
@@ -535,7 +503,6 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         private void OnGetClassifierResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Classifier> response = new DetailedResponse<Classifier>();
-            Dictionary<string, object> customData = ((RequestObject<Classifier>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -546,14 +513,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Classifier>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -562,7 +522,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             }
 
             if (((RequestObject<Classifier>)req).Callback != null)
-                ((RequestObject<Classifier>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Classifier>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List classifiers.
@@ -615,7 +575,6 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         private void OnListClassifiersResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ClassifierList> response = new DetailedResponse<ClassifierList>();
-            Dictionary<string, object> customData = ((RequestObject<ClassifierList>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -626,14 +585,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ClassifierList>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -642,7 +594,7 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             }
 
             if (((RequestObject<ClassifierList>)req).Callback != null)
-                ((RequestObject<ClassifierList>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ClassifierList>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/NaturalLanguageUnderstandingService.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/NaturalLanguageUnderstandingService.cs
@@ -168,11 +168,8 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
         /// more information. (optional)</param>
         /// <param name="limitTextCharacters">Sets the maximum number of characters that are processed by the service.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="AnalysisResults" />AnalysisResults</returns>
-        public bool Analyze(Callback<AnalysisResults> callback, Features features, Dictionary<string, object> customData = null, string text = null, string html = null, string url = null, bool? clean = null, string xpath = null, bool? fallbackToRaw = null, bool? returnAnalyzedText = null, string language = null, long? limitTextCharacters = null)
+        public bool Analyze(Callback<AnalysisResults> callback, Features features, string text = null, string html = null, string url = null, bool? clean = null, string xpath = null, bool? fallbackToRaw = null, bool? returnAnalyzedText = null, string language = null, long? limitTextCharacters = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Analyze`");
@@ -183,17 +180,15 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural-language-understanding", "V1", "Analyze"))
             {
@@ -269,11 +264,8 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="modelId">Model ID of the model to delete.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DeleteModelResults" />DeleteModelResults</returns>
-        public bool DeleteModel(Callback<DeleteModelResults> callback, string modelId, Dictionary<string, object> customData = null)
+        public bool DeleteModel(Callback<DeleteModelResults> callback, string modelId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteModel`");
@@ -284,17 +276,15 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural-language-understanding", "V1", "DeleteModel"))
             {
@@ -346,11 +336,8 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
         /// deployed to your Natural Language Understanding service.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ListModelsResults" />ListModelsResults</returns>
-        public bool ListModels(Callback<ListModelsResults> callback, Dictionary<string, object> customData = null)
+        public bool ListModels(Callback<ListModelsResults> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListModels`");
@@ -359,17 +346,15 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("natural-language-understanding", "V1", "ListModels"))
             {

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/NaturalLanguageUnderstandingService.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/NaturalLanguageUnderstandingService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.NaturalLanguageUnderstanding.V1
 {
-    public class NaturalLanguageUnderstandingService : BaseService
+    public partial class NaturalLanguageUnderstandingService : BaseService
     {
         private const string serviceId = "natural-language-understanding";
         private const string defaultUrl = "https://gateway.watsonplatform.net/natural-language-understanding/api";
@@ -241,7 +241,6 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
         private void OnAnalyzeResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<AnalysisResults> response = new DetailedResponse<AnalysisResults>();
-            Dictionary<string, object> customData = ((RequestObject<AnalysisResults>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -252,14 +251,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<AnalysisResults>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -268,7 +260,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             }
 
             if (((RequestObject<AnalysisResults>)req).Callback != null)
-                ((RequestObject<AnalysisResults>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<AnalysisResults>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete model.
@@ -325,7 +317,6 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
         private void OnDeleteModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DeleteModelResults> response = new DetailedResponse<DeleteModelResults>();
-            Dictionary<string, object> customData = ((RequestObject<DeleteModelResults>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -336,14 +327,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DeleteModelResults>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -352,7 +336,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             }
 
             if (((RequestObject<DeleteModelResults>)req).Callback != null)
-                ((RequestObject<DeleteModelResults>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DeleteModelResults>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List models.
@@ -408,7 +392,6 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
         private void OnListModelsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ListModelsResults> response = new DetailedResponse<ListModelsResults>();
-            Dictionary<string, object> customData = ((RequestObject<ListModelsResults>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -419,14 +402,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ListModelsResults>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -435,7 +411,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1
             }
 
             if (((RequestObject<ListModelsResults>)req).Callback != null)
-                ((RequestObject<ListModelsResults>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ListModelsResults>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/PersonalityInsights/V3/PersonalityInsightsService.cs
+++ b/Scripts/Services/PersonalityInsights/V3/PersonalityInsightsService.cs
@@ -193,11 +193,8 @@ namespace IBM.Watson.PersonalityInsights.V3
         /// description.
         ///
         /// Default: `text/plain`. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Profile" />Profile</returns>
-        public bool Profile(Callback<Profile> callback, Content content, Dictionary<string, object> customData = null, string contentLanguage = null, string acceptLanguage = null, bool? rawScores = null, bool? csvHeaders = null, bool? consumptionPreferences = null, string contentType = null)
+        public bool Profile(Callback<Profile> callback, Content content, string contentLanguage = null, string acceptLanguage = null, bool? rawScores = null, bool? csvHeaders = null, bool? consumptionPreferences = null, string contentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Profile`");
@@ -208,17 +205,15 @@ namespace IBM.Watson.PersonalityInsights.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("personality_insights", "V3", "Profile"))
             {
@@ -358,11 +353,8 @@ namespace IBM.Watson.PersonalityInsights.V3
         /// description.
         ///
         /// Default: `text/plain`. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="System.IO.MemoryStream" />System.IO.MemoryStream</returns>
-        public bool ProfileAsCsv(Callback<System.IO.MemoryStream> callback, Content content, Dictionary<string, object> customData = null, string contentLanguage = null, string acceptLanguage = null, bool? rawScores = null, bool? csvHeaders = null, bool? consumptionPreferences = null, string contentType = null)
+        public bool ProfileAsCsv(Callback<System.IO.MemoryStream> callback, Content content, string contentLanguage = null, string acceptLanguage = null, bool? rawScores = null, bool? csvHeaders = null, bool? consumptionPreferences = null, string contentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ProfileAsCsv`");
@@ -373,17 +365,15 @@ namespace IBM.Watson.PersonalityInsights.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("personality_insights", "V3", "ProfileAsCsv"))
             {

--- a/Scripts/Services/PersonalityInsights/V3/PersonalityInsightsService.cs
+++ b/Scripts/Services/PersonalityInsights/V3/PersonalityInsightsService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.PersonalityInsights.V3
 {
-    public class PersonalityInsightsService : BaseService
+    public partial class PersonalityInsightsService : BaseService
     {
         private const string serviceId = "personality_insights";
         private const string defaultUrl = "https://gateway.watsonplatform.net/personality-insights/api";
@@ -270,7 +270,6 @@ namespace IBM.Watson.PersonalityInsights.V3
         private void OnProfileResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Profile> response = new DetailedResponse<Profile>();
-            Dictionary<string, object> customData = ((RequestObject<Profile>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -281,14 +280,7 @@ namespace IBM.Watson.PersonalityInsights.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Profile>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -297,7 +289,7 @@ namespace IBM.Watson.PersonalityInsights.V3
             }
 
             if (((RequestObject<Profile>)req).Callback != null)
-                ((RequestObject<Profile>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Profile>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get profile as csv.
@@ -443,7 +435,6 @@ namespace IBM.Watson.PersonalityInsights.V3
         private void OnProfileAsCsvResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<System.IO.MemoryStream> response = new DetailedResponse<System.IO.MemoryStream>();
-            Dictionary<string, object> customData = ((RequestObject<System.IO.MemoryStream>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -453,7 +444,7 @@ namespace IBM.Watson.PersonalityInsights.V3
             response.Result = new System.IO.MemoryStream(resp.Data);
 
             if (((RequestObject<System.IO.MemoryStream>)req).Callback != null)
-                ((RequestObject<System.IO.MemoryStream>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<System.IO.MemoryStream>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/SpeechToText/V1/Model/AudioListing.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/AudioListing.cs
@@ -66,8 +66,8 @@ namespace IBM.Watson.SpeechToText.V1.Model
         [JsonProperty("status", NullValueHandling = NullValueHandling.Ignore)]
         public string Status { get; set; }
         /// <summary>
-        /// **For an audio-type resource,**  the total seconds of audio in the resource. The value is always a whole
-        /// number. Omitted for an archive-type resource.
+        /// **For an audio-type resource,**  the total seconds of audio in the resource. Omitted for an archive-type
+        /// resource.
         /// </summary>
         [JsonProperty("duration", NullValueHandling = NullValueHandling.Ignore)]
         public long? Duration { get; set; }

--- a/Scripts/Services/SpeechToText/V1/Model/AudioResource.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/AudioResource.cs
@@ -63,7 +63,7 @@ namespace IBM.Watson.SpeechToText.V1.Model
         [JsonProperty("status", NullValueHandling = NullValueHandling.Ignore)]
         public string Status { get; set; }
         /// <summary>
-        /// The total seconds of audio in the audio resource. The value is always a whole number.
+        /// The total seconds of audio in the audio resource.
         /// </summary>
         [JsonProperty("duration", NullValueHandling = NullValueHandling.Ignore)]
         public long? Duration { get; set; }

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
@@ -166,7 +166,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnGetModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<SpeechModel> response = new DetailedResponse<SpeechModel>();
-            Dictionary<string, object> customData = ((RequestObject<SpeechModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -177,14 +176,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<SpeechModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -193,7 +185,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<SpeechModel>)req).Callback != null)
-                ((RequestObject<SpeechModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<SpeechModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List models.
@@ -249,7 +241,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnListModelsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<SpeechModels> response = new DetailedResponse<SpeechModels>();
-            Dictionary<string, object> customData = ((RequestObject<SpeechModels>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -260,14 +251,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<SpeechModels>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -276,7 +260,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<SpeechModels>)req).Callback != null)
-                ((RequestObject<SpeechModels>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<SpeechModels>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Recognize audio.
@@ -313,6 +297,7 @@ namespace IBM.Watson.SpeechToText.V1
         ///
         /// Where indicated, the format that you specify must include the sampling rate and can optionally include the
         /// number of channels and the endianness of the audio.
+        /// * `audio/alaw` (**Required.** Specify the sampling rate (`rate`) of the audio.)
         /// * `audio/basic` (**Required.** Use only with narrowband models.)
         /// * `audio/flac`
         /// * `audio/g729` (Use only with narrowband models.)
@@ -406,7 +391,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// spotting](https://cloud.ibm.com/docs/services/speech-to-text/output.html#keyword_spotting).
         /// (optional)</param>
         /// <param name="maxAlternatives">The maximum number of alternative transcripts that the service is to return.
-        /// By default, the service returns a single transcript. See [Maximum
+        /// By default, the service returns a single transcript. If you specify a value of `0`, the service uses the
+        /// default value, `1`. See [Maximum
         /// alternatives](https://cloud.ibm.com/docs/services/speech-to-text/output.html#max_alternatives). (optional,
         /// default to 1)</param>
         /// <param name="wordAlternativesThreshold">A confidence value that is the lower bound for identifying a
@@ -599,7 +585,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnRecognizeResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<SpeechRecognitionResults> response = new DetailedResponse<SpeechRecognitionResults>();
-            Dictionary<string, object> customData = ((RequestObject<SpeechRecognitionResults>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -610,14 +595,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<SpeechRecognitionResults>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -626,7 +604,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<SpeechRecognitionResults>)req).Callback != null)
-                ((RequestObject<SpeechRecognitionResults>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<SpeechRecognitionResults>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Check a job.
@@ -694,7 +672,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnCheckJobResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<RecognitionJob> response = new DetailedResponse<RecognitionJob>();
-            Dictionary<string, object> customData = ((RequestObject<RecognitionJob>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -705,14 +682,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<RecognitionJob>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -721,7 +691,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<RecognitionJob>)req).Callback != null)
-                ((RequestObject<RecognitionJob>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<RecognitionJob>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Check jobs.
@@ -782,7 +752,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnCheckJobsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<RecognitionJobs> response = new DetailedResponse<RecognitionJobs>();
-            Dictionary<string, object> customData = ((RequestObject<RecognitionJobs>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -793,14 +762,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<RecognitionJobs>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -809,7 +771,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<RecognitionJobs>)req).Callback != null)
-                ((RequestObject<RecognitionJobs>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<RecognitionJobs>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create a job.
@@ -869,6 +831,7 @@ namespace IBM.Watson.SpeechToText.V1
         ///
         /// Where indicated, the format that you specify must include the sampling rate and can optionally include the
         /// number of channels and the endianness of the audio.
+        /// * `audio/alaw` (**Required.** Specify the sampling rate (`rate`) of the audio.)
         /// * `audio/basic` (**Required.** Use only with narrowband models.)
         /// * `audio/flac`
         /// * `audio/g729` (Use only with narrowband models.)
@@ -978,7 +941,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// spotting](https://cloud.ibm.com/docs/services/speech-to-text/output.html#keyword_spotting).
         /// (optional)</param>
         /// <param name="maxAlternatives">The maximum number of alternative transcripts that the service is to return.
-        /// By default, the service returns a single transcript. See [Maximum
+        /// By default, the service returns a single transcript. If you specify a value of `0`, the service uses the
+        /// default value, `1`. See [Maximum
         /// alternatives](https://cloud.ibm.com/docs/services/speech-to-text/output.html#max_alternatives). (optional,
         /// default to 1)</param>
         /// <param name="wordAlternativesThreshold">A confidence value that is the lower bound for identifying a
@@ -1187,7 +1151,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnCreateJobResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<RecognitionJob> response = new DetailedResponse<RecognitionJob>();
-            Dictionary<string, object> customData = ((RequestObject<RecognitionJob>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1198,14 +1161,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<RecognitionJob>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1214,7 +1170,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<RecognitionJob>)req).Callback != null)
-                ((RequestObject<RecognitionJob>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<RecognitionJob>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a job.
@@ -1276,7 +1232,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteJobResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1287,14 +1242,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1303,7 +1251,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Register a callback.
@@ -1401,7 +1349,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnRegisterCallbackResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<RegisterStatus> response = new DetailedResponse<RegisterStatus>();
-            Dictionary<string, object> customData = ((RequestObject<RegisterStatus>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1412,14 +1359,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<RegisterStatus>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1428,7 +1368,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<RegisterStatus>)req).Callback != null)
-                ((RequestObject<RegisterStatus>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<RegisterStatus>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Unregister a callback.
@@ -1493,7 +1433,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnUnregisterCallbackResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1504,14 +1443,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1520,7 +1452,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create a custom language model.
@@ -1616,7 +1548,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnCreateLanguageModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<LanguageModel> response = new DetailedResponse<LanguageModel>();
-            Dictionary<string, object> customData = ((RequestObject<LanguageModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1627,14 +1558,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<LanguageModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1643,7 +1567,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<LanguageModel>)req).Callback != null)
-                ((RequestObject<LanguageModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<LanguageModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a custom language model.
@@ -1706,7 +1630,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteLanguageModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1717,14 +1640,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1733,7 +1649,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get a custom language model.
@@ -1795,7 +1711,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnGetLanguageModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<LanguageModel> response = new DetailedResponse<LanguageModel>();
-            Dictionary<string, object> customData = ((RequestObject<LanguageModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1806,14 +1721,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<LanguageModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1822,7 +1730,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<LanguageModel>)req).Callback != null)
-                ((RequestObject<LanguageModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<LanguageModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List custom language models.
@@ -1888,7 +1796,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnListLanguageModelsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<LanguageModels> response = new DetailedResponse<LanguageModels>();
-            Dictionary<string, object> customData = ((RequestObject<LanguageModels>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1899,14 +1806,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<LanguageModels>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1915,7 +1815,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<LanguageModels>)req).Callback != null)
-                ((RequestObject<LanguageModels>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<LanguageModels>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Reset a custom language model.
@@ -1979,7 +1879,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnResetLanguageModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1990,14 +1889,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2006,7 +1898,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Train a custom language model.
@@ -2115,7 +2007,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnTrainLanguageModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2126,14 +2017,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2142,7 +2026,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Upgrade a custom language model.
@@ -2214,7 +2098,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnUpgradeLanguageModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2225,14 +2108,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2241,7 +2117,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add a corpus.
@@ -2367,7 +2243,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnAddCorpusResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2378,14 +2253,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2394,7 +2262,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a corpus.
@@ -2463,7 +2331,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteCorpusResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2474,14 +2341,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2490,7 +2350,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get a corpus.
@@ -2556,7 +2416,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnGetCorpusResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Corpus> response = new DetailedResponse<Corpus>();
-            Dictionary<string, object> customData = ((RequestObject<Corpus>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2567,14 +2426,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Corpus>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2583,7 +2435,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<Corpus>)req).Callback != null)
-                ((RequestObject<Corpus>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Corpus>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List corpora.
@@ -2646,7 +2498,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnListCorporaResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Corpora> response = new DetailedResponse<Corpora>();
-            Dictionary<string, object> customData = ((RequestObject<Corpora>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2657,14 +2508,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Corpora>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2673,7 +2517,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<Corpora>)req).Callback != null)
-                ((RequestObject<Corpora>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Corpora>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add a custom word.
@@ -2795,7 +2639,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnAddWordResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2806,14 +2649,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2822,7 +2658,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add custom words.
@@ -2935,7 +2771,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnAddWordsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -2946,14 +2781,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -2962,7 +2790,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a custom word.
@@ -3033,7 +2861,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteWordResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3044,14 +2871,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3060,7 +2880,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get a custom word.
@@ -3127,7 +2947,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnGetWordResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Word> response = new DetailedResponse<Word>();
-            Dictionary<string, object> customData = ((RequestObject<Word>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3138,14 +2957,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Word>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3154,7 +2966,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<Word>)req).Callback != null)
-                ((RequestObject<Word>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Word>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List custom words.
@@ -3239,7 +3051,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnListWordsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Words> response = new DetailedResponse<Words>();
-            Dictionary<string, object> customData = ((RequestObject<Words>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3250,14 +3061,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Words>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3266,7 +3070,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<Words>)req).Callback != null)
-                ((RequestObject<Words>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Words>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add a grammar.
@@ -3389,7 +3193,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnAddGrammarResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3400,14 +3203,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3416,7 +3212,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a grammar.
@@ -3485,7 +3281,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteGrammarResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3496,14 +3291,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3512,7 +3300,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get a grammar.
@@ -3578,7 +3366,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnGetGrammarResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Grammar> response = new DetailedResponse<Grammar>();
-            Dictionary<string, object> customData = ((RequestObject<Grammar>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3589,14 +3376,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Grammar>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3605,7 +3385,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<Grammar>)req).Callback != null)
-                ((RequestObject<Grammar>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Grammar>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List grammars.
@@ -3668,7 +3448,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnListGrammarsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Grammars> response = new DetailedResponse<Grammars>();
-            Dictionary<string, object> customData = ((RequestObject<Grammars>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3679,14 +3458,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Grammars>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3695,7 +3467,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<Grammars>)req).Callback != null)
-                ((RequestObject<Grammars>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Grammars>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create a custom acoustic model.
@@ -3779,7 +3551,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnCreateAcousticModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<AcousticModel> response = new DetailedResponse<AcousticModel>();
-            Dictionary<string, object> customData = ((RequestObject<AcousticModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3790,14 +3561,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<AcousticModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3806,7 +3570,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<AcousticModel>)req).Callback != null)
-                ((RequestObject<AcousticModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<AcousticModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a custom acoustic model.
@@ -3869,7 +3633,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteAcousticModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3880,14 +3643,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3896,7 +3652,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get a custom acoustic model.
@@ -3958,7 +3714,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnGetAcousticModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<AcousticModel> response = new DetailedResponse<AcousticModel>();
-            Dictionary<string, object> customData = ((RequestObject<AcousticModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -3969,14 +3724,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<AcousticModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -3985,7 +3733,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<AcousticModel>)req).Callback != null)
-                ((RequestObject<AcousticModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<AcousticModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List custom acoustic models.
@@ -4051,7 +3799,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnListAcousticModelsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<AcousticModels> response = new DetailedResponse<AcousticModels>();
-            Dictionary<string, object> customData = ((RequestObject<AcousticModels>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4062,14 +3809,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<AcousticModels>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4078,7 +3818,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<AcousticModels>)req).Callback != null)
-                ((RequestObject<AcousticModels>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<AcousticModels>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Reset a custom acoustic model.
@@ -4142,7 +3882,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnResetAcousticModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4153,14 +3892,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4169,7 +3901,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Train a custom acoustic model.
@@ -4270,7 +4002,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnTrainAcousticModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4281,14 +4012,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4297,7 +4021,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Upgrade a custom acoustic model.
@@ -4393,7 +4117,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnUpgradeAcousticModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4404,14 +4127,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4420,7 +4136,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add an audio resource.
@@ -4462,6 +4178,7 @@ namespace IBM.Watson.SpeechToText.V1
         ///  You can add an individual audio file in any format that the service supports for speech recognition. For an
         /// audio-type resource, use the `Content-Type` parameter to specify the audio format (MIME type) of the audio
         /// file, including specifying the sampling rate, channels, and endianness where indicated.
+        /// * `audio/alaw` (Specify the sampling rate (`rate`) of the audio.)
         /// * `audio/basic` (Use only with narrowband models.)
         /// * `audio/flac`
         /// * `audio/g729` (Use only with narrowband models.)
@@ -4601,7 +4318,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnAddAudioResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4612,14 +4328,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4628,7 +4337,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete an audio resource.
@@ -4696,7 +4405,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteAudioResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4707,14 +4415,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4723,7 +4424,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get an audio resource.
@@ -4802,7 +4503,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnGetAudioResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<AudioListing> response = new DetailedResponse<AudioListing>();
-            Dictionary<string, object> customData = ((RequestObject<AudioListing>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4813,14 +4513,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<AudioListing>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4829,7 +4522,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<AudioListing>)req).Callback != null)
-                ((RequestObject<AudioListing>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<AudioListing>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List audio resources.
@@ -4894,7 +4587,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnListAudioResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<AudioResources> response = new DetailedResponse<AudioResources>();
-            Dictionary<string, object> customData = ((RequestObject<AudioResources>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -4905,14 +4597,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<AudioResources>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -4921,7 +4606,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<AudioResources>)req).Callback != null)
-                ((RequestObject<AudioResources>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<AudioResources>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete labeled data.
@@ -4990,7 +4675,6 @@ namespace IBM.Watson.SpeechToText.V1
         private void OnDeleteUserDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -5001,14 +4685,7 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -5017,7 +4694,7 @@ namespace IBM.Watson.SpeechToText.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
@@ -119,11 +119,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="modelId">The identifier of the model in the form of its name from the output of the **Get a
         /// model** method.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="SpeechModel" />SpeechModel</returns>
-        public bool GetModel(Callback<SpeechModel> callback, string modelId, Dictionary<string, object> customData = null)
+        public bool GetModel(Callback<SpeechModel> callback, string modelId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetModel`");
@@ -134,17 +131,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "GetModel"))
             {
@@ -196,11 +191,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// **See also:** [Languages and models](https://cloud.ibm.com/docs/services/speech-to-text/models.html).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="SpeechModels" />SpeechModels</returns>
-        public bool ListModels(Callback<SpeechModels> callback, Dictionary<string, object> customData = null)
+        public bool ListModels(Callback<SpeechModels> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListModels`");
@@ -209,17 +201,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ListModels"))
             {
@@ -459,11 +449,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// (optional, default to false)</param>
         /// <param name="contentType">The format (MIME type) of the audio. For more information about specifying an
         /// audio format, see **Audio formats (content types)** in the method description. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="SpeechRecognitionResults" />SpeechRecognitionResults</returns>
-        public bool Recognize(Callback<SpeechRecognitionResults> callback, byte[] audio, Dictionary<string, object> customData = null, string model = null, string languageCustomizationId = null, string acousticCustomizationId = null, string baseModelVersion = null, double? customizationWeight = null, long? inactivityTimeout = null, List<string> keywords = null, float? keywordsThreshold = null, long? maxAlternatives = null, float? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool? profanityFilter = null, bool? smartFormatting = null, bool? speakerLabels = null, string customizationId = null, string grammarName = null, bool? redaction = null, string contentType = null)
+        public bool Recognize(Callback<SpeechRecognitionResults> callback, byte[] audio, string model = null, string languageCustomizationId = null, string acousticCustomizationId = null, string baseModelVersion = null, double? customizationWeight = null, long? inactivityTimeout = null, List<string> keywords = null, float? keywordsThreshold = null, long? maxAlternatives = null, float? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool? profanityFilter = null, bool? smartFormatting = null, bool? speakerLabels = null, string customizationId = null, string grammarName = null, bool? redaction = null, string contentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Recognize`");
@@ -474,17 +461,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "Recognize"))
             {
@@ -625,11 +610,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="id">The identifier of the asynchronous job that is to be used for the request. You must make
         /// the request with credentials for the instance of the service that owns the job.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="RecognitionJob" />RecognitionJob</returns>
-        public bool CheckJob(Callback<RecognitionJob> callback, string id, Dictionary<string, object> customData = null)
+        public bool CheckJob(Callback<RecognitionJob> callback, string id)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CheckJob`");
@@ -640,17 +622,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "CheckJob"))
             {
@@ -707,11 +687,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// jobs](https://cloud.ibm.com/docs/services/speech-to-text/async.html#jobs).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="RecognitionJobs" />RecognitionJobs</returns>
-        public bool CheckJobs(Callback<RecognitionJobs> callback, Dictionary<string, object> customData = null)
+        public bool CheckJobs(Callback<RecognitionJobs> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CheckJobs`");
@@ -720,17 +697,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "CheckJobs"))
             {
@@ -1009,11 +984,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// (optional, default to false)</param>
         /// <param name="contentType">The format (MIME type) of the audio. For more information about specifying an
         /// audio format, see **Audio formats (content types)** in the method description. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="RecognitionJob" />RecognitionJob</returns>
-        public bool CreateJob(Callback<RecognitionJob> callback, byte[] audio, Dictionary<string, object> customData = null, string model = null, string callbackUrl = null, string events = null, string userToken = null, long? resultsTtl = null, string languageCustomizationId = null, string acousticCustomizationId = null, string baseModelVersion = null, double? customizationWeight = null, long? inactivityTimeout = null, List<string> keywords = null, float? keywordsThreshold = null, long? maxAlternatives = null, float? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool? profanityFilter = null, bool? smartFormatting = null, bool? speakerLabels = null, string customizationId = null, string grammarName = null, bool? redaction = null, string contentType = null)
+        public bool CreateJob(Callback<RecognitionJob> callback, byte[] audio, string model = null, string callbackUrl = null, string events = null, string userToken = null, long? resultsTtl = null, string languageCustomizationId = null, string acousticCustomizationId = null, string baseModelVersion = null, double? customizationWeight = null, long? inactivityTimeout = null, List<string> keywords = null, float? keywordsThreshold = null, long? maxAlternatives = null, float? wordAlternativesThreshold = null, bool? wordConfidence = null, bool? timestamps = null, bool? profanityFilter = null, bool? smartFormatting = null, bool? speakerLabels = null, string customizationId = null, string grammarName = null, bool? redaction = null, string contentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateJob`");
@@ -1024,17 +996,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "CreateJob"))
             {
@@ -1185,11 +1155,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="id">The identifier of the asynchronous job that is to be used for the request. You must make
         /// the request with credentials for the instance of the service that owns the job.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteJob(Callback<object> callback, string id, Dictionary<string, object> customData = null)
+        public bool DeleteJob(Callback<object> callback, string id)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteJob`");
@@ -1200,17 +1167,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteJob"))
             {
@@ -1294,11 +1259,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// that it sends via the `X-Callback-Signature` header. The service includes the header during URL verification
         /// and with every notification sent to the callback URL. It calculates the signature over the payload of the
         /// notification. If you omit the parameter, the service does not send the header. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="RegisterStatus" />RegisterStatus</returns>
-        public bool RegisterCallback(Callback<RegisterStatus> callback, string callbackUrl, Dictionary<string, object> customData = null, string userSecret = null)
+        public bool RegisterCallback(Callback<RegisterStatus> callback, string callbackUrl, string userSecret = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `RegisterCallback`");
@@ -1309,17 +1271,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "RegisterCallback"))
             {
@@ -1382,11 +1342,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="callbackUrl">The callback URL that is to be unregistered.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool UnregisterCallback(Callback<object> callback, string callbackUrl, Dictionary<string, object> customData = null)
+        public bool UnregisterCallback(Callback<object> callback, string callbackUrl)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UnregisterCallback`");
@@ -1397,17 +1354,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "UnregisterCallback"))
             {
@@ -1486,11 +1441,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// base model; for example, `en-US` for either of the US English language models. (optional)</param>
         /// <param name="description">A description of the new custom language model. Use a localized description that
         /// matches the language of the custom model. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="LanguageModel" />LanguageModel</returns>
-        public bool CreateLanguageModel(Callback<LanguageModel> callback, string name, string baseModelName, Dictionary<string, object> customData = null, string dialect = null, string description = null)
+        public bool CreateLanguageModel(Callback<LanguageModel> callback, string name, string baseModelName, string dialect = null, string description = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateLanguageModel`");
@@ -1503,17 +1455,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "CreateLanguageModel"))
             {
@@ -1583,11 +1533,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom language model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteLanguageModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool DeleteLanguageModel(Callback<object> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteLanguageModel`");
@@ -1598,17 +1545,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteLanguageModel"))
             {
@@ -1664,11 +1609,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom language model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="LanguageModel" />LanguageModel</returns>
-        public bool GetLanguageModel(Callback<LanguageModel> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool GetLanguageModel(Callback<LanguageModel> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetLanguageModel`");
@@ -1679,17 +1621,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "GetLanguageModel"))
             {
@@ -1747,11 +1687,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="language">The identifier of the language for which custom language or custom acoustic models
         /// are to be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic
         /// models that are owned by the requesting credentials. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="LanguageModels" />LanguageModels</returns>
-        public bool ListLanguageModels(Callback<LanguageModels> callback, Dictionary<string, object> customData = null, string language = null)
+        public bool ListLanguageModels(Callback<LanguageModels> callback, string language = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListLanguageModels`");
@@ -1760,17 +1697,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ListLanguageModels"))
             {
@@ -1832,11 +1767,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom language model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool ResetLanguageModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool ResetLanguageModel(Callback<object> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ResetLanguageModel`");
@@ -1847,17 +1779,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ResetLanguageModel"))
             {
@@ -1952,11 +1882,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// The value that you assign is used for all recognition requests that use the model. You can override it for
         /// any recognition request by specifying a customization weight for that request. (optional, default to
         /// 0.3)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool TrainLanguageModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null, string wordTypeToAdd = null, double? customizationWeight = null)
+        public bool TrainLanguageModel(Callback<object> callback, string customizationId, string wordTypeToAdd = null, double? customizationWeight = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `TrainLanguageModel`");
@@ -1967,17 +1894,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "TrainLanguageModel"))
             {
@@ -2051,11 +1976,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom language model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool UpgradeLanguageModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool UpgradeLanguageModel(Callback<object> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpgradeLanguageModel`");
@@ -2066,17 +1988,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "UpgradeLanguageModel"))
             {
@@ -2183,11 +2103,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="allowOverwrite">If `true`, the specified corpus overwrites an existing corpus with the same
         /// name. If `false`, the request fails if a corpus with the same name already exists. The parameter has no
         /// effect if a corpus with the same name does not already exist. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddCorpus(Callback<object> callback, string customizationId, string corpusName, System.IO.FileStream corpusFile, Dictionary<string, object> customData = null, bool? allowOverwrite = null)
+        public bool AddCorpus(Callback<object> callback, string customizationId, string corpusName, System.IO.FileStream corpusFile, bool? allowOverwrite = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddCorpus`");
@@ -2202,17 +2119,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "AddCorpus"))
             {
@@ -2282,11 +2197,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
         /// <param name="corpusName">The name of the corpus for the custom language model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteCorpus(Callback<object> callback, string customizationId, string corpusName, Dictionary<string, object> customData = null)
+        public bool DeleteCorpus(Callback<object> callback, string customizationId, string corpusName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteCorpus`");
@@ -2299,17 +2211,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteCorpus"))
             {
@@ -2367,11 +2277,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
         /// <param name="corpusName">The name of the corpus for the custom language model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Corpus" />Corpus</returns>
-        public bool GetCorpus(Callback<Corpus> callback, string customizationId, string corpusName, Dictionary<string, object> customData = null)
+        public bool GetCorpus(Callback<Corpus> callback, string customizationId, string corpusName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetCorpus`");
@@ -2384,17 +2291,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "GetCorpus"))
             {
@@ -2451,11 +2356,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom language model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Corpora" />Corpora</returns>
-        public bool ListCorpora(Callback<Corpora> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool ListCorpora(Callback<Corpora> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListCorpora`");
@@ -2466,17 +2368,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ListCorpora"))
             {
@@ -2579,11 +2479,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="displayAs">An alternative spelling for the custom word when it appears in a transcript. Use the
         /// parameter when you want the word to have a spelling that is different from its usual representation or from
         /// its spelling in corpora training data. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddWord(Callback<object> callback, string customizationId, string wordName, Dictionary<string, object> customData = null, string word = null, List<string> soundsLike = null, string displayAs = null)
+        public bool AddWord(Callback<object> callback, string customizationId, string wordName, string word = null, List<string> soundsLike = null, string displayAs = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddWord`");
@@ -2596,17 +2493,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "AddWord"))
             {
@@ -2715,11 +2610,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// custom model.</param>
         /// <param name="words">An array of `CustomWord` objects that provides information about each custom word that
         /// is to be added to or updated in the custom language model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddWords(Callback<object> callback, string customizationId, List<CustomWord> words, Dictionary<string, object> customData = null)
+        public bool AddWords(Callback<object> callback, string customizationId, List<CustomWord> words)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddWords`");
@@ -2732,17 +2624,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "AddWords"))
             {
@@ -2812,11 +2702,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="wordName">The custom word that is to be deleted from the custom language model. URL-encode the
         /// word if it includes non-ASCII characters. For more information, see [Character
         /// encoding](https://cloud.ibm.com/docs/services/speech-to-text/language-resource.html#charEncoding).</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteWord(Callback<object> callback, string customizationId, string wordName, Dictionary<string, object> customData = null)
+        public bool DeleteWord(Callback<object> callback, string customizationId, string wordName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteWord`");
@@ -2829,17 +2716,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteWord"))
             {
@@ -2898,11 +2783,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="wordName">The custom word that is to be read from the custom language model. URL-encode the
         /// word if it includes non-ASCII characters. For more information, see [Character
         /// encoding](https://cloud.ibm.com/docs/services/speech-to-text/language-resource.html#charEncoding).</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Word" />Word</returns>
-        public bool GetWord(Callback<Word> callback, string customizationId, string wordName, Dictionary<string, object> customData = null)
+        public bool GetWord(Callback<Word> callback, string customizationId, string wordName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetWord`");
@@ -2915,17 +2797,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "GetWord"))
             {
@@ -2996,11 +2876,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// alphabetical ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase
         /// letters. For count ordering, values with the same count are ordered alphabetically. With the `curl` command,
         /// URL encode the `+` symbol as `%2B`. (optional, default to alphabetical)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Words" />Words</returns>
-        public bool ListWords(Callback<Words> callback, string customizationId, Dictionary<string, object> customData = null, string wordType = null, string sort = null)
+        public bool ListWords(Callback<Words> callback, string customizationId, string wordType = null, string sort = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListWords`");
@@ -3011,17 +2888,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ListWords"))
             {
@@ -3129,11 +3004,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="allowOverwrite">If `true`, the specified grammar overwrites an existing grammar with the same
         /// name. If `false`, the request fails if a grammar with the same name already exists. The parameter has no
         /// effect if a grammar with the same name does not already exist. (optional, default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddGrammar(Callback<object> callback, string customizationId, string grammarName, string grammarFile, string contentType, Dictionary<string, object> customData = null, bool? allowOverwrite = null)
+        public bool AddGrammar(Callback<object> callback, string customizationId, string grammarName, string grammarFile, string contentType, bool? allowOverwrite = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddGrammar`");
@@ -3150,17 +3022,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "AddGrammar"))
             {
@@ -3232,11 +3102,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
         /// <param name="grammarName">The name of the grammar for the custom language model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteGrammar(Callback<object> callback, string customizationId, string grammarName, Dictionary<string, object> customData = null)
+        public bool DeleteGrammar(Callback<object> callback, string customizationId, string grammarName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteGrammar`");
@@ -3249,17 +3116,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteGrammar"))
             {
@@ -3317,11 +3182,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
         /// <param name="grammarName">The name of the grammar for the custom language model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Grammar" />Grammar</returns>
-        public bool GetGrammar(Callback<Grammar> callback, string customizationId, string grammarName, Dictionary<string, object> customData = null)
+        public bool GetGrammar(Callback<Grammar> callback, string customizationId, string grammarName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetGrammar`");
@@ -3334,17 +3196,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "GetGrammar"))
             {
@@ -3401,11 +3261,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom language model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Grammars" />Grammars</returns>
-        public bool ListGrammars(Callback<Grammars> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool ListGrammars(Callback<Grammars> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListGrammars`");
@@ -3416,17 +3273,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ListGrammars"))
             {
@@ -3491,11 +3346,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// customization](https://cloud.ibm.com/docs/services/speech-to-text/custom.html#languageSupport).</param>
         /// <param name="description">A description of the new custom acoustic model. Use a localized description that
         /// matches the language of the custom model. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="AcousticModel" />AcousticModel</returns>
-        public bool CreateAcousticModel(Callback<AcousticModel> callback, string name, string baseModelName, Dictionary<string, object> customData = null, string description = null)
+        public bool CreateAcousticModel(Callback<AcousticModel> callback, string name, string baseModelName, string description = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateAcousticModel`");
@@ -3508,17 +3360,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "CreateAcousticModel"))
             {
@@ -3586,11 +3436,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom acoustic model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteAcousticModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool DeleteAcousticModel(Callback<object> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteAcousticModel`");
@@ -3601,17 +3448,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteAcousticModel"))
             {
@@ -3667,11 +3512,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom acoustic model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="AcousticModel" />AcousticModel</returns>
-        public bool GetAcousticModel(Callback<AcousticModel> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool GetAcousticModel(Callback<AcousticModel> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetAcousticModel`");
@@ -3682,17 +3524,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "GetAcousticModel"))
             {
@@ -3750,11 +3590,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="language">The identifier of the language for which custom language or custom acoustic models
         /// are to be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic
         /// models that are owned by the requesting credentials. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="AcousticModels" />AcousticModels</returns>
-        public bool ListAcousticModels(Callback<AcousticModels> callback, Dictionary<string, object> customData = null, string language = null)
+        public bool ListAcousticModels(Callback<AcousticModels> callback, string language = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListAcousticModels`");
@@ -3763,17 +3600,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ListAcousticModels"))
             {
@@ -3835,11 +3670,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom acoustic model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool ResetAcousticModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool ResetAcousticModel(Callback<object> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ResetAcousticModel`");
@@ -3850,17 +3682,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ResetAcousticModel"))
             {
@@ -3951,11 +3781,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// of the audio resources. The custom language model must be based on the same version of the same base model
         /// as the custom acoustic model. The credentials specified with the request must own both custom models.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool TrainAcousticModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null, string customLanguageModelId = null)
+        public bool TrainAcousticModel(Callback<object> callback, string customizationId, string customLanguageModelId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `TrainAcousticModel`");
@@ -3966,17 +3793,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "TrainAcousticModel"))
             {
@@ -4062,11 +3887,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// message `No input data modified since last training`. See [Upgrading a custom acoustic
         /// model](https://cloud.ibm.com/docs/services/speech-to-text/custom-upgrade.html#upgradeAcoustic). (optional,
         /// default to false)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool UpgradeAcousticModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null, string customLanguageModelId = null, bool? force = null)
+        public bool UpgradeAcousticModel(Callback<object> callback, string customizationId, string customLanguageModelId = null, bool? force = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpgradeAcousticModel`");
@@ -4077,17 +3899,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "UpgradeAcousticModel"))
             {
@@ -4251,11 +4071,8 @@ namespace IBM.Watson.SpeechToText.V1
         ///
         /// For an archive-type resource, the media type of the archive file. For more information, see **Content types
         /// for archive-type resources** in the method description. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddAudio(Callback<object> callback, string customizationId, string audioName, byte[] audioResource, Dictionary<string, object> customData = null, string containedContentType = null, bool? allowOverwrite = null, string contentType = null)
+        public bool AddAudio(Callback<object> callback, string customizationId, string audioName, byte[] audioResource, string containedContentType = null, bool? allowOverwrite = null, string contentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddAudio`");
@@ -4270,17 +4087,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "AddAudio"))
             {
@@ -4356,11 +4171,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
         /// <param name="audioName">The name of the audio resource for the custom acoustic model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteAudio(Callback<object> callback, string customizationId, string audioName, Dictionary<string, object> customData = null)
+        public bool DeleteAudio(Callback<object> callback, string customizationId, string audioName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteAudio`");
@@ -4373,17 +4185,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteAudio"))
             {
@@ -4454,11 +4264,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
         /// <param name="audioName">The name of the audio resource for the custom acoustic model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="AudioListing" />AudioListing</returns>
-        public bool GetAudio(Callback<AudioListing> callback, string customizationId, string audioName, Dictionary<string, object> customData = null)
+        public bool GetAudio(Callback<AudioListing> callback, string customizationId, string audioName)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetAudio`");
@@ -4471,17 +4278,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "GetAudio"))
             {
@@ -4540,11 +4345,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom acoustic model that is to be used
         /// for the request. You must make the request with credentials for the instance of the service that owns the
         /// custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="AudioResources" />AudioResources</returns>
-        public bool ListAudio(Callback<AudioResources> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool ListAudio(Callback<AudioResources> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListAudio`");
@@ -4555,17 +4357,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "ListAudio"))
             {
@@ -4624,11 +4424,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customerId">The customer ID for which all data is to be deleted.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteUserData(Callback<object> callback, string customerId, Dictionary<string, object> customData = null)
+        public bool DeleteUserData(Callback<object> callback, string customerId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteUserData`");
@@ -4639,17 +4436,15 @@ namespace IBM.Watson.SpeechToText.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("speech_to_text", "V1", "DeleteUserData"))
             {

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextServiceExtension.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextServiceExtension.cs
@@ -246,13 +246,13 @@ namespace IBM.Watson.SpeechToText.V1
         /// This callback object is used by the Recognize() and StartListening() methods.
         /// </summary>
         /// <param name="results">The ResultList object containing the results.</param>
-        public delegate void OnRecognize(SpeechRecognitionEvent results, Dictionary<string, object> customData = null);
+        public delegate void OnRecognize(SpeechRecognitionEvent results);
 
         /// <summary>
         /// This callback object is used by the RecognizeSpeaker() method.
         /// </summary>
         /// <param name="speakerRecognitionEvent">Array of speaker label results.</param>
-        public delegate void OnRecognizeSpeaker(SpeakerRecognitionEvent speakerRecognitionEvent, Dictionary<string, object> customData = null);
+        public delegate void OnRecognizeSpeaker(SpeakerRecognitionEvent speakerRecognitionEvent);
 
         /// <summary>
         /// This starts the service listening and it will invoke the callback for any recognized speech.
@@ -262,7 +262,7 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="callback">All recognize results are passed to this callback.</param>
         /// <param name="speakerLabelCallback">Speaker label goes through this callback if it arrives separately from recognize result.</param>
         /// <returns>Returns true on success, false on failure.</returns>
-        public bool StartListening(OnRecognize callback, OnRecognizeSpeaker speakerLabelCallback = null, Dictionary<string, object> customData = null)
+        public bool StartListening(OnRecognize callback, OnRecognizeSpeaker speakerLabelCallback = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("callback");
@@ -270,17 +270,11 @@ namespace IBM.Watson.SpeechToText.V1
                 return false;
             if (!CreateListenConnector())
                 return false;
-
-            if (customData == null)
-                customData = new Dictionary<string, object>();
-
+            
             Dictionary<string, string> customHeaders = new Dictionary<string, string>();
-            if (customData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in customData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    customHeaders.Add(kvp.Key, kvp.Value);
-                }
+                customHeaders.Add(kvp.Key, kvp.Value);
             }
 
             if (customHeaders != null && _listenSocket != null)
@@ -539,10 +533,10 @@ namespace IBM.Watson.SpeechToText.V1
             if (msg is WSConnector.TextMessage)
             {
                 WSConnector.TextMessage tm = (WSConnector.TextMessage)msg;
-                Dictionary<string, object> customData = new Dictionary<string, object>();
-                customData.Add(Constants.String.JSON, tm.Text);
-                if (tm.Headers != null && tm.Headers.Count > 0)
-                    customData.Add(Constants.String.RESPONSE_HEADERS, tm.Headers);
+                //Dictionary<string, object> customData = new Dictionary<string, object>();
+                //customData.Add(Constants.String.JSON, tm.Text);
+                //if (tm.Headers != null && tm.Headers.Count > 0)
+                //    customData.Add(Constants.String.RESPONSE_HEADERS, tm.Headers);
 
                 IDictionary json = Json.Deserialize(tm.Text) as IDictionary;
                 if (json != null)
@@ -558,7 +552,7 @@ namespace IBM.Watson.SpeechToText.V1
                             //    SendStart();
 
                             if (_listenCallback != null)
-                                _listenCallback(results, customData);
+                                _listenCallback(results);
                             else
                                 StopListening();            // automatically stop listening if our callback is destroyed.
                         }

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextServiceExtension.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextServiceExtension.cs
@@ -533,10 +533,6 @@ namespace IBM.Watson.SpeechToText.V1
             if (msg is WSConnector.TextMessage)
             {
                 WSConnector.TextMessage tm = (WSConnector.TextMessage)msg;
-                //Dictionary<string, object> customData = new Dictionary<string, object>();
-                //customData.Add(Constants.String.JSON, tm.Text);
-                //if (tm.Headers != null && tm.Headers.Count > 0)
-                //    customData.Add(Constants.String.RESPONSE_HEADERS, tm.Headers);
 
                 IDictionary json = Json.Deserialize(tm.Text) as IDictionary;
                 if (json != null)

--- a/Scripts/Services/TextToSpeech/V1/TextToSpeechService.cs
+++ b/Scripts/Services/TextToSpeech/V1/TextToSpeechService.cs
@@ -124,11 +124,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// to be returned. You must make the request with service credentials created for the instance of the service
         /// that owns the custom model. Omit the parameter to see information about the specified voice with no
         /// customization. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Voice" />Voice</returns>
-        public bool GetVoice(Callback<Voice> callback, string voice, Dictionary<string, object> customData = null, string customizationId = null)
+        public bool GetVoice(Callback<Voice> callback, string voice, string customizationId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetVoice`");
@@ -139,17 +136,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "GetVoice"))
             {
@@ -207,11 +202,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// voices](https://cloud.ibm.com/docs/services/text-to-speech/voices.html#listVoices).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Voices" />Voices</returns>
-        public bool ListVoices(Callback<Voices> callback, Dictionary<string, object> customData = null)
+        public bool ListVoices(Callback<Voices> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListVoices`");
@@ -220,17 +212,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "ListVoices"))
             {
@@ -364,11 +354,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// **Audio formats (accept types)** in the method description.
         ///
         /// Default: `audio/ogg;codecs=opus`. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="byte[]" />byte[]</returns>
-        public bool Synthesize(Callback<byte[]> callback, string text, Dictionary<string, object> customData = null, string voice = null, string customizationId = null, string accept = null)
+        public bool Synthesize(Callback<byte[]> callback, string text, string voice = null, string customizationId = null, string accept = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Synthesize`");
@@ -379,17 +366,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "Synthesize"))
             {
@@ -467,11 +452,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// translation for the custom model's language. You must make the request with service credentials created for
         /// the instance of the service that owns the custom model. Omit the parameter to see the translation for the
         /// specified voice with no customization. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Pronunciation" />Pronunciation</returns>
-        public bool GetPronunciation(Callback<Pronunciation> callback, string text, Dictionary<string, object> customData = null, string voice = null, string format = null, string customizationId = null)
+        public bool GetPronunciation(Callback<Pronunciation> callback, string text, string voice = null, string format = null, string customizationId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetPronunciation`");
@@ -482,17 +464,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "GetPronunciation"))
             {
@@ -569,11 +549,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// language, `en-US`. (optional, default to en-US)</param>
         /// <param name="description">A description of the new custom voice model. Specifying a description is
         /// recommended. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="VoiceModel" />VoiceModel</returns>
-        public bool CreateVoiceModel(Callback<VoiceModel> callback, string name, Dictionary<string, object> customData = null, string language = null, string description = null)
+        public bool CreateVoiceModel(Callback<VoiceModel> callback, string name, string language = null, string description = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateVoiceModel`");
@@ -584,17 +561,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "CreateVoiceModel"))
             {
@@ -662,11 +637,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
         /// request with service credentials created for the instance of the service that owns the custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteVoiceModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool DeleteVoiceModel(Callback<object> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteVoiceModel`");
@@ -677,17 +649,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "DeleteVoiceModel"))
             {
@@ -745,11 +715,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
         /// request with service credentials created for the instance of the service that owns the custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="VoiceModel" />VoiceModel</returns>
-        public bool GetVoiceModel(Callback<VoiceModel> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool GetVoiceModel(Callback<VoiceModel> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetVoiceModel`");
@@ -760,17 +727,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "GetVoiceModel"))
             {
@@ -830,11 +795,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="language">The language for which custom voice models that are owned by the requesting service
         /// credentials are to be returned. Omit the parameter to see all custom voice models that are owned by the
         /// requester. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="VoiceModels" />VoiceModels</returns>
-        public bool ListVoiceModels(Callback<VoiceModels> callback, Dictionary<string, object> customData = null, string language = null)
+        public bool ListVoiceModels(Callback<VoiceModels> callback, string language = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListVoiceModels`");
@@ -843,17 +805,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "ListVoiceModels"))
             {
@@ -937,11 +897,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="words">An array of `Word` objects that provides the words and their translations that are to be
         /// added or updated for the custom voice model. Pass an empty array to make no additions or updates.
         /// (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool UpdateVoiceModel(Callback<object> callback, string customizationId, Dictionary<string, object> customData = null, string name = null, string description = null, List<Word> words = null)
+        public bool UpdateVoiceModel(Callback<object> callback, string customizationId, string name = null, string description = null, List<Word> words = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateVoiceModel`");
@@ -952,17 +909,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "UpdateVoiceModel"))
             {
@@ -1056,11 +1011,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// part of speech, for any word; you cannot create multiple entries with different parts of speech for the same
         /// word. For more information, see [Working with Japanese
         /// entries](https://cloud.ibm.com/docs/services/text-to-speech/custom-rules.html#jaNotes). (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddWord(Callback<object> callback, string customizationId, string word, string translation, Dictionary<string, object> customData = null, string partOfSpeech = null)
+        public bool AddWord(Callback<object> callback, string customizationId, string word, string translation, string partOfSpeech = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddWord`");
@@ -1075,17 +1027,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPUT,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "AddWord"))
             {
@@ -1174,11 +1124,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// The **List custom words** method returns an array of `Word` objects. Each object shows a word and its
         /// translation from the custom voice model. The words are listed in alphabetical order, with uppercase letters
         /// listed before lowercase letters. The array is empty if the custom model contains no words.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddWords(Callback<object> callback, string customizationId, List<Word> words, Dictionary<string, object> customData = null)
+        public bool AddWords(Callback<object> callback, string customizationId, List<Word> words)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddWords`");
@@ -1191,17 +1138,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "AddWords"))
             {
@@ -1266,11 +1211,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
         /// request with service credentials created for the instance of the service that owns the custom model.</param>
         /// <param name="word">The word that is to be deleted from the custom voice model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteWord(Callback<object> callback, string customizationId, string word, Dictionary<string, object> customData = null)
+        public bool DeleteWord(Callback<object> callback, string customizationId, string word)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteWord`");
@@ -1283,17 +1225,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "DeleteWord"))
             {
@@ -1352,11 +1292,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
         /// request with service credentials created for the instance of the service that owns the custom model.</param>
         /// <param name="word">The word that is to be queried from the custom voice model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Translation" />Translation</returns>
-        public bool GetWord(Callback<Translation> callback, string customizationId, string word, Dictionary<string, object> customData = null)
+        public bool GetWord(Callback<Translation> callback, string customizationId, string word)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetWord`");
@@ -1369,17 +1306,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "GetWord"))
             {
@@ -1437,11 +1372,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
         /// request with service credentials created for the instance of the service that owns the custom model.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Words" />Words</returns>
-        public bool ListWords(Callback<Words> callback, string customizationId, Dictionary<string, object> customData = null)
+        public bool ListWords(Callback<Words> callback, string customizationId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListWords`");
@@ -1452,17 +1384,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "ListWords"))
             {
@@ -1521,11 +1451,8 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customerId">The customer ID for which all data is to be deleted.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteUserData(Callback<object> callback, string customerId, Dictionary<string, object> customData = null)
+        public bool DeleteUserData(Callback<object> callback, string customerId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteUserData`");
@@ -1536,17 +1463,15 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("text_to_speech", "V1", "DeleteUserData"))
             {

--- a/Scripts/Services/TextToSpeech/V1/TextToSpeechService.cs
+++ b/Scripts/Services/TextToSpeech/V1/TextToSpeechService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.TextToSpeech.V1
 {
-    public class TextToSpeechService : BaseService
+    public partial class TextToSpeechService : BaseService
     {
         private const string serviceId = "text_to_speech";
         private const string defaultUrl = "https://stream.watsonplatform.net/text-to-speech/api";
@@ -175,7 +175,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnGetVoiceResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Voice> response = new DetailedResponse<Voice>();
-            Dictionary<string, object> customData = ((RequestObject<Voice>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -186,14 +185,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Voice>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -202,7 +194,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<Voice>)req).Callback != null)
-                ((RequestObject<Voice>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Voice>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List voices.
@@ -260,7 +252,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnListVoicesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Voices> response = new DetailedResponse<Voices>();
-            Dictionary<string, object> customData = ((RequestObject<Voices>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -271,14 +262,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Voices>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -287,7 +271,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<Voices>)req).Callback != null)
-                ((RequestObject<Voices>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Voices>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Synthesize audio.
@@ -447,7 +431,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnSynthesizeResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<byte[]> response = new DetailedResponse<byte[]>();
-            Dictionary<string, object> customData = ((RequestObject<byte[]>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -457,7 +440,7 @@ namespace IBM.Watson.TextToSpeech.V1
             response.Result = resp.Data;
 
             if (((RequestObject<byte[]>)req).Callback != null)
-                ((RequestObject<byte[]>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<byte[]>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get pronunciation.
@@ -547,7 +530,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnGetPronunciationResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Pronunciation> response = new DetailedResponse<Pronunciation>();
-            Dictionary<string, object> customData = ((RequestObject<Pronunciation>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -558,14 +540,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Pronunciation>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -574,7 +549,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<Pronunciation>)req).Callback != null)
-                ((RequestObject<Pronunciation>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Pronunciation>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create a custom model.
@@ -652,7 +627,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnCreateVoiceModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<VoiceModel> response = new DetailedResponse<VoiceModel>();
-            Dictionary<string, object> customData = ((RequestObject<VoiceModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -663,14 +637,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<VoiceModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -679,7 +646,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<VoiceModel>)req).Callback != null)
-                ((RequestObject<VoiceModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<VoiceModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a custom model.
@@ -742,7 +709,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnDeleteVoiceModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -753,14 +719,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -769,7 +728,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get a custom model.
@@ -833,7 +792,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnGetVoiceModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<VoiceModel> response = new DetailedResponse<VoiceModel>();
-            Dictionary<string, object> customData = ((RequestObject<VoiceModel>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -844,14 +802,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<VoiceModel>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -860,7 +811,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<VoiceModel>)req).Callback != null)
-                ((RequestObject<VoiceModel>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<VoiceModel>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List custom models.
@@ -928,7 +879,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnListVoiceModelsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<VoiceModels> response = new DetailedResponse<VoiceModels>();
-            Dictionary<string, object> customData = ((RequestObject<VoiceModels>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -939,14 +889,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<VoiceModels>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -955,7 +898,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<VoiceModels>)req).Callback != null)
-                ((RequestObject<VoiceModels>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<VoiceModels>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update a custom model.
@@ -1052,7 +995,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnUpdateVoiceModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1063,14 +1005,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1079,7 +1014,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add a custom word.
@@ -1181,7 +1116,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnAddWordResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1192,14 +1126,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1208,7 +1135,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Add custom words.
@@ -1303,7 +1230,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnAddWordsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1314,14 +1240,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1330,7 +1249,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a custom word.
@@ -1396,7 +1315,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnDeleteWordResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1407,14 +1325,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1423,7 +1334,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Get a custom word.
@@ -1490,7 +1401,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnGetWordResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Translation> response = new DetailedResponse<Translation>();
-            Dictionary<string, object> customData = ((RequestObject<Translation>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1501,14 +1411,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Translation>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1517,7 +1420,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<Translation>)req).Callback != null)
-                ((RequestObject<Translation>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Translation>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// List custom words.
@@ -1581,7 +1484,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnListWordsResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Words> response = new DetailedResponse<Words>();
-            Dictionary<string, object> customData = ((RequestObject<Words>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1592,14 +1494,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Words>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1608,7 +1503,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<Words>)req).Callback != null)
-                ((RequestObject<Words>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Words>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete labeled data.
@@ -1677,7 +1572,6 @@ namespace IBM.Watson.TextToSpeech.V1
         private void OnDeleteUserDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1688,14 +1582,7 @@ namespace IBM.Watson.TextToSpeech.V1
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1704,7 +1591,7 @@ namespace IBM.Watson.TextToSpeech.V1
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/ToneAnalyzer/V3/ToneAnalyzerService.cs
+++ b/Scripts/Services/ToneAnalyzer/V3/ToneAnalyzerService.cs
@@ -28,7 +28,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.ToneAnalyzer.V3
 {
-    public class ToneAnalyzerService : BaseService
+    public partial class ToneAnalyzerService : BaseService
     {
         private const string serviceId = "tone_analyzer";
         private const string defaultUrl = "https://gateway.watsonplatform.net/tone-analyzer/api";
@@ -243,7 +243,6 @@ namespace IBM.Watson.ToneAnalyzer.V3
         private void OnToneResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ToneAnalysis> response = new DetailedResponse<ToneAnalysis>();
-            Dictionary<string, object> customData = ((RequestObject<ToneAnalysis>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -254,14 +253,7 @@ namespace IBM.Watson.ToneAnalyzer.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ToneAnalysis>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -270,7 +262,7 @@ namespace IBM.Watson.ToneAnalyzer.V3
             }
 
             if (((RequestObject<ToneAnalysis>)req).Callback != null)
-                ((RequestObject<ToneAnalysis>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ToneAnalysis>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Analyze customer engagement tone.
@@ -365,7 +357,6 @@ namespace IBM.Watson.ToneAnalyzer.V3
         private void OnToneChatResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<UtteranceAnalyses> response = new DetailedResponse<UtteranceAnalyses>();
-            Dictionary<string, object> customData = ((RequestObject<UtteranceAnalyses>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -376,14 +367,7 @@ namespace IBM.Watson.ToneAnalyzer.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<UtteranceAnalyses>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -392,7 +376,7 @@ namespace IBM.Watson.ToneAnalyzer.V3
             }
 
             if (((RequestObject<UtteranceAnalyses>)req).Callback != null)
-                ((RequestObject<UtteranceAnalyses>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<UtteranceAnalyses>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Scripts/Services/ToneAnalyzer/V3/ToneAnalyzerService.cs
+++ b/Scripts/Services/ToneAnalyzer/V3/ToneAnalyzerService.cs
@@ -170,11 +170,8 @@ namespace IBM.Watson.ToneAnalyzer.V3
         /// different languages for **Content-Language** and **Accept-Language**. (optional, default to en)</param>
         /// <param name="contentType">The type of the input. A character encoding can be specified by including a
         /// `charset` parameter. For example, 'text/plain;charset=utf-8'. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ToneAnalysis" />ToneAnalysis</returns>
-        public bool Tone(Callback<ToneAnalysis> callback, ToneInput toneInput, Dictionary<string, object> customData = null, bool? sentences = null, List<string> tones = null, string contentLanguage = null, string acceptLanguage = null, string contentType = null)
+        public bool Tone(Callback<ToneAnalysis> callback, ToneInput toneInput, bool? sentences = null, List<string> tones = null, string contentLanguage = null, string acceptLanguage = null, string contentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Tone`");
@@ -185,17 +182,15 @@ namespace IBM.Watson.ToneAnalyzer.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("tone_analyzer", "V3", "Tone"))
             {
@@ -292,11 +287,8 @@ namespace IBM.Watson.ToneAnalyzer.V3
         /// <param name="acceptLanguage">The desired language of the response. For two-character arguments, regional
         /// variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use
         /// different languages for **Content-Language** and **Accept-Language**. (optional, default to en)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="UtteranceAnalyses" />UtteranceAnalyses</returns>
-        public bool ToneChat(Callback<UtteranceAnalyses> callback, List<Utterance> utterances, Dictionary<string, object> customData = null, string contentLanguage = null, string acceptLanguage = null)
+        public bool ToneChat(Callback<UtteranceAnalyses> callback, List<Utterance> utterances, string contentLanguage = null, string acceptLanguage = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ToneChat`");
@@ -307,17 +299,15 @@ namespace IBM.Watson.ToneAnalyzer.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("tone_analyzer", "V3", "ToneChat"))
             {

--- a/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
+++ b/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
@@ -162,11 +162,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// <param name="acceptLanguage">The desired language of parts of the response. See the response for details.
         /// (optional, default to en)</param>
         /// <param name="imagesFileContentType">The content type of imagesFile. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="ClassifiedImages" />ClassifiedImages</returns>
-        public bool Classify(Callback<ClassifiedImages> callback, Dictionary<string, object> customData = null, System.IO.FileStream imagesFile = null, string url = null, float? threshold = null, List<string> owners = null, List<string> classifierIds = null, string acceptLanguage = null, string imagesFileContentType = null)
+        public bool Classify(Callback<ClassifiedImages> callback, System.IO.FileStream imagesFile = null, string url = null, float? threshold = null, List<string> owners = null, List<string> classifierIds = null, string acceptLanguage = null, string imagesFileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Classify`");
@@ -175,17 +172,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "Classify"))
             {
@@ -283,11 +278,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// <param name="acceptLanguage">The desired language of parts of the response. See the response for details.
         /// (optional, default to en)</param>
         /// <param name="imagesFileContentType">The content type of imagesFile. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="DetectedFaces" />DetectedFaces</returns>
-        public bool DetectFaces(Callback<DetectedFaces> callback, Dictionary<string, object> customData = null, System.IO.FileStream imagesFile = null, string url = null, string acceptLanguage = null, string imagesFileContentType = null)
+        public bool DetectFaces(Callback<DetectedFaces> callback, System.IO.FileStream imagesFile = null, string url = null, string acceptLanguage = null, string imagesFileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DetectFaces`");
@@ -296,17 +288,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "DetectFaces"))
             {
@@ -385,11 +375,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// classes of the new classifier. Must contain a minimum of 10 images.
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool CreateClassifier(Callback<Classifier> callback, string name, Dictionary<string, System.IO.FileStream> positiveExamples, Dictionary<string, object> customData = null, System.IO.FileStream negativeExamples = null)
+        public bool CreateClassifier(Callback<Classifier> callback, string name, System.IO.FileStream positiveExamples, System.IO.FileStream negativeExamples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateClassifier`");
@@ -404,17 +391,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "CreateClassifier"))
             {
@@ -480,11 +465,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">The ID of the classifier.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteClassifier(Callback<object> callback, string classifierId, Dictionary<string, object> customData = null)
+        public bool DeleteClassifier(Callback<object> callback, string classifierId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteClassifier`");
@@ -495,17 +477,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "DeleteClassifier"))
             {
@@ -556,11 +536,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">The ID of the classifier.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool GetClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, object> customData = null)
+        public bool GetClassifier(Callback<Classifier> callback, string classifierId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetClassifier`");
@@ -571,17 +548,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "GetClassifier"))
             {
@@ -631,11 +606,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="verbose">Specify `true` to return details about the classifiers. Omit this parameter to return
         /// a brief list of classifiers. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Classifiers" />Classifiers</returns>
-        public bool ListClassifiers(Callback<Classifiers> callback, Dictionary<string, object> customData = null, bool? verbose = null)
+        public bool ListClassifiers(Callback<Classifiers> callback, bool? verbose = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ListClassifiers`");
@@ -644,17 +616,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "ListClassifiers"))
             {
@@ -734,11 +704,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// classes of the new classifier. Must contain a minimum of 10 images.
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, object> customData = null, Dictionary<string, System.IO.FileStream> positiveExamples = null, System.IO.FileStream negativeExamples = null)
+        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, System.IO.FileStream positiveExamples = null, System.IO.FileStream negativeExamples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateClassifier`");
@@ -749,17 +716,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbPOST,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "UpdateClassifier"))
             {
@@ -824,11 +789,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">The ID of the classifier.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="byte[]" />byte[]</returns>
-        public bool GetCoreMlModel(Callback<byte[]> callback, string classifierId, Dictionary<string, object> customData = null)
+        public bool GetCoreMlModel(Callback<byte[]> callback, string classifierId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `GetCoreMlModel`");
@@ -839,17 +801,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbGET,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "GetCoreMlModel"))
             {
@@ -895,11 +855,8 @@ namespace IBM.Watson.VisualRecognition.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customerId">The customer ID for which all data is to be deleted.</param>
-        /// <param name="customData">A Dictionary<string, object> of data that will be passed to the callback. The raw
-        /// json output from the REST call will be passed in this object as the value of the 'json'
-        /// key.</string></param>
         /// <returns><see cref="object" />object</returns>
-        public bool DeleteUserData(Callback<object> callback, string customerId, Dictionary<string, object> customData = null)
+        public bool DeleteUserData(Callback<object> callback, string customerId)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DeleteUserData`");
@@ -910,17 +867,15 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 Callback = callback,
                 HttpMethod = UnityWebRequest.kHttpVerbDELETE,
-                DisableSslVerification = DisableSslVerification,
-                CustomData = customData == null ? new Dictionary<string, object>() : customData
+                DisableSslVerification = DisableSslVerification
             };
 
-            if (req.CustomData.ContainsKey(Constants.String.CUSTOM_REQUEST_HEADERS))
+            foreach (KeyValuePair<string, string> kvp in customRequestHeaders)
             {
-                foreach (KeyValuePair<string, string> kvp in req.CustomData[Constants.String.CUSTOM_REQUEST_HEADERS] as Dictionary<string, string>)
-                {
-                    req.Headers.Add(kvp.Key, kvp.Value);
-                }
+                req.Headers.Add(kvp.Key, kvp.Value);
             }
+
+            ClearCustomRequestHeaders();
 
             foreach (KeyValuePair<string, string> kvp in Common.GetSdkHeaders("watson_vision_combined", "V3", "DeleteUserData"))
             {

--- a/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
+++ b/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
@@ -376,7 +376,7 @@ namespace IBM.Watson.VisualRecognition.V3
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool CreateClassifier(Callback<Classifier> callback, string name, System.IO.FileStream positiveExamples, System.IO.FileStream negativeExamples = null)
+        public bool CreateClassifier(Callback<Classifier> callback, string name, Dictionary<string, System.IO.FileStream> positiveExamples, System.IO.FileStream negativeExamples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateClassifier`");
@@ -705,7 +705,7 @@ namespace IBM.Watson.VisualRecognition.V3
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, System.IO.FileStream positiveExamples = null, System.IO.FileStream negativeExamples = null)
+        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, System.IO.FileStream> positiveExamples = null, System.IO.FileStream negativeExamples = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateClassifier`");

--- a/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
+++ b/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
@@ -27,7 +27,7 @@ using UnityEngine.Networking;
 
 namespace IBM.Watson.VisualRecognition.V3
 {
-    public class VisualRecognitionService : BaseService
+    public partial class VisualRecognitionService : BaseService
     {
         private const string serviceId = "watson_vision_combined";
         private const string defaultUrl = "https://gateway.watsonplatform.net/visual-recognition/api";
@@ -229,7 +229,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnClassifyResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<ClassifiedImages> response = new DetailedResponse<ClassifiedImages>();
-            Dictionary<string, object> customData = ((RequestObject<ClassifiedImages>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -240,14 +239,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<ClassifiedImages>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -256,7 +248,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<ClassifiedImages>)req).Callback != null)
-                ((RequestObject<ClassifiedImages>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<ClassifiedImages>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Detect faces in images.
@@ -346,7 +338,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnDetectFacesResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<DetectedFaces> response = new DetailedResponse<DetectedFaces>();
-            Dictionary<string, object> customData = ((RequestObject<DetectedFaces>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -357,14 +348,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<DetectedFaces>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -373,7 +357,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<DetectedFaces>)req).Callback != null)
-                ((RequestObject<DetectedFaces>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<DetectedFaces>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Create a classifier.
@@ -470,7 +454,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnCreateClassifierResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Classifier> response = new DetailedResponse<Classifier>();
-            Dictionary<string, object> customData = ((RequestObject<Classifier>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -481,14 +464,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Classifier>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -497,7 +473,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<Classifier>)req).Callback != null)
-                ((RequestObject<Classifier>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Classifier>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete a classifier.
@@ -552,7 +528,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnDeleteClassifierResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -563,14 +538,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -579,7 +547,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Retrieve classifier details.
@@ -636,7 +604,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnGetClassifierResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Classifier> response = new DetailedResponse<Classifier>();
-            Dictionary<string, object> customData = ((RequestObject<Classifier>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -647,14 +614,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Classifier>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -663,7 +623,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<Classifier>)req).Callback != null)
-                ((RequestObject<Classifier>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Classifier>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Retrieve a list of classifiers.
@@ -721,7 +681,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnListClassifiersResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Classifiers> response = new DetailedResponse<Classifiers>();
-            Dictionary<string, object> customData = ((RequestObject<Classifiers>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -732,14 +691,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Classifiers>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -748,7 +700,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<Classifiers>)req).Callback != null)
-                ((RequestObject<Classifiers>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Classifiers>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Update a classifier.
@@ -843,7 +795,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnUpdateClassifierResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<Classifier> response = new DetailedResponse<Classifier>();
-            Dictionary<string, object> customData = ((RequestObject<Classifier>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -854,14 +805,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<Classifier>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -870,7 +814,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<Classifier>)req).Callback != null)
-                ((RequestObject<Classifier>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<Classifier>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Retrieve a Core ML model of a classifier.
@@ -928,7 +872,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnGetCoreMlModelResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<byte[]> response = new DetailedResponse<byte[]>();
-            Dictionary<string, object> customData = ((RequestObject<byte[]>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -938,7 +881,7 @@ namespace IBM.Watson.VisualRecognition.V3
             response.Result = resp.Data;
 
             if (((RequestObject<byte[]>)req).Callback != null)
-                ((RequestObject<byte[]>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<byte[]>)req).Callback(response, resp.Error);
         }
         /// <summary>
         /// Delete labeled data.
@@ -1004,7 +947,6 @@ namespace IBM.Watson.VisualRecognition.V3
         private void OnDeleteUserDataResponse(RESTConnector.Request req, RESTConnector.Response resp)
         {
             DetailedResponse<object> response = new DetailedResponse<object>();
-            Dictionary<string, object> customData = ((RequestObject<object>)req).CustomData;
             foreach (KeyValuePair<string, string> kvp in resp.Headers)
             {
                 response.Headers.Add(kvp.Key, kvp.Value);
@@ -1015,14 +957,7 @@ namespace IBM.Watson.VisualRecognition.V3
             {
                 string json = Encoding.UTF8.GetString(resp.Data);
                 response.Result = JsonConvert.DeserializeObject<object>(json);
-                if (!customData.ContainsKey("json"))
-                {
-                    customData.Add("json", json);
-                }
-                else
-                {
-                    customData["json"] = json;
-                }
+                response.Response = json;
             }
             catch (Exception e)
             {
@@ -1031,7 +966,7 @@ namespace IBM.Watson.VisualRecognition.V3
             }
 
             if (((RequestObject<object>)req).Callback != null)
-                ((RequestObject<object>)req).Callback(response, resp.Error, customData);
+                ((RequestObject<object>)req).Callback(response, resp.Error);
         }
     }
 }

--- a/Tests/AssistantV1IntegrationTests.cs
+++ b/Tests/AssistantV1IntegrationTests.cs
@@ -31,8 +31,6 @@ namespace IBM.Watson.Tests
     {
         private AssistantService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string workspaceId;
         private string createdWorkspaceName = "unity-sdk-example-workspace-delete";
         private string createdWorkspaceDescription = "A Workspace created by the Unity SDK Assistant example script. Please delete this.";
@@ -64,7 +62,6 @@ namespace IBM.Watson.Tests
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -82,8 +79,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         [UnityTest, Order(0)]
@@ -106,15 +102,13 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 workspaceId: workspaceId,
-                nodesVisitedDetails: true,
-                customData: customData
+                nodesVisitedDetails: true
             );
 
             while (messageResponse == null)
                 yield return null;
 
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
 
             messageResponse = null;
             JObject input = new JObject();
@@ -137,15 +131,13 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 input: input,
                 context: context as JObject,
-                nodesVisitedDetails: true,
-                customData: customData
+                nodesVisitedDetails: true
             );
 
             while (messageResponse == null)
                 yield return null;
 
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
 
             messageResponse = null;
             input = new JObject();
@@ -168,15 +160,13 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 input: input,
                 context: context as JObject,
-                nodesVisitedDetails: true,
-                customData: customData
+                nodesVisitedDetails: true
             );
 
             while (messageResponse == null)
                 yield return null;
 
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
 
             messageResponse = null;
             input = new JObject();
@@ -199,15 +189,13 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 input: input,
                 context: context as JObject,
-                nodesVisitedDetails: true,
-                customData: customData
+                nodesVisitedDetails: true
             );
 
             while (messageResponse == null)
                 yield return null;
 
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
 
             messageResponse = null;
             input = new JObject();
@@ -230,15 +218,13 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 input: input,
                 context: context as JObject,
-                nodesVisitedDetails: true,
-                customData: customData
+                nodesVisitedDetails: true
             );
 
             while (messageResponse == null)
                 yield return null;
 
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
 
             messageResponse = null;
             input = new JObject();
@@ -261,8 +247,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 input: input,
                 context: context as JObject,
-                nodesVisitedDetails: true,
-                customData: customData
+                nodesVisitedDetails: true
             );
 
             while (messageResponse == null)
@@ -290,8 +275,7 @@ namespace IBM.Watson.Tests
                 name: createdWorkspaceName,
                 description: createdWorkspaceDescription,
                 language: createdWorkspaceLanguage,
-                learningOptOut: true,
-                customData: customData
+                learningOptOut: true
             );
 
             while (createWorkspaceResponse == null)
@@ -318,8 +302,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 export: true,
                 includeAudit: true,
-                sort: "-name",
-                customData: customData
+                sort: "-name"
             );
 
             while (getWorkspaceResponse == null)
@@ -344,8 +327,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-name",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listWorkspacesResponse == null)
@@ -372,8 +354,7 @@ namespace IBM.Watson.Tests
                 description: updatedWorkspaceDescription,
                 language: createdWorkspaceLanguage,
                 learningOptOut: true,
-                append: false,
-                customData: customData
+                append: false
             );
 
             while (updateWorkspaceResponse == null)
@@ -397,8 +378,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 intent: createdIntentName,
-                description: createdIntentDescription,
-                customData: customData
+                description: createdIntentDescription
             );
 
             while (createIntentResponse == null)
@@ -423,8 +403,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 intent: createdIntentName,
                 export: true,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (getIntentResponse == null)
@@ -451,8 +430,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-name",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listIntentsResponse == null)
@@ -477,8 +455,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 intent: createdIntentName,
                 newIntent: updatedIntentName,
-                newDescription: updatedIntentDescription,
-                customData: customData
+                newDescription: updatedIntentDescription
             );
 
             while (updateIntentResponse == null)
@@ -501,8 +478,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 intent: updatedIntentName,
-                text: createdExampleText,
-                customData: customData
+                text: createdExampleText
             );
 
             while (createExampleResponse == null)
@@ -526,8 +502,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 intent: updatedIntentName,
                 text: createdExampleText,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (getExampleResponse == null)
@@ -554,8 +529,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-text",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listExamplesResponse == null)
@@ -579,8 +553,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 intent: updatedIntentName,
                 text: createdExampleText,
-                newText: updatedExampleText,
-                customData: customData
+                newText: updatedExampleText
             );
 
             while (updateExampleResponse == null)
@@ -602,8 +575,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 workspaceId: workspaceId,
-                text: createdCounterExampleText,
-                customData: customData
+                text: createdCounterExampleText
             );
 
             while (createCounterexampleResponse == null)
@@ -626,8 +598,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 text: createdCounterExampleText,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (getCounterexampleResponse == null)
@@ -653,8 +624,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-text",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listCounterexamplesResponse == null)
@@ -677,8 +647,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 text: createdCounterExampleText,
-                newText: updatedCounterExampleText,
-                customData: customData
+                newText: updatedCounterExampleText
             );
 
             while (updateCounterexampleResponse == null)
@@ -703,8 +672,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 entity: createdEntityName,
                 description: createdEntityDescription,
-                fuzzyMatch: true,
-                customData: customData
+                fuzzyMatch: true
             );
 
             while (createEntityResponse == null)
@@ -729,8 +697,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 entity: createdEntityName,
                 export: true,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (getEntityResponse == null)
@@ -757,8 +724,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-entity",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listEntitiesResponse == null)
@@ -784,8 +750,7 @@ namespace IBM.Watson.Tests
                 entity: createdEntityName,
                 newEntity: updatedEntityName,
                 newDescription: updatedEntityDescription,
-                newFuzzyMatch: true,
-                customData: customData
+                newFuzzyMatch: true
             );
 
             while (updateEntityResponse == null)
@@ -809,8 +774,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 entity: updatedEntityName,
                 export: true,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listMentionsResponse == null)
@@ -833,8 +797,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 entity: updatedEntityName,
-                value: createdValueText,
-                customData: customData
+                value: createdValueText
             );
 
             while (createValueResponse == null)
@@ -859,8 +822,7 @@ namespace IBM.Watson.Tests
                 entity: updatedEntityName,
                 value: createdValueText,
                 export: true,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (getValueResponse == null)
@@ -888,8 +850,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-value",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listValuesResponse == null)
@@ -913,8 +874,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 entity: updatedEntityName,
                 value: createdValueText,
-                newValue: updatedValueText,
-                customData: customData
+                newValue: updatedValueText
             );
 
             while (updateValueResponse == null)
@@ -938,9 +898,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 entity: updatedEntityName,
                 value: updatedValueText,
-                synonym: createdSynonymText,
-                customData: customData
-
+                synonym: createdSynonymText
             );
 
             while (createSynonymResponse == null)
@@ -965,8 +923,7 @@ namespace IBM.Watson.Tests
                 entity: updatedEntityName,
                 value: updatedValueText,
                 synonym: createdSynonymText,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (getSynonymResponse == null)
@@ -994,8 +951,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-synonym",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listSynonymsResponse == null)
@@ -1020,8 +976,7 @@ namespace IBM.Watson.Tests
                 entity: updatedEntityName,
                 value: updatedValueText,
                 synonym: createdSynonymText,
-                newSynonym: updatedSynonymText,
-                customData: customData
+                newSynonym: updatedSynonymText
             );
 
             while (updateSynonymResponse == null)
@@ -1045,8 +1000,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 dialogNode: createdDialogNode,
-                description: createdDialogNodeDescription,
-                customData: customData
+                description: createdDialogNodeDescription
             );
 
             while (createDialogNodeResponse == null)
@@ -1070,8 +1024,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 dialogNode: createdDialogNode,
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (getDialogNodeResponse == null)
@@ -1097,8 +1050,7 @@ namespace IBM.Watson.Tests
                 pageLimit: 1,
                 includeCount: true,
                 sort: "-dialog_node",
-                includeAudit: true,
-                customData: customData
+                includeAudit: true
             );
 
             while (listDialogNodesResponse == null)
@@ -1123,8 +1075,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 dialogNode: createdDialogNode,
                 newDialogNode: updatedDialogNode,
-                newDescription: updatedDialogNodeDescription,
-                customData: customData
+                newDescription: updatedDialogNodeDescription
             );
 
             while (updateDialogNodeResponse == null)
@@ -1145,8 +1096,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listAllLogsResponse.Logs);
                     Assert.IsNull(error);
                 },
-                filter: "(language::en,request.context.metadata.deployment::deployment_1)",
-                customData: customData
+                filter: "(language::en,request.context.metadata.deployment::deployment_1)"
             );
 
             while (listAllLogsResponse == null)
@@ -1169,8 +1119,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 filter: "(language::en,request.context.metadata.deployment::deployment_1)",
-                pageLimit: 1,
-                customData: customData
+                pageLimit: 1
             );
 
             while (listLogsResponse == null)
@@ -1190,8 +1139,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);
                 },
-                customerId: "test-customer-id",
-                customData: customData
+                customerId: "test-customer-id"
             );
 
             while (deleteUserDataResponse == null)
@@ -1213,8 +1161,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 workspaceId: workspaceId,
-                dialogNode: updatedDialogNode,
-                customData: customData
+                dialogNode: updatedDialogNode
             );
 
             while (deleteDialogNodeResponse == null)
@@ -1237,8 +1184,7 @@ namespace IBM.Watson.Tests
                 workspaceId: workspaceId,
                 entity: updatedEntityName,
                 value: updatedValueText,
-                synonym: updatedSynonymText,
-                customData: customData
+                synonym: updatedSynonymText
             );
 
             while (deleteSynonymResponse == null)
@@ -1260,8 +1206,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 entity: updatedEntityName,
-                value: updatedValueText,
-                customData: customData
+                value: updatedValueText
             );
 
             while (deleteValueResponse == null)
@@ -1282,8 +1227,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 workspaceId: workspaceId,
-                entity: updatedEntityName,
-                customData: customData
+                entity: updatedEntityName
             );
 
             while (deleteEntityResponse == null)
@@ -1304,8 +1248,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 workspaceId: workspaceId,
-                text: updatedCounterExampleText,
-                customData: customData
+                text: updatedCounterExampleText
             );
 
             while (deleteCounterexampleResponse == null)
@@ -1327,8 +1270,7 @@ namespace IBM.Watson.Tests
                 },
                 workspaceId: workspaceId,
                 intent: updatedIntentName,
-                text: updatedExampleText,
-                customData: customData
+                text: updatedExampleText
             );
 
             while (deleteExampleResponse == null)
@@ -1349,8 +1291,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 workspaceId: workspaceId,
-                intent: updatedIntentName,
-                customData: customData
+                intent: updatedIntentName
             );
 
             while (deleteIntentResponse == null)
@@ -1371,8 +1312,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(deleteWorkspaceResponse);
                     Assert.IsNull(error);
                 },
-                workspaceId: workspaceId,
-                customData: customData
+                workspaceId: workspaceId
             );
 
             while (deleteWorkspaceResponse == null)

--- a/Tests/AssistantV1IntegrationTests.cs
+++ b/Tests/AssistantV1IntegrationTests.cs
@@ -95,7 +95,7 @@ namespace IBM.Watson.Tests
             JToken conversationId = null;
             Log.Debug("AssistantV1IntegrationTests", "Attempting to Message...");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
                     messageResponse = response.Result;
                     context = messageResponse.Context;
@@ -122,7 +122,7 @@ namespace IBM.Watson.Tests
             input.Add("text", "Are you open on Christmas?");
             Log.Debug("AssistantV1IntegrationTests", "Attempting to Message...Are you open on Christmas?");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
                     messageResponse = response.Result;
                     context = messageResponse.Context;
@@ -153,7 +153,7 @@ namespace IBM.Watson.Tests
             input.Add("text", "What are your hours?");
             Log.Debug("AssistantV1IntegrationTests", "Attempting to Message...What are your hours?");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
                     messageResponse = response.Result;
                     context = messageResponse.Context;
@@ -184,7 +184,7 @@ namespace IBM.Watson.Tests
             input.Add("text", "I'd like to make an appointment for 12pm.");
             Log.Debug("AssistantV1IntegrationTests", "Attempting to Message...I'd like to make an appointment for 12pm.");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
                     messageResponse = response.Result;
                     context = messageResponse.Context;
@@ -215,7 +215,7 @@ namespace IBM.Watson.Tests
             input.Add("text", "On Friday please.");
             Log.Debug("AssistantV1IntegrationTests", "Attempting to Message...On Friday please.");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
                     messageResponse = response.Result;
                     context = messageResponse.Context;
@@ -246,7 +246,7 @@ namespace IBM.Watson.Tests
             input.Add("text", "Yes.");
             Log.Debug("AssistantV1IntegrationTests", "Attempting to Message...Yes.");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
                     messageResponse = response.Result;
                     context = messageResponse.Context;
@@ -275,9 +275,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateWorkspace...");
             Workspace createWorkspaceResponse = null;
             service.CreateWorkspace(
-                callback: (DetailedResponse<Workspace> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Workspace> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateWorkspace result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateWorkspace result: {0}", response.Response);
                     createWorkspaceResponse = response.Result;
                     workspaceId = createWorkspaceResponse.WorkspaceId;
                     Assert.IsNotNull(createWorkspaceResponse);
@@ -304,9 +304,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetWorkspace...");
             Workspace getWorkspaceResponse = null;
             service.GetWorkspace(
-                callback: (DetailedResponse<Workspace> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Workspace> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetWorkspace result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetWorkspace result: {0}", response.Response);
                     getWorkspaceResponse = response.Result;
                     Assert.IsNotNull(getWorkspaceResponse);
                     Assert.IsTrue(getWorkspaceResponse.WorkspaceId == workspaceId);
@@ -332,9 +332,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListWorkspaces...");
             WorkspaceCollection listWorkspacesResponse = null;
             service.ListWorkspaces(
-                callback: (DetailedResponse<WorkspaceCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<WorkspaceCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListWorkspaces result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListWorkspaces result: {0}", response.Response);
                     listWorkspacesResponse = response.Result;
                     Assert.IsNotNull(listWorkspacesResponse);
                     Assert.IsNotNull(listWorkspacesResponse.Workspaces);
@@ -358,9 +358,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateWorkspace...");
             Workspace updateWorkspaceResponse = null;
             service.UpdateWorkspace(
-                callback: (DetailedResponse<Workspace> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Workspace> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateWorkspace result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateWorkspace result: {0}", response.Response);
                     updateWorkspaceResponse = response.Result;
                     Assert.IsNotNull(updateWorkspaceResponse);
                     Assert.IsTrue(updateWorkspaceResponse.Name == updatedWorkspaceName);
@@ -386,9 +386,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateIntent...");
             Intent createIntentResponse = null;
             service.CreateIntent(
-                callback: (DetailedResponse<Intent> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Intent> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateIntent result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateIntent result: {0}", response.Response);
                     createIntentResponse = response.Result;
                     Assert.IsNotNull(createIntentResponse);
                     Assert.IsTrue(createIntentResponse._Intent == createdIntentName);
@@ -411,9 +411,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetIntent...");
             Intent getIntentResponse = null;
             service.GetIntent(
-                callback: (DetailedResponse<Intent> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Intent> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetIntent result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetIntent result: {0}", response.Response);
                     getIntentResponse = response.Result;
                     Assert.IsNotNull(getIntentResponse);
                     Assert.IsTrue(getIntentResponse._Intent == createdIntentName);
@@ -437,9 +437,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListIntents...");
             IntentCollection listIntentsResponse = null;
             service.ListIntents(
-                callback: (DetailedResponse<IntentCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<IntentCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListIntents result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListIntents result: {0}", response.Response);
                     listIntentsResponse = response.Result;
                     Assert.IsNotNull(listIntentsResponse);
                     Assert.IsNotNull(listIntentsResponse.Intents);
@@ -465,9 +465,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateIntent...");
             Intent updateIntentResponse = null;
             service.UpdateIntent(
-                callback: (DetailedResponse<Intent> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Intent> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateIntent result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateIntent result: {0}", response.Response);
                     updateIntentResponse = response.Result;
                     Assert.IsNotNull(updateIntentResponse);
                     Assert.IsTrue(updateIntentResponse._Intent == updatedIntentName);
@@ -491,9 +491,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateExample...");
             Example createExampleResponse = null;
             service.CreateExample(
-                callback: (DetailedResponse<Example> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Example> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateExample result: {0}", response.Response);
                     createExampleResponse = response.Result;
                     Assert.IsNotNull(createExampleResponse);
                     Assert.IsTrue(createExampleResponse.Text == createdExampleText);
@@ -515,9 +515,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetExample...");
             Example getExampleResponse = null;
             service.GetExample(
-                callback: (DetailedResponse<Example> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Example> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetExample result: {0}", response.Response);
                     getExampleResponse = response.Result;
                     Assert.IsNotNull(getExampleResponse);
                     Assert.IsTrue(getExampleResponse.Text == createdExampleText);
@@ -540,9 +540,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListExamples...");
             ExampleCollection listExamplesResponse = null;
             service.ListExamples(
-                callback: (DetailedResponse<ExampleCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ExampleCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListExamples result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListExamples result: {0}", response.Response);
                     listExamplesResponse = response.Result;
                     Assert.IsNotNull(listExamplesResponse);
                     Assert.IsNotNull(listExamplesResponse.Examples);
@@ -568,9 +568,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateExample...");
             Example updateExampleResponse = null;
             service.UpdateExample(
-                callback: (DetailedResponse<Example> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Example> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateExample result: {0}", response.Response);
                     updateExampleResponse = response.Result;
                     Assert.IsNotNull(updateExampleResponse);
                     Assert.IsTrue(updateExampleResponse.Text == updatedExampleText);
@@ -593,9 +593,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateCounterexample...");
             Counterexample createCounterexampleResponse = null;
             service.CreateCounterexample(
-                callback: (DetailedResponse<Counterexample> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Counterexample> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateCounterexample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateCounterexample result: {0}", response.Response);
                     createCounterexampleResponse = response.Result;
                     Assert.IsNotNull(createCounterexampleResponse);
                     Assert.IsTrue(createCounterexampleResponse.Text == createdCounterExampleText);
@@ -616,9 +616,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetCounterexample...");
             Counterexample getCounterexampleResponse = null;
             service.GetCounterexample(
-                callback: (DetailedResponse<Counterexample> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Counterexample> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetCounterexample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetCounterexample result: {0}", response.Response);
                     getCounterexampleResponse = response.Result;
                     Assert.IsNotNull(getCounterexampleResponse);
                     Assert.IsTrue(getCounterexampleResponse.Text == createdCounterExampleText);
@@ -640,9 +640,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListCounterexamples...");
             CounterexampleCollection listCounterexamplesResponse = null;
             service.ListCounterexamples(
-                callback: (DetailedResponse<CounterexampleCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<CounterexampleCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListCounterexamples result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListCounterexamples result: {0}", response.Response);
                     listCounterexamplesResponse = response.Result;
                     Assert.IsNotNull(listCounterexamplesResponse);
                     Assert.IsNotNull(listCounterexamplesResponse.Counterexamples);
@@ -667,9 +667,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateCounterexample...");
             Counterexample updateCounterexampleResponse = null;
             service.UpdateCounterexample(
-                callback: (DetailedResponse<Counterexample> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Counterexample> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateCounterexample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateCounterexample result: {0}", response.Response);
                     updateCounterexampleResponse = response.Result;
                     Assert.IsNotNull(updateCounterexampleResponse);
                     Assert.IsTrue(updateCounterexampleResponse.Text == updatedCounterExampleText);
@@ -691,9 +691,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateEntity...");
             Entity createEntityResponse = null;
             service.CreateEntity(
-                callback: (DetailedResponse<Entity> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Entity> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateEntity result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateEntity result: {0}", response.Response);
                     createEntityResponse = response.Result;
                     Assert.IsNotNull(createEntityResponse);
                     Assert.IsTrue(createEntityResponse._Entity == createdEntityName);
@@ -717,9 +717,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetEntity...");
             Entity getEntityResponse = null;
             service.GetEntity(
-                callback: (DetailedResponse<Entity> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Entity> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetEntity result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetEntity result: {0}", response.Response);
                     getEntityResponse = response.Result;
                     Assert.IsNotNull(getEntityResponse);
                     Assert.IsTrue(getEntityResponse._Entity == createdEntityName);
@@ -743,9 +743,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListEntities...");
             EntityCollection listEntitiesResponse = null;
             service.ListEntities(
-                callback: (DetailedResponse<EntityCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<EntityCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListEntities result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListEntities result: {0}", response.Response);
                     listEntitiesResponse = response.Result;
                     Assert.IsNotNull(listEntitiesResponse);
                     Assert.IsNotNull(listEntitiesResponse.Entities);
@@ -771,9 +771,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateEntity...");
             Entity updateEntityResponse = null;
             service.UpdateEntity(
-                callback: (DetailedResponse<Entity> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Entity> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateEntity result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateEntity result: {0}", response.Response);
                     updateEntityResponse = response.Result;
                     Assert.IsNotNull(updateEntityResponse);
                     Assert.IsTrue(updateEntityResponse._Entity == updatedEntityName);
@@ -798,9 +798,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListMentions...");
             EntityMentionCollection listMentionsResponse = null;
             service.ListMentions(
-                callback: (DetailedResponse<EntityMentionCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<EntityMentionCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListMentions result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListMentions result: {0}", response.Response);
                     listMentionsResponse = response.Result;
                     Assert.IsNotNull(listMentionsResponse);
                     Assert.IsNotNull(listMentionsResponse.Examples);
@@ -823,9 +823,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateValue...");
             Value createValueResponse = null;
             service.CreateValue(
-                callback: (DetailedResponse<Value> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Value> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateValue result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateValue result: {0}", response.Response);
                     createValueResponse = response.Result;
                     Assert.IsNotNull(createValueResponse);
                     Assert.IsTrue(createValueResponse._Value == createdValueText);
@@ -847,9 +847,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetValue...");
             Value getValueResponse = null;
             service.GetValue(
-                callback: (DetailedResponse<Value> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Value> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetValue result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetValue result: {0}", response.Response);
                     getValueResponse = response.Result;
                     Assert.IsNotNull(getValueResponse);
                     Assert.IsTrue(getValueResponse._Value == createdValueText);
@@ -873,9 +873,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListValues...");
             ValueCollection listValuesResponse = null;
             service.ListValues(
-                callback: (DetailedResponse<ValueCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ValueCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListValues result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListValues result: {0}", response.Response);
                     listValuesResponse = response.Result;
                     Assert.IsNotNull(listValuesResponse);
                     Assert.IsNotNull(listValuesResponse.Values);
@@ -902,9 +902,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateValue...");
             Value updateValueResponse = null;
             service.UpdateValue(
-                callback: (DetailedResponse<Value> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Value> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateValue result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateValue result: {0}", response.Response);
                     updateValueResponse = response.Result;
                     Assert.IsNotNull(updateValueResponse);
                     Assert.IsTrue(updateValueResponse._Value == updatedValueText);
@@ -927,9 +927,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateSynonym...");
             Synonym createSynonymResponse = null;
             service.CreateSynonym(
-                callback: (DetailedResponse<Synonym> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Synonym> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateSynonym result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateSynonym result: {0}", response.Response);
                     createSynonymResponse = response.Result;
                     Assert.IsNotNull(createSynonymResponse);
                     Assert.IsTrue(createSynonymResponse._Synonym == createdSynonymText);
@@ -953,9 +953,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetSynonym...");
             Synonym getSynonymResponse = null;
             service.GetSynonym(
-                callback: (DetailedResponse<Synonym> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Synonym> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetSynonym result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetSynonym result: {0}", response.Response);
                     getSynonymResponse = response.Result;
                     Assert.IsNotNull(getSynonymResponse);
                     Assert.IsTrue(getSynonymResponse._Synonym == createdSynonymText);
@@ -979,9 +979,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListSynonyms...");
             SynonymCollection listSynonymsResponse = null;
             service.ListSynonyms(
-                callback: (DetailedResponse<SynonymCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<SynonymCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListSynonyms result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListSynonyms result: {0}", response.Response);
                     listSynonymsResponse = response.Result;
                     Assert.IsNotNull(listSynonymsResponse);
                     Assert.IsNotNull(listSynonymsResponse.Synonyms);
@@ -1008,9 +1008,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateSynonym...");
             Synonym updateSynonymResponse = null;
             service.UpdateSynonym(
-                callback: (DetailedResponse<Synonym> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Synonym> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateSynonym result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateSynonym result: {0}", response.Response);
                     updateSynonymResponse = response.Result;
                     Assert.IsNotNull(updateSynonymResponse);
                     Assert.IsTrue(updateSynonymResponse._Synonym == updatedSynonymText);
@@ -1034,9 +1034,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to CreateDialogNode...");
             DialogNode createDialogNodeResponse = null;
             service.CreateDialogNode(
-                callback: (DetailedResponse<DialogNode> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DialogNode> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateDialogNode result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "CreateDialogNode result: {0}", response.Response);
                     createDialogNodeResponse = response.Result;
                     Assert.IsNotNull(createDialogNodeResponse);
                     Assert.IsTrue(createDialogNodeResponse._DialogNode == createdDialogNode);
@@ -1059,9 +1059,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to GetDialogNode...");
             DialogNode getDialogNodeResponse = null;
             service.GetDialogNode(
-                callback: (DetailedResponse<DialogNode> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DialogNode> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "GetDialogNode result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "GetDialogNode result: {0}", response.Response);
                     getDialogNodeResponse = response.Result;
                     Assert.IsNotNull(getDialogNodeResponse);
                     Assert.IsTrue(getDialogNodeResponse._DialogNode == createdDialogNode);
@@ -1084,9 +1084,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListDialogNodes...");
             DialogNodeCollection listDialogNodesResponse = null;
             service.ListDialogNodes(
-                callback: (DetailedResponse<DialogNodeCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DialogNodeCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListDialogNodes result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListDialogNodes result: {0}", response.Response);
                     listDialogNodesResponse = response.Result;
                     Assert.IsNotNull(listDialogNodesResponse);
                     Assert.IsNotNull(listDialogNodesResponse.DialogNodes);
@@ -1111,9 +1111,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to UpdateDialogNode...");
             DialogNode updateDialogNodeResponse = null;
             service.UpdateDialogNode(
-                callback: (DetailedResponse<DialogNode> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DialogNode> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateDialogNode result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "UpdateDialogNode result: {0}", response.Response);
                     updateDialogNodeResponse = response.Result;
                     Assert.IsNotNull(updateDialogNodeResponse);
                     Assert.IsTrue(updateDialogNodeResponse._DialogNode == updatedDialogNode);
@@ -1137,9 +1137,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListAllLogs...");
             LogCollection listAllLogsResponse = null;
             service.ListAllLogs(
-                callback: (DetailedResponse<LogCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<LogCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListAllLogs result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListAllLogs result: {0}", response.Response);
                     listAllLogsResponse = response.Result;
                     Assert.IsNotNull(listAllLogsResponse);
                     Assert.IsNotNull(listAllLogsResponse.Logs);
@@ -1159,9 +1159,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to ListLogs...");
             LogCollection listLogsResponse = null;
             service.ListLogs(
-                callback: (DetailedResponse<LogCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<LogCollection> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "ListLogs result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListLogs result: {0}", response.Response);
                     listLogsResponse = response.Result;
                     Assert.IsNotNull(listLogsResponse);
                     Assert.IsNotNull(listLogsResponse.Logs);
@@ -1183,9 +1183,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteUserData...");
             object deleteUserDataResponse = null;
             service.DeleteUserData(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteUserData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteUserData result: {0}", response.Response);
                     deleteUserDataResponse = response.Result;
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);
@@ -1205,9 +1205,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteDialogNode...");
             object deleteDialogNodeResponse = null;
             service.DeleteDialogNode(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteDialogNode result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteDialogNode result: {0}", response.Response);
                     deleteDialogNodeResponse = response.Result;
                     Assert.IsNotNull(deleteDialogNodeResponse);
                     Assert.IsNull(error);
@@ -1227,9 +1227,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteSynonym...");
             object deleteSynonymResponse = null;
             service.DeleteSynonym(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteSynonym result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteSynonym result: {0}", response.Response);
                     deleteSynonymResponse = response.Result;
                     Assert.IsNotNull(deleteSynonymResponse);
                     Assert.IsNull(error);
@@ -1251,9 +1251,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteValue...");
             object deleteValueResponse = null;
             service.DeleteValue(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteValue result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteValue result: {0}", response.Response);
                     deleteValueResponse = response.Result;
                     Assert.IsNotNull(deleteValueResponse);
                     Assert.IsNull(error);
@@ -1274,9 +1274,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteEntity...");
             object deleteEntityResponse = null;
             service.DeleteEntity(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteEntity result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteEntity result: {0}", response.Response);
                     deleteEntityResponse = response.Result;
                     Assert.IsNotNull(deleteEntityResponse);
                     Assert.IsNull(error);
@@ -1296,9 +1296,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteCounterexample...");
             object deleteCounterexampleResponse = null;
             service.DeleteCounterexample(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteCounterexample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteCounterexample result: {0}", response.Response);
                     deleteCounterexampleResponse = response.Result;
                     Assert.IsNotNull(deleteCounterexampleResponse);
                     Assert.IsNull(error);
@@ -1318,9 +1318,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteExample...");
             object deleteExampleResponse = null;
             service.DeleteExample(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteExample result: {0}", response.Response);
                     deleteExampleResponse = response.Result;
                     Assert.IsNotNull(deleteExampleResponse);
                     Assert.IsNull(error);
@@ -1341,9 +1341,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteIntent...");
             object deleteIntentResponse = null;
             service.DeleteIntent(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteIntent result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteIntent result: {0}", response.Response);
                     deleteIntentResponse = response.Result;
                     Assert.IsNotNull(response.Result);
                     Assert.IsNull(error);
@@ -1364,9 +1364,9 @@ namespace IBM.Watson.Tests
             Log.Debug("AssistantServiceV1IntegrationTests", "Attempting to DeleteWorkspace...");
             object deleteWorkspaceResponse = null;
             service.DeleteWorkspace(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteWorkspace result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("AssistantServiceV1IntegrationTests", "DeleteWorkspace result: {0}", response.Response);
                     deleteWorkspaceResponse = response.Result;
                     Assert.IsNotNull(deleteWorkspaceResponse);
                     Assert.IsNull(error);

--- a/Tests/AssistantV2IntegrationTests.cs
+++ b/Tests/AssistantV2IntegrationTests.cs
@@ -53,9 +53,9 @@ namespace IBM.Watson.Tests
             SessionResponse createSessionResponse = null;
             Log.Debug("AssistantV2IntegrationTests", "Attempting to CreateSession...");
             service.CreateSession(
-                callback: (DetailedResponse<SessionResponse> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<SessionResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     createSessionResponse = response.Result;
                     sessionId = createSessionResponse.SessionId;
                     Assert.IsNotNull(createSessionResponse);
@@ -71,9 +71,9 @@ namespace IBM.Watson.Tests
             MessageResponse messageResponse = null;
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -96,9 +96,9 @@ namespace IBM.Watson.Tests
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...Are you open on Christmas?");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -122,9 +122,9 @@ namespace IBM.Watson.Tests
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...What are your hours?");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -149,9 +149,9 @@ namespace IBM.Watson.Tests
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...I'd like to make an appointment for 12pm.");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -176,9 +176,9 @@ namespace IBM.Watson.Tests
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...On Friday please.");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -203,9 +203,9 @@ namespace IBM.Watson.Tests
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...Yes.");
             service.Message(
-                callback: (DetailedResponse<MessageResponse> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -221,9 +221,9 @@ namespace IBM.Watson.Tests
             object deleteSessionResponse = null;
             Log.Debug("AssistantV2IntegrationTests", "Attempting to DeleteSession...");
             service.DeleteSession(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", customData["json"].ToString());
+                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
                     deleteSessionResponse = response.Result;
                     Assert.IsNotNull(response.Result);
                     Assert.IsNull(error);

--- a/Tests/AssistantV2IntegrationTests.cs
+++ b/Tests/AssistantV2IntegrationTests.cs
@@ -52,6 +52,7 @@ namespace IBM.Watson.Tests
 
             SessionResponse createSessionResponse = null;
             Log.Debug("AssistantV2IntegrationTests", "Attempting to CreateSession...");
+            service.WithHeader("X-Watson-Test", "1");
             service.CreateSession(
                 callback: (DetailedResponse<SessionResponse> response, IBMError error) =>
                 {
@@ -70,6 +71,7 @@ namespace IBM.Watson.Tests
 
             MessageResponse messageResponse = null;
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...");
+            service.WithHeader("X-Watson-Test", "1");
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
@@ -95,6 +97,7 @@ namespace IBM.Watson.Tests
                 }
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...Are you open on Christmas?");
+            service.WithHeader("X-Watson-Test", "1");
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
@@ -121,6 +124,7 @@ namespace IBM.Watson.Tests
                 }
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...What are your hours?");
+            service.WithHeader("X-Watson-Test", "1");
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
@@ -148,6 +152,7 @@ namespace IBM.Watson.Tests
                 }
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...I'd like to make an appointment for 12pm.");
+            service.WithHeader("X-Watson-Test", "1");
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
@@ -175,6 +180,7 @@ namespace IBM.Watson.Tests
                 }
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...On Friday please.");
+            service.WithHeader("X-Watson-Test", "1");
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
@@ -202,6 +208,7 @@ namespace IBM.Watson.Tests
 
             };
             Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...Yes.");
+            service.WithHeader("X-Watson-Test", "1");
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
@@ -220,6 +227,7 @@ namespace IBM.Watson.Tests
 
             object deleteSessionResponse = null;
             Log.Debug("AssistantV2IntegrationTests", "Attempting to DeleteSession...");
+            service.WithHeader("X-Watson-Test", "1");
             service.DeleteSession(
                 callback: (DetailedResponse<object> response, IBMError error) =>
                 {

--- a/Tests/CompareComplyV1IntegrationTests.cs
+++ b/Tests/CompareComplyV1IntegrationTests.cs
@@ -84,9 +84,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(contractAFilepath))
             {
                 service.ConvertToHtml(
-                    callback: (DetailedResponse<HTMLReturn> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<HTMLReturn> response, IBMError error) =>
                     {
-                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ConvertToHtml result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ConvertToHtml result: {0}", response.Response);
                         convertToHtmlResponse = response.Result;
                         Assert.IsNotNull(convertToHtmlResponse);
                         Assert.IsNotNull(convertToHtmlResponse.Html);
@@ -113,9 +113,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(contractAFilepath))
             {
                 service.ClassifyElements(
-                    callback: (DetailedResponse<ClassifyReturn> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<ClassifyReturn> response, IBMError error) =>
                     {
-                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ClassifyElements result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ClassifyElements result: {0}", response.Response);
                         classifyElementsResponse = response.Result;
                         Assert.IsNotNull(classifyElementsResponse);
                         Assert.IsNotNull(classifyElementsResponse.Elements);
@@ -142,9 +142,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(tableFilepath))
             {
                 service.ExtractTables(
-                    callback: (DetailedResponse<TableReturn> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<TableReturn> response, IBMError error) =>
                     {
-                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ExtractTables result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ExtractTables result: {0}", response.Response);
                         extractTablesResponse = response.Result;
                         Assert.IsNotNull(extractTablesResponse);
                         Assert.IsNotNull(extractTablesResponse.Tables);
@@ -173,9 +173,9 @@ namespace IBM.Watson.Tests
                 using (FileStream fs1 = File.OpenRead(contractBFilepath))
                 {
                     service.CompareDocuments(
-                        callback: (DetailedResponse<CompareReturn> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                        callback: (DetailedResponse<CompareReturn> response, IBMError error) =>
                         {
-                            Log.Debug("CompareComplyServiceV1IntegrationTests", "CompareDocuments result: {0}", customResponseData["json"].ToString());
+                            Log.Debug("CompareComplyServiceV1IntegrationTests", "CompareDocuments result: {0}", response.Response);
                             compareDocumentsResponse = response.Result;
                             Assert.IsNotNull(compareDocumentsResponse);
                             Assert.IsNotNull(compareDocumentsResponse.Documents);
@@ -304,9 +304,9 @@ namespace IBM.Watson.Tests
             #endregion
 
             service.AddFeedback(
-                callback: (DetailedResponse<FeedbackReturn> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<FeedbackReturn> response, IBMError error) =>
                 {
-                    Log.Debug("CompareComplyServiceV1IntegrationTests", "AddFeedback result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("CompareComplyServiceV1IntegrationTests", "AddFeedback result: {0}", response.Response);
                     addFeedbackResponse = response.Result;
                     createdFeedbackId = addFeedbackResponse.FeedbackId;
                     Assert.IsNotNull(addFeedbackResponse);
@@ -331,9 +331,9 @@ namespace IBM.Watson.Tests
             Log.Debug("CompareComplyServiceV1IntegrationTests", "Attempting to GetFeedback...");
             GetFeedback getFeedbackResponse = null;
             service.GetFeedback(
-                callback: (DetailedResponse<GetFeedback> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<GetFeedback> response, IBMError error) =>
                 {
-                    Log.Debug("CompareComplyServiceV1IntegrationTests", "GetFeedback result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("CompareComplyServiceV1IntegrationTests", "GetFeedback result: {0}", response.Response);
                     getFeedbackResponse = response.Result;
                     Assert.IsNotNull(getFeedbackResponse);
                     Assert.IsTrue(getFeedbackResponse.FeedbackId == createdFeedbackId);
@@ -356,9 +356,9 @@ namespace IBM.Watson.Tests
             Log.Debug("CompareComplyServiceV1IntegrationTests", "Attempting to ListFeedback...");
             FeedbackList listFeedbackResponse = null;
             service.ListFeedback(
-                callback: (DetailedResponse<FeedbackList> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<FeedbackList> response, IBMError error) =>
                 {
-                    Log.Debug("CompareComplyServiceV1IntegrationTests", "ListFeedback result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("CompareComplyServiceV1IntegrationTests", "ListFeedback result: {0}", response.Response);
                     listFeedbackResponse = response.Result;
                     Assert.IsNotNull(listFeedbackResponse);
                     Assert.IsNotNull(listFeedbackResponse.Feedback);
@@ -386,9 +386,9 @@ namespace IBM.Watson.Tests
                 using (FileStream fsOutput = File.OpenRead(objectStorageCredentialsOutputFilepath))
                 {
                     service.CreateBatch(
-                        callback: (DetailedResponse<BatchStatus> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                        callback: (DetailedResponse<BatchStatus> response, IBMError error) =>
                         {
-                            Log.Debug("CompareComplyServiceV1IntegrationTests", "CreateBatch result: {0}", customResponseData["json"].ToString());
+                            Log.Debug("CompareComplyServiceV1IntegrationTests", "CreateBatch result: {0}", response.Response);
                             createBatchResponse = response.Result;
                             createdBatchId = createBatchResponse.BatchId;
                             Assert.IsNotNull(createBatchResponse);
@@ -419,9 +419,9 @@ namespace IBM.Watson.Tests
             Log.Debug("CompareComplyServiceV1IntegrationTests", "Attempting to GetBatch...");
             BatchStatus getBatchResponse = null;
             service.GetBatch(
-                callback: (DetailedResponse<BatchStatus> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<BatchStatus> response, IBMError error) =>
                 {
-                    Log.Debug("CompareComplyServiceV1IntegrationTests", "GetBatch result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("CompareComplyServiceV1IntegrationTests", "GetBatch result: {0}", response.Response);
                     getBatchResponse = response.Result;
                     Assert.IsNotNull(getBatchResponse);
                     Assert.IsTrue(getBatchResponse.BatchId == createdBatchId);
@@ -443,9 +443,9 @@ namespace IBM.Watson.Tests
             Log.Debug("CompareComplyServiceV1IntegrationTests", "Attempting to ListBatches...");
             Batches listBatchesResponse = null;
             service.ListBatches(
-                callback: (DetailedResponse<Batches> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Batches> response, IBMError error) =>
                 {
-                    Log.Debug("CompareComplyServiceV1IntegrationTests", "ListBatches result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("CompareComplyServiceV1IntegrationTests", "ListBatches result: {0}", response.Response);
                     listBatchesResponse = response.Result;
                     Assert.IsNotNull(listBatchesResponse);
                     Assert.IsNotNull(listBatchesResponse._Batches);
@@ -467,9 +467,9 @@ namespace IBM.Watson.Tests
             Log.Debug("CompareComplyServiceV1IntegrationTests", "Attempting to UpdateBatch...");
             BatchStatus updateBatchResponse = null;
             service.UpdateBatch(
-                callback: (DetailedResponse<BatchStatus> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<BatchStatus> response, IBMError error) =>
                 {
-                    Log.Debug("CompareComplyServiceV1IntegrationTests", "UpdateBatch result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("CompareComplyServiceV1IntegrationTests", "UpdateBatch result: {0}", response.Response);
                     updateBatchResponse = response.Result;
                     Assert.IsNotNull(updateBatchResponse);
                     Assert.IsNull(error);
@@ -492,9 +492,9 @@ namespace IBM.Watson.Tests
             Log.Debug("CompareComplyServiceV1IntegrationTests", "Attempting to DeleteFeedback...");
             FeedbackDeleted deleteFeedbackResponse = null;
             service.DeleteFeedback(
-                callback: (DetailedResponse<FeedbackDeleted> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<FeedbackDeleted> response, IBMError error) =>
                 {
-                    Log.Debug("CompareComplyServiceV1IntegrationTests", "DeleteFeedback result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("CompareComplyServiceV1IntegrationTests", "DeleteFeedback result: {0}", response.Response);
                     deleteFeedbackResponse = response.Result;
                     Assert.IsNotNull(deleteFeedbackResponse);
                     Assert.IsTrue(deleteFeedbackResponse.Status == 200);

--- a/Tests/CompareComplyV1IntegrationTests.cs
+++ b/Tests/CompareComplyV1IntegrationTests.cs
@@ -32,8 +32,6 @@ namespace IBM.Watson.Tests
     {
         private CompareComplyService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string contractAFilepath;
         private string contractBFilepath;
         private string tableFilepath;
@@ -46,7 +44,6 @@ namespace IBM.Watson.Tests
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
 
             contractAFilepath = Application.dataPath + "/Watson/Tests/TestData/CompareComplyV1/contract_A.pdf";
             contractBFilepath = Application.dataPath + "/Watson/Tests/TestData/CompareComplyV1/contract_B.pdf";
@@ -71,8 +68,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region ConvertToHtml
@@ -94,8 +90,7 @@ namespace IBM.Watson.Tests
                     },
                     file: fs,
                     modelId: "contracts",
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath)),
-                    customData: customData
+                    fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath))
                 );
 
                 while (convertToHtmlResponse == null)
@@ -123,8 +118,7 @@ namespace IBM.Watson.Tests
                     },
                     file: fs,
                     modelId: "contracts",
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath)),
-                    customData: customData
+                    fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath))
                 );
 
                 while (classifyElementsResponse == null)
@@ -152,8 +146,7 @@ namespace IBM.Watson.Tests
                     },
                     file: fs,
                     modelId: "tables",
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(tableFilepath)),
-                    customData: customData
+                    fileContentType: Utility.GetMimeType(Path.GetExtension(tableFilepath))
                 );
 
                 while (extractTablesResponse == null)
@@ -187,8 +180,7 @@ namespace IBM.Watson.Tests
                         file2Label: "Contract B",
                         modelId: "contracts",
                         file1ContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath)),
-                        file2ContentType: Utility.GetMimeType(Path.GetExtension(contractBFilepath)),
-                        customData: customData
+                        file2ContentType: Utility.GetMimeType(Path.GetExtension(contractBFilepath))
                     );
 
                     while (compareDocumentsResponse == null)
@@ -315,8 +307,7 @@ namespace IBM.Watson.Tests
                 },
                 feedbackData: feedbackData,
                 userId: "user_id_123x",
-                comment: "Test feedback comment",
-                customData: customData
+                comment: "Test feedback comment"
             );
 
             while (addFeedbackResponse == null)
@@ -340,8 +331,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 feedbackId: createdFeedbackId,
-                modelId: "contracts",
-                customData: customData
+                modelId: "contracts"
             );
 
             while (getFeedbackResponse == null)
@@ -366,8 +356,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 feedbackType: "element_classification",
-                includeTotal: true,
-                customData: customData
+                includeTotal: true
             );
 
             while (listFeedbackResponse == null)
@@ -402,8 +391,7 @@ namespace IBM.Watson.Tests
                         outputCredentialsFile: fsOutput,
                         outputBucketLocation: "us-south",
                         outputBucketName: "compare-comply-integration-test-bucket-output",
-                        modelId: "contracts",
-                        customData: customData
+                        modelId: "contracts"
                     );
                 }
             }
@@ -427,8 +415,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getBatchResponse.BatchId == createdBatchId);
                     Assert.IsNull(error);
                 },
-                batchId: createdBatchId,
-                customData: customData
+                batchId: createdBatchId
             );
 
             while (getBatchResponse == null)
@@ -451,8 +438,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listBatchesResponse._Batches);
                     Assert.IsTrue(listBatchesResponse._Batches.Count > 0);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (listBatchesResponse == null)
@@ -476,8 +462,7 @@ namespace IBM.Watson.Tests
                 },
                 batchId: createdBatchId,
                 action: "rescan",
-                modelId: "contracts",
-                customData: customData
+                modelId: "contracts"
             );
 
             while (updateBatchResponse == null)
@@ -502,8 +487,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 feedbackId: createdFeedbackId,
-                modelId: "contracts",
-                customData: customData
+                modelId: "contracts"
             );
 
             while (deleteFeedbackResponse == null)

--- a/Tests/CoreTests.cs
+++ b/Tests/CoreTests.cs
@@ -15,13 +15,27 @@
 *
 */
 
+using System.Collections;
 using System.Collections.Generic;
+using IBM.Cloud.SDK;
+using IBM.Watson.Assistant.V1;
+using IBM.Watson.Assistant.V1.Model;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 namespace IBM.Watson.Tests
 {
     public class CoreTests
     {
+        private AssistantService service;
+        private string versionDate = "2019-02-13";
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            LogSystem.InstallDefaultReactors();
+        }
+
         [Test]
         public void TestGetDefaultHeaders()
         {
@@ -29,6 +43,28 @@ namespace IBM.Watson.Tests
             Assert.IsNotNull(defaultHeaders);
             Assert.IsTrue(defaultHeaders["X-IBMCloud-SDK-Analytics"] == "service_name=TestSevice;service_version=V1;operation_id=TestOperation");
             Assert.IsNotNull(defaultHeaders["User-Agent"]);
+        }
+
+        [UnityTest]
+        public IEnumerator TestSetHeaders()
+        {
+            if (service == null)
+            {
+                service = new AssistantService(versionDate);
+            }
+
+            while (!service.Credentials.HasIamTokenData())
+                yield return null;
+
+            WorkspaceCollection listWorkspacesResponse = null;
+            service.WithHeader("myHeaderName", "myHeaderValue");
+            service.ListWorkspaces(
+                callback: (DetailedResponse<WorkspaceCollection> response, IBMError error) =>
+                {
+                    Log.Debug("AssistantServiceV1IntegrationTests", "ListWorkspaces result: {0}", response.Response);
+                    listWorkspacesResponse = response.Result;
+                }
+            );
         }
     }
 }

--- a/Tests/DiscoveryV1IntegrationTests.cs
+++ b/Tests/DiscoveryV1IntegrationTests.cs
@@ -34,8 +34,6 @@ namespace IBM.Watson.Tests
     {
         private DiscoveryService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string watsonBeatsJeopardyTxtFilePath;
         private string watsonBeatsJeopardyHtmlFilePath;
         private string stopwordsFilePath;
@@ -71,7 +69,6 @@ namespace IBM.Watson.Tests
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
             environmentId = Environment.GetEnvironmentVariable("DISCOVERY_ENVIRONMENT_ID");
             createdConfigurationName = Guid.NewGuid().ToString();
             updatedConfigurationName = createdConfigurationName + "-updated";
@@ -99,8 +96,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region CreateEnvironment
@@ -122,9 +118,7 @@ namespace IBM.Watson.Tests
                 },
                 name: createdEnvironmentName,
                 description: createdEnvironmentDescription,
-                size: "S",
-
-                customData: customData
+                size: "S"
             );
 
             while (createEnvironmentResponse == null)
@@ -147,8 +141,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getEnvironmentResponse.EnvironmentId == environmentId);
                     Assert.IsNull(error);
                 },
-                environmentId: environmentId,
-                customData: customData
+                environmentId: environmentId
             );
 
             while (getEnvironmentResponse == null)
@@ -171,8 +164,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listEnvironmentsResponse.Environments);
                     Assert.IsTrue(listEnvironmentsResponse.Environments.Count > 0);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (listEnvironmentsResponse == null)
@@ -201,9 +193,7 @@ namespace IBM.Watson.Tests
                 environmentId: environmentId,
                 name: updatedEnvironmentName,
                 description: updatedEnvironmentDescription,
-                size: "LT",
-
-                customData: customData
+                size: "LT"
             );
 
             while (updateEnvironmentResponse == null)
@@ -231,8 +221,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 name: createdConfigurationName,
-                description: createdConfigurationDescription,
-                customData: customData
+                description: createdConfigurationDescription
             );
 
             while (createConfigurationResponse == null)
@@ -258,8 +247,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                configurationId: createdConfigurationId,
-                customData: customData
+                configurationId: createdConfigurationId
             );
 
             while (getConfigurationResponse == null)
@@ -285,8 +273,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                name: createdConfigurationName,
-                customData: customData
+                name: createdConfigurationName
             );
 
             while (listConfigurationsResponse == null)
@@ -311,8 +298,7 @@ namespace IBM.Watson.Tests
                 environmentId: environmentId,
                 configurationId: createdConfigurationId,
                 name: updatedConfigurationName,
-                description: updatedConfigurationDescription,
-                customData: customData
+                description: updatedConfigurationDescription
             );
 
             while (updateConfigurationResponse == null)
@@ -336,14 +322,12 @@ namespace IBM.Watson.Tests
                         Assert.IsNotNull(testConfigurationInEnvironmentResponse);
                         Assert.IsNotNull(testConfigurationInEnvironmentResponse.Status);
                         Assert.IsNotNull(testConfigurationInEnvironmentResponse.Snapshots);
-                        Assert.IsTrue(testConfigurationInEnvironmentResponse.Snapshots.Count > 0);
                         Assert.IsNull(error);
                     },
                     environmentId: environmentId,
                     configurationId: createdConfigurationId,
                     file: fs,
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath)),
-                    customData: customData
+                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
                 );
 
                 while (testConfigurationInEnvironmentResponse == null)
@@ -376,8 +360,7 @@ namespace IBM.Watson.Tests
                 name: createdCollectionName,
                 description: createdCollectionDescription,
                 configurationId: createdConfigurationId,
-                language: "en",
-                customData: customData
+                language: "en"
             );
 
             while (createCollectionResponse == null)
@@ -409,8 +392,7 @@ namespace IBM.Watson.Tests
                 name: createdJapaneseCollectionName,
                 description: createdJapaneseCollectionDescription,
                 configurationId: createdConfigurationId,
-                language: "ja",
-                customData: customData
+                language: "ja"
             );
 
             while (createCollectionResponse == null)
@@ -437,8 +419,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (getCollectionResponse == null)
@@ -463,8 +444,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                name: createdCollectionName,
-                customData: customData
+                name: createdCollectionName
             );
 
             while (listCollectionsResponse == null)
@@ -494,8 +474,7 @@ namespace IBM.Watson.Tests
                 collectionId: collectionId,
                 name: updatedCollectionName,
                 description: updatedCollectionDescription,
-                configurationId: createdConfigurationId,
-                customData: customData
+                configurationId: createdConfigurationId
             );
 
             while (updateCollectionResponse == null)
@@ -519,8 +498,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionIds: new List<string>() { collectionId },
-                customData: customData
+                collectionIds: new List<string>() { collectionId }
             );
 
             while (listFieldsResponse == null)
@@ -544,8 +522,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (listCollectionFieldsResponse == null)
@@ -587,9 +564,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 collectionId: collectionId,
-                expansions: expansions,
-
-                customData: customData
+                expansions: expansions
             );
 
             while (createExpansionsResponse == null)
@@ -619,8 +594,7 @@ namespace IBM.Watson.Tests
                     },
                     environmentId: environmentId,
                     collectionId: collectionId,
-                    stopwordFile: fs,
-                    customData: customData
+                    stopwordFile: fs
                 );
 
                 while (createStopwordListResponse == null)
@@ -675,8 +649,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 collectionId: createdJapaneseCollectionId,
-                tokenizationRules: tokenizationRules,
-                customData: customData
+                tokenizationRules: tokenizationRules
             );
 
             while (createTokenizationDictionaryResponse == null)
@@ -708,8 +681,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (getStopwordListStatusResponse == null)
@@ -736,8 +708,7 @@ namespace IBM.Watson.Tests
 
                 },
                 environmentId: environmentId,
-                collectionId: createdJapaneseCollectionId,
-                customData: customData
+                collectionId: createdJapaneseCollectionId
             );
 
             while (getTokenizationDictionaryStatusResponse == null)
@@ -762,8 +733,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (listExpansionsResponse == null)
@@ -792,8 +762,7 @@ namespace IBM.Watson.Tests
                     environmentId: environmentId,
                     collectionId: collectionId,
                     file: fs,
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath)),
-                    customData: customData
+                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
                 );
 
                 while (addDocumentResponse == null)
@@ -819,8 +788,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 collectionId: collectionId,
-                documentId: addedDocumentId,
-                customData: customData
+                documentId: addedDocumentId
             );
 
             while (getDocumentStatusResponse == null)
@@ -849,8 +817,7 @@ namespace IBM.Watson.Tests
                     collectionId: collectionId,
                     documentId: addedDocumentId,
                     file: fs,
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath)),
-                    customData: customData
+                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
                 );
 
                 while (updateDocumentResponse == null)
@@ -880,8 +847,7 @@ namespace IBM.Watson.Tests
                 passages: true,
                 count: 10,
                 highlight: true,
-                loggingOptOut: true,
-                customData: customData
+                loggingOptOut: true
             );
 
             while (federatedQueryResponse == null)
@@ -907,8 +873,7 @@ namespace IBM.Watson.Tests
                 collectionIds: new List<string>() { collectionId },
                 naturalLanguageQuery: "When did Watson win Jeopardy",
                 count: 10,
-                highlight: true,
-                customData: customData
+                highlight: true
             );
 
             while (federatedQueryNoticesResponse == null)
@@ -937,8 +902,7 @@ namespace IBM.Watson.Tests
                 naturalLanguageQuery: "When did Watson win Jeopardy",
                 passages: true,
                 count: 10,
-                highlight: true,
-                customData: customData
+                highlight: true
             );
 
             while (queryResponse == null)
@@ -969,8 +933,7 @@ namespace IBM.Watson.Tests
                 collectionId: collectionId,
                 entity: entity,
                 feature: "disambiguate",
-                count: 10,
-                customData: customData
+                count: 10
             );
 
             while (queryEntitiesResponse == null)
@@ -997,8 +960,7 @@ namespace IBM.Watson.Tests
                 naturalLanguageQuery: "When did Watson win Jeopardy",
                 passages: true,
                 count: 10,
-                highlight: true,
-                customData: customData
+                highlight: true
             );
 
             while (queryNoticesResponse == null)
@@ -1030,8 +992,7 @@ namespace IBM.Watson.Tests
                 environmentId: environmentId,
                 collectionId: collectionId,
                 entities: entities,
-                count: 10,
-                customData: customData
+                count: 10
             );
 
             while (queryRelationsResponse == null)
@@ -1067,8 +1028,7 @@ namespace IBM.Watson.Tests
                 environmentId: environmentId,
                 collectionId: collectionId,
                 naturalLanguageQuery: "When did Watson win Jeopardy",
-                examples: examples,
-                customData: customData
+                examples: examples
             );
 
             while (addTrainingDataResponse == null)
@@ -1096,8 +1056,7 @@ namespace IBM.Watson.Tests
                 collectionId: collectionId,
                 queryId: queryId,
                 documentId: addedDocumentId,
-                relevance: 2,
-                customData: customData
+                relevance: 2
             );
 
             while (createTrainingExampleResponse == null)
@@ -1123,8 +1082,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 collectionId: collectionId,
-                queryId: queryId,
-                customData: customData
+                queryId: queryId
             );
 
             while (getTrainingDataResponse == null)
@@ -1150,8 +1108,7 @@ namespace IBM.Watson.Tests
                 environmentId: environmentId,
                 collectionId: collectionId,
                 queryId: queryId,
-                exampleId: addedDocumentId,
-                customData: customData
+                exampleId: addedDocumentId
             );
 
             while (getTrainingExampleResponse == null)
@@ -1176,8 +1133,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (listTrainingDataResponse == null)
@@ -1203,8 +1159,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 collectionId: collectionId,
-                queryId: queryId,
-                customData: customData
+                queryId: queryId
             );
 
             while (listTrainingExamplesResponse == null)
@@ -1231,8 +1186,7 @@ namespace IBM.Watson.Tests
                 collectionId: collectionId,
                 queryId: queryId,
                 exampleId: addedDocumentId,
-                relevance: 3,
-                customData: customData
+                relevance: 3
             );
 
             while (updateTrainingExampleResponse == null)
@@ -1263,8 +1217,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 type: "click",
-                data: data,
-                customData: customData
+                data: data
             );
 
             while (createEventResponse == null)
@@ -1287,8 +1240,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(getMetricsEventRateResponse.Aggregations);
                     Assert.IsNull(error);
                 },
-                resultType: "document",
-                customData: customData
+                resultType: "document"
             );
 
             while (getMetricsEventRateResponse == null)
@@ -1311,8 +1263,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(getMetricsQueryResponse.Aggregations);
                     Assert.IsNull(error);
                 },
-                resultType: "document",
-                customData: customData
+                resultType: "document"
             );
 
             while (getMetricsQueryResponse == null)
@@ -1335,8 +1286,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(getMetricsQueryEventResponse.Aggregations);
                     Assert.IsNull(error);
                 },
-                resultType: "document",
-                customData: customData
+                resultType: "document"
             );
 
             while (getMetricsQueryEventResponse == null)
@@ -1359,8 +1309,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(getMetricsQueryNoResultsResponse.Aggregations);
                     Assert.IsNull(error);
                 },
-                resultType: "document",
-                customData: customData
+                resultType: "document"
             );
 
             while (getMetricsQueryNoResultsResponse == null)
@@ -1383,8 +1332,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(getMetricsQueryTokenEventResponse.Aggregations);
                     Assert.IsNull(error);
                 },
-                count: 10,
-                customData: customData
+                count: 10
             );
 
             while (getMetricsQueryTokenEventResponse == null)
@@ -1408,8 +1356,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 query: "When did Watson beat Jeopardy",
-                count: 10,
-                customData: customData
+                count: 10
             );
 
             while (queryLogResponse == null)
@@ -1445,9 +1392,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 sourceType: "box",
-                credentialDetails: credentialDetails,
-
-                customData: customData
+                credentialDetails: credentialDetails
             );
 
             while (createCredentialsResponse == null)
@@ -1472,8 +1417,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                credentialId: credentialId,
-                customData: customData
+                credentialId: credentialId
             );
 
             while (getCredentialsResponse == null)
@@ -1497,8 +1441,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listCredentialsResponse._Credentials.Count > 0);
                     Assert.IsNull(error);
                 },
-                environmentId: environmentId,
-                customData: customData
+                environmentId: environmentId
             );
 
             while (listCredentialsResponse == null)
@@ -1536,8 +1479,7 @@ namespace IBM.Watson.Tests
                 environmentId: environmentId,
                 credentialId: credentialId,
                 sourceType: "box",
-                credentialDetails: credentialDetails,
-                customData: customData
+                credentialDetails: credentialDetails
             );
 
             while (updateCredentialsResponse == null)
@@ -1561,8 +1503,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(gatewayId);
                     Assert.IsNull(error);
                 },
-                environmentId: environmentId,
-                customData: customData
+                environmentId: environmentId
             );
 
             while (createGatewayResponse == null)
@@ -1586,8 +1527,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                gatewayId: gatewayId,
-                customData: customData
+                gatewayId: gatewayId
             );
 
             while (getGatewayResponse == null)
@@ -1611,8 +1551,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listGatewaysResponse.Gateways.Count > 0);
                     Assert.IsNull(error);
                 },
-                environmentId: environmentId,
-                customData: customData
+                environmentId: environmentId
             );
 
             while (listGatewaysResponse == null)
@@ -1637,8 +1576,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                gatewayId: gatewayId,
-                customData: customData
+                gatewayId: gatewayId
             );
 
             while (deleteGatewayResponse == null)
@@ -1663,8 +1601,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                credentialId: credentialId,
-                customData: customData
+                credentialId: credentialId
             );
 
             while (deleteCredentialsResponse == null)
@@ -1685,8 +1622,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                     isComplete = true;
                 },
-                customerId: "customerId",
-                customData: customData
+                customerId: "customerId"
             );
 
             while (!isComplete)
@@ -1710,8 +1646,7 @@ namespace IBM.Watson.Tests
                 environmentId: environmentId,
                 collectionId: collectionId,
                 queryId: queryId,
-                exampleId: addedDocumentId,
-                customData: customData
+                exampleId: addedDocumentId
             );
 
             while (!isComplete)
@@ -1734,8 +1669,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 collectionId: collectionId,
-                queryId: queryId,
-                customData: customData
+                queryId: queryId
             );
 
             while (!isComplete)
@@ -1757,8 +1691,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (!isComplete)
@@ -1784,8 +1717,7 @@ namespace IBM.Watson.Tests
                 },
                 environmentId: environmentId,
                 collectionId: collectionId,
-                documentId: addedDocumentId,
-                customData: customData
+                documentId: addedDocumentId
             );
 
             while (deleteDocumentResponse == null)
@@ -1808,8 +1740,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 environmentId: environmentId,
-                collectionId: createdJapaneseCollectionId,
-                customData: customData
+                collectionId: createdJapaneseCollectionId
             );
 
             while (!isComplete)
@@ -1832,8 +1763,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (!isComplete)
@@ -1855,8 +1785,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (!isComplete)
@@ -1882,8 +1811,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionId: createdJapaneseCollectionId,
-                customData: customData
+                collectionId: createdJapaneseCollectionId
             );
 
             while (deleteCollectionResponse == null)
@@ -1909,8 +1837,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
 
             while (deleteCollectionResponse == null)
@@ -1933,8 +1860,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 environmentId: environmentId,
-                configurationId: createdConfigurationId,
-                customData: customData
+                configurationId: createdConfigurationId
             );
 
             while (deleteConfigurationResponse == null)
@@ -1957,8 +1883,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(deleteEnvironmentResponse);
                     Assert.IsNull(error);
                 },
-                environmentId: createdEnvironmentId,
-                customData: customData
+                environmentId: createdEnvironmentId
             );
 
             while (deleteEnvironmentResponse == null)
@@ -1990,8 +1915,7 @@ namespace IBM.Watson.Tests
                     getTokenizationDictionaryStatusResponse = response.Result;
                 },
                 environmentId: environmentId,
-                collectionId: collectionId,
-                customData: customData
+                collectionId: collectionId
             );
             }
             catch
@@ -2015,8 +1939,7 @@ namespace IBM.Watson.Tests
                 service.GetStopwordListStatus(
                     callback: OnCheckStopwordsListStatus,
                     environmentId: environmentId,
-                    collectionId: collectionId,
-                    customData: customData
+                    collectionId: collectionId
                 );
             }
             catch
@@ -2057,8 +1980,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listCollectionsResponse.Collections.Count > 0);
                     Assert.IsNull(error);
                 },
-                environmentId: environmentId,
-                customData: customData
+                environmentId: environmentId
             );
 
             while (listCollectionsResponse == null)
@@ -2080,8 +2002,7 @@ namespace IBM.Watson.Tests
                         count++;
                     },
                     environmentId: environmentId,
-                    collectionId: collectionId,
-                    customData: customData
+                    collectionId: collectionId
                 );
 
             while (count < collectionIdsToDelete.Count)

--- a/Tests/DiscoveryV1IntegrationTests.cs
+++ b/Tests/DiscoveryV1IntegrationTests.cs
@@ -111,9 +111,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to CreateEnvironment...");
             ModelEnvironment createEnvironmentResponse = null;
             service.CreateEnvironment(
-                callback: (DetailedResponse<ModelEnvironment> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ModelEnvironment> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateEnvironment result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateEnvironment result: {0}", response.Response);
                     createEnvironmentResponse = response.Result;
                     createdEnvironmentId = createEnvironmentResponse.EnvironmentId;
                     Assert.IsNotNull(createEnvironmentResponse);
@@ -139,9 +139,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetEnvironment...");
             ModelEnvironment getEnvironmentResponse = null;
             service.GetEnvironment(
-                callback: (DetailedResponse<ModelEnvironment> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ModelEnvironment> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetEnvironment result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetEnvironment result: {0}", response.Response);
                     getEnvironmentResponse = response.Result;
                     Assert.IsNotNull(getEnvironmentResponse);
                     Assert.IsTrue(getEnvironmentResponse.EnvironmentId == environmentId);
@@ -163,9 +163,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListEnvironments...");
             ListEnvironmentsResponse listEnvironmentsResponse = null;
             service.ListEnvironments(
-                callback: (DetailedResponse<ListEnvironmentsResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ListEnvironmentsResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListEnvironments result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListEnvironments result: {0}", response.Response);
                     listEnvironmentsResponse = response.Result;
                     Assert.IsNotNull(listEnvironmentsResponse);
                     Assert.IsNotNull(listEnvironmentsResponse.Environments);
@@ -188,9 +188,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to UpdateEnvironment...");
             ModelEnvironment updateEnvironmentResponse = null;
             service.UpdateEnvironment(
-                callback: (DetailedResponse<ModelEnvironment> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ModelEnvironment> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateEnvironment result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateEnvironment result: {0}", response.Response);
                     updateEnvironmentResponse = response.Result;
                     Assert.IsNotNull(updateEnvironmentResponse);
                     Assert.IsTrue(updateEnvironmentResponse.Name == updatedEnvironmentName);
@@ -218,9 +218,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to CreateConfiguration...");
             Configuration createConfigurationResponse = null;
             service.CreateConfiguration(
-                callback: (DetailedResponse<Configuration> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Configuration> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateConfiguration result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateConfiguration result: {0}", response.Response);
                     createConfigurationResponse = response.Result;
                     createdConfigurationId = createConfigurationResponse.ConfigurationId;
                     Assert.IsNotNull(createConfigurationResponse);
@@ -247,9 +247,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetConfiguration...");
             Configuration getConfigurationResponse = null;
             service.GetConfiguration(
-                callback: (DetailedResponse<Configuration> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Configuration> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetConfiguration result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetConfiguration result: {0}", response.Response);
                     getConfigurationResponse = response.Result;
                     Assert.IsNotNull(getConfigurationResponse);
                     Assert.IsTrue(getConfigurationResponse.ConfigurationId == createdConfigurationId);
@@ -274,9 +274,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListConfigurations...");
             ListConfigurationsResponse listConfigurationsResponse = null;
             service.ListConfigurations(
-                callback: (DetailedResponse<ListConfigurationsResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ListConfigurationsResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListConfigurations result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListConfigurations result: {0}", response.Response);
                     listConfigurationsResponse = response.Result;
                     Assert.IsNotNull(listConfigurationsResponse);
                     Assert.IsNotNull(listConfigurationsResponse.Configurations);
@@ -301,9 +301,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to UpdateConfiguration...");
             Configuration updateConfigurationResponse = null;
             service.UpdateConfiguration(
-                callback: (DetailedResponse<Configuration> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Configuration> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateConfiguration result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateConfiguration result: {0}", response.Response);
                     updateConfigurationResponse = response.Result;
                     Assert.IsNotNull(updateConfigurationResponse);
                     Assert.IsNull(error);
@@ -329,9 +329,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(watsonBeatsJeopardyHtmlFilePath))
             {
                 service.TestConfigurationInEnvironment(
-                    callback: (DetailedResponse<TestDocument> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<TestDocument> response, IBMError error) =>
                     {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "TestConfigurationInEnvironment result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("DiscoveryServiceV1IntegrationTests", "TestConfigurationInEnvironment result: {0}", response.Response);
                         testConfigurationInEnvironmentResponse = response.Result;
                         Assert.IsNotNull(testConfigurationInEnvironmentResponse);
                         Assert.IsNotNull(testConfigurationInEnvironmentResponse.Status);
@@ -359,9 +359,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to CreateCollection...");
             Collection createCollectionResponse = null;
             service.CreateCollection(
-                callback: (DetailedResponse<Collection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Collection> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateCollection result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateCollection result: {0}", response.Response);
                     createCollectionResponse = response.Result;
                     collectionId = createCollectionResponse.CollectionId;
                     Assert.IsNotNull(createCollectionResponse);
@@ -392,9 +392,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to CreateJapaneseCollection...");
             Collection createCollectionResponse = null;
             service.CreateCollection(
-                callback: (DetailedResponse<Collection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Collection> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateCollection result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateCollection result: {0}", response.Response);
                     createCollectionResponse = response.Result;
                     createdJapaneseCollectionId = createCollectionResponse.CollectionId;
                     Assert.IsNotNull(createCollectionResponse);
@@ -425,9 +425,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetCollection...");
             Collection getCollectionResponse = null;
             service.GetCollection(
-                callback: (DetailedResponse<Collection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Collection> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetCollection result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetCollection result: {0}", response.Response);
                     getCollectionResponse = response.Result;
                     Assert.IsNotNull(getCollectionResponse);
                     Assert.IsTrue(getCollectionResponse.Name == createdCollectionName);
@@ -453,9 +453,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListCollections...");
             ListCollectionsResponse listCollectionsResponse = null;
             service.ListCollections(
-                callback: (DetailedResponse<ListCollectionsResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ListCollectionsResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCollections result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCollections result: {0}", response.Response);
                     listCollectionsResponse = response.Result;
                     Assert.IsNotNull(listCollectionsResponse);
                     Assert.IsNotNull(listCollectionsResponse.Collections);
@@ -479,9 +479,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to UpdateCollection...");
             Collection updateCollectionResponse = null;
             service.UpdateCollection(
-                callback: (DetailedResponse<Collection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Collection> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateCollection result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateCollection result: {0}", response.Response);
                     updateCollectionResponse = response.Result;
                     Assert.IsNotNull(updateCollectionResponse);
                     Assert.IsTrue(updateCollectionResponse.Name == updatedCollectionName);
@@ -510,9 +510,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListFields...");
             ListCollectionFieldsResponse listFieldsResponse = null;
             service.ListFields(
-                callback: (DetailedResponse<ListCollectionFieldsResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ListCollectionFieldsResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListFields result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListFields result: {0}", response.Response);
                     listFieldsResponse = response.Result;
                     Assert.IsNotNull(listFieldsResponse);
                     Assert.IsNotNull(listFieldsResponse.Fields);
@@ -535,9 +535,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListCollectionFields...");
             ListCollectionFieldsResponse listCollectionFieldsResponse = null;
             service.ListCollectionFields(
-                callback: (DetailedResponse<ListCollectionFieldsResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ListCollectionFieldsResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCollectionFields result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCollectionFields result: {0}", response.Response);
                     listCollectionFieldsResponse = response.Result;
                     Assert.IsNotNull(listCollectionFieldsResponse);
                     Assert.IsNotNull(listCollectionFieldsResponse.Fields);
@@ -574,9 +574,9 @@ namespace IBM.Watson.Tests
                 }
             };
             service.CreateExpansions(
-                callback: (DetailedResponse<Expansions> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Expansions> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateExpansions result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateExpansions result: {0}", response.Response);
                     createExpansionsResponse = response.Result;
                     Assert.IsNotNull(createExpansionsResponse);
                     Assert.IsNotNull(createExpansionsResponse._Expansions);
@@ -608,9 +608,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(stopwordsFilePath))
             {
                 service.CreateStopwordList(
-                    callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error) =>
                     {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateStopwordList result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateStopwordList result: {0}", response.Response);
                         createStopwordListResponse = response.Result;
                         Assert.IsNotNull(createStopwordListResponse);
                         Assert.IsNotNull(createStopwordListResponse.Status);
@@ -664,9 +664,9 @@ namespace IBM.Watson.Tests
             #endregion
 
             service.CreateTokenizationDictionary(
-                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateTokenizationDictionary result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateTokenizationDictionary result: {0}", response.Response);
                     createTokenizationDictionaryResponse = response.Result;
                     Assert.IsNotNull(createTokenizationDictionaryResponse);
                     Assert.IsNotNull(createTokenizationDictionaryResponse.Status);
@@ -698,9 +698,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetStopwordListStatus...");
             TokenDictStatusResponse getStopwordListStatusResponse = null;
             service.GetStopwordListStatus(
-                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetStopwordListStatus result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetStopwordListStatus result: {0}", response.Response);
                     getStopwordListStatusResponse = response.Result;
                     Assert.IsNotNull(getStopwordListStatusResponse);
                     Assert.IsNotNull(getStopwordListStatusResponse.Status);
@@ -725,9 +725,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetTokenizationDictionaryStatus...");
             TokenDictStatusResponse getTokenizationDictionaryStatusResponse = null;
             service.GetTokenizationDictionaryStatus(
-                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTokenizationDictionaryStatus result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTokenizationDictionaryStatus result: {0}", response.Response);
                     getTokenizationDictionaryStatusResponse = response.Result;
                     Assert.IsNotNull(getTokenizationDictionaryStatusResponse);
                     Assert.IsNotNull(getTokenizationDictionaryStatusResponse.Status);
@@ -752,9 +752,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListExpansions...");
             Expansions listExpansionsResponse = null;
             service.ListExpansions(
-                callback: (DetailedResponse<Expansions> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Expansions> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListExpansions result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListExpansions result: {0}", response.Response);
                     listExpansionsResponse = response.Result;
                     Assert.IsNotNull(listExpansionsResponse);
                     Assert.IsNotNull(listExpansionsResponse._Expansions);
@@ -780,9 +780,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(watsonBeatsJeopardyHtmlFilePath))
             {
                 service.AddDocument(
-                    callback: (DetailedResponse<DocumentAccepted> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<DocumentAccepted> response, IBMError error) =>
                     {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "AddDocument result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("DiscoveryServiceV1IntegrationTests", "AddDocument result: {0}", response.Response);
                         addDocumentResponse = response.Result;
                         addedDocumentId = addDocumentResponse.DocumentId;
                         Assert.IsNotNull(addDocumentResponse);
@@ -809,9 +809,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetDocumentStatus...");
             DocumentStatus getDocumentStatusResponse = null;
             service.GetDocumentStatus(
-                callback: (DetailedResponse<DocumentStatus> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DocumentStatus> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetDocumentStatus result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetDocumentStatus result: {0}", response.Response);
                     getDocumentStatusResponse = response.Result;
                     Assert.IsNotNull(getDocumentStatusResponse);
                     Assert.IsTrue(getDocumentStatusResponse.DocumentId == addedDocumentId);
@@ -837,9 +837,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(watsonBeatsJeopardyHtmlFilePath))
             {
                 service.UpdateDocument(
-                    callback: (DetailedResponse<DocumentAccepted> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<DocumentAccepted> response, IBMError error) =>
                     {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateDocument result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateDocument result: {0}", response.Response);
                         updateDocumentResponse = response.Result;
                         Assert.IsNotNull(updateDocumentResponse);
                         Assert.IsTrue(updateDocumentResponse.DocumentId == addedDocumentId);
@@ -866,9 +866,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to FederatedQuery...");
             QueryResponse federatedQueryResponse = null;
             service.FederatedQuery(
-                callback: (DetailedResponse<QueryResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<QueryResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "FederatedQuery result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "FederatedQuery result: {0}", response.Response);
                     federatedQueryResponse = response.Result;
                     Assert.IsNotNull(federatedQueryResponse);
                     Assert.IsNotNull(federatedQueryResponse.MatchingResults);
@@ -896,9 +896,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to FederatedQueryNotices...");
             QueryNoticesResponse federatedQueryNoticesResponse = null;
             service.FederatedQueryNotices(
-                callback: (DetailedResponse<QueryNoticesResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<QueryNoticesResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "FederatedQueryNotices result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "FederatedQueryNotices result: {0}", response.Response);
                     federatedQueryNoticesResponse = response.Result;
                     Assert.IsNotNull(federatedQueryNoticesResponse);
                     Assert.IsNull(error);
@@ -923,9 +923,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to Query...");
             QueryResponse queryResponse = null;
             service.Query(
-                callback: (DetailedResponse<QueryResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<QueryResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "Query result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "Query result: {0}", response.Response);
                     queryResponse = response.Result;
                     sessionToken = queryResponse.SessionToken;
                     Assert.IsNotNull(queryResponse);
@@ -958,9 +958,9 @@ namespace IBM.Watson.Tests
             };
 
             service.QueryEntities(
-                callback: (DetailedResponse<QueryEntitiesResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<QueryEntitiesResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryEntities result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryEntities result: {0}", response.Response);
                     queryEntitiesResponse = response.Result;
                     Assert.IsNotNull(queryEntitiesResponse);
                     Assert.IsNull(error);
@@ -985,9 +985,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to QueryNotices...");
             QueryNoticesResponse queryNoticesResponse = null;
             service.QueryNotices(
-                callback: (DetailedResponse<QueryNoticesResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<QueryNoticesResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryNotices result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryNotices result: {0}", response.Response);
                     queryNoticesResponse = response.Result;
                     Assert.IsNotNull(queryNoticesResponse);
                     Assert.IsNull(error);
@@ -1020,9 +1020,9 @@ namespace IBM.Watson.Tests
                 }
             };
             service.QueryRelations(
-                callback: (DetailedResponse<QueryRelationsResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<QueryRelationsResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryRelations result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryRelations result: {0}", response.Response);
                     queryRelationsResponse = response.Result;
                     Assert.IsNotNull(queryRelationsResponse);
                     Assert.IsNull(error);
@@ -1054,9 +1054,9 @@ namespace IBM.Watson.Tests
                 }
             };
             service.AddTrainingData(
-                callback: (DetailedResponse<TrainingQuery> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TrainingQuery> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "AddTrainingData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "AddTrainingData result: {0}", response.Response);
                     addTrainingDataResponse = response.Result;
                     queryId = addTrainingDataResponse.QueryId;
                     Assert.IsNotNull(addTrainingDataResponse);
@@ -1084,9 +1084,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to CreateTrainingExample...");
             TrainingExample createTrainingExampleResponse = null;
             service.CreateTrainingExample(
-                callback: (DetailedResponse<TrainingExample> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TrainingExample> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateTrainingExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateTrainingExample result: {0}", response.Response);
                     createTrainingExampleResponse = response.Result;
                     Assert.IsNotNull(createTrainingExampleResponse);
                     Assert.IsTrue(createTrainingExampleResponse.DocumentId == addedDocumentId);
@@ -1112,9 +1112,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetTrainingData...");
             TrainingQuery getTrainingDataResponse = null;
             service.GetTrainingData(
-                callback: (DetailedResponse<TrainingQuery> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TrainingQuery> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTrainingData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTrainingData result: {0}", response.Response);
                     getTrainingDataResponse = response.Result;
                     Assert.IsNotNull(getTrainingDataResponse);
                     Assert.IsTrue(getTrainingDataResponse.QueryId == queryId);
@@ -1139,9 +1139,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetTrainingExample...");
             TrainingExample getTrainingExampleResponse = null;
             service.GetTrainingExample(
-                callback: (DetailedResponse<TrainingExample> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TrainingExample> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTrainingExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTrainingExample result: {0}", response.Response);
                     getTrainingExampleResponse = response.Result;
                     Assert.IsNotNull(getTrainingExampleResponse);
                     Assert.IsTrue(getTrainingExampleResponse.DocumentId == addedDocumentId);
@@ -1166,9 +1166,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListTrainingData...");
             TrainingDataSet listTrainingDataResponse = null;
             service.ListTrainingData(
-                callback: (DetailedResponse<TrainingDataSet> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TrainingDataSet> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListTrainingData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListTrainingData result: {0}", response.Response);
                     listTrainingDataResponse = response.Result;
                     Assert.IsNotNull(listTrainingDataResponse);
                     Assert.IsNotNull(listTrainingDataResponse.Queries);
@@ -1192,9 +1192,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListTrainingExamples...");
             TrainingExampleList listTrainingExamplesResponse = null;
             service.ListTrainingExamples(
-                callback: (DetailedResponse<TrainingExampleList> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TrainingExampleList> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListTrainingExamples result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListTrainingExamples result: {0}", response.Response);
                     listTrainingExamplesResponse = response.Result;
                     Assert.IsNotNull(listTrainingExamplesResponse);
                     Assert.IsNotNull(listTrainingExamplesResponse.Examples);
@@ -1219,9 +1219,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to UpdateTrainingExample...");
             TrainingExample updateTrainingExampleResponse = null;
             service.UpdateTrainingExample(
-                callback: (DetailedResponse<TrainingExample> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TrainingExample> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateTrainingExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateTrainingExample result: {0}", response.Response);
                     updateTrainingExampleResponse = response.Result;
                     Assert.IsNotNull(updateTrainingExampleResponse);
                     Assert.IsTrue(updateTrainingExampleResponse.DocumentId == addedDocumentId);
@@ -1254,9 +1254,9 @@ namespace IBM.Watson.Tests
                 DocumentId = addedDocumentId
             };
             service.CreateEvent(
-                callback: (DetailedResponse<CreateEventResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<CreateEventResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateEvent result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateEvent result: {0}", response.Response);
                     createEventResponse = response.Result;
                     Assert.IsNotNull(createEventResponse);
                     Assert.IsTrue(createEventResponse.Type == "click");
@@ -1279,9 +1279,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetMetricsEventRate...");
             MetricResponse getMetricsEventRateResponse = null;
             service.GetMetricsEventRate(
-                callback: (DetailedResponse<MetricResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MetricResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsEventRate result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsEventRate result: {0}", response.Response);
                     getMetricsEventRateResponse = response.Result;
                     Assert.IsNotNull(getMetricsEventRateResponse);
                     Assert.IsNotNull(getMetricsEventRateResponse.Aggregations);
@@ -1303,9 +1303,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetMetricsQuery...");
             MetricResponse getMetricsQueryResponse = null;
             service.GetMetricsQuery(
-                callback: (DetailedResponse<MetricResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MetricResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQuery result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQuery result: {0}", response.Response);
                     getMetricsQueryResponse = response.Result;
                     Assert.IsNotNull(getMetricsQueryResponse);
                     Assert.IsNotNull(getMetricsQueryResponse.Aggregations);
@@ -1327,9 +1327,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetMetricsQueryEvent...");
             MetricResponse getMetricsQueryEventResponse = null;
             service.GetMetricsQueryEvent(
-                callback: (DetailedResponse<MetricResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MetricResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQueryEvent result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQueryEvent result: {0}", response.Response);
                     getMetricsQueryEventResponse = response.Result;
                     Assert.IsNotNull(getMetricsQueryEventResponse);
                     Assert.IsNotNull(getMetricsQueryEventResponse.Aggregations);
@@ -1351,9 +1351,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetMetricsQueryNoResults...");
             MetricResponse getMetricsQueryNoResultsResponse = null;
             service.GetMetricsQueryNoResults(
-                callback: (DetailedResponse<MetricResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MetricResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQueryNoResults result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQueryNoResults result: {0}", response.Response);
                     getMetricsQueryNoResultsResponse = response.Result;
                     Assert.IsNotNull(getMetricsQueryNoResultsResponse);
                     Assert.IsNotNull(getMetricsQueryNoResultsResponse.Aggregations);
@@ -1375,9 +1375,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetMetricsQueryTokenEvent...");
             MetricTokenResponse getMetricsQueryTokenEventResponse = null;
             service.GetMetricsQueryTokenEvent(
-                callback: (DetailedResponse<MetricTokenResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<MetricTokenResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQueryTokenEvent result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetMetricsQueryTokenEvent result: {0}", response.Response);
                     getMetricsQueryTokenEventResponse = response.Result;
                     Assert.IsNotNull(getMetricsQueryTokenEventResponse);
                     Assert.IsNotNull(getMetricsQueryTokenEventResponse.Aggregations);
@@ -1399,9 +1399,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to QueryLog...");
             LogQueryResponse queryLogResponse = null;
             service.QueryLog(
-                callback: (DetailedResponse<LogQueryResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<LogQueryResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryLog result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "QueryLog result: {0}", response.Response);
                     queryLogResponse = response.Result;
                     Assert.IsNotNull(queryLogResponse);
                     Assert.IsNotNull(queryLogResponse.Results);
@@ -1434,9 +1434,9 @@ namespace IBM.Watson.Tests
                 PrivateKey = "myPrivateKey"
             };
             service.CreateCredentials(
-                callback: (DetailedResponse<ModelCredentials> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ModelCredentials> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateCredentials result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateCredentials result: {0}", response.Response);
                     createCredentialsResponse = response.Result;
                     credentialId = createCredentialsResponse.CredentialId;
                     Assert.IsNotNull(createCredentialsResponse);
@@ -1462,9 +1462,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetCredentials...");
             ModelCredentials getCredentialsResponse = null;
             service.GetCredentials(
-                callback: (DetailedResponse<ModelCredentials> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ModelCredentials> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetCredentials result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetCredentials result: {0}", response.Response);
                     getCredentialsResponse = response.Result;
                     Assert.IsNotNull(getCredentialsResponse);
                     Assert.IsTrue(getCredentialsResponse.CredentialId == credentialId);
@@ -1488,9 +1488,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListCredentials...");
             CredentialsList listCredentialsResponse = null;
             service.ListCredentials(
-                callback: (DetailedResponse<CredentialsList> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<CredentialsList> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCredentials result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCredentials result: {0}", response.Response);
                     listCredentialsResponse = response.Result;
                     Assert.IsNotNull(listCredentialsResponse);
                     Assert.IsNotNull(listCredentialsResponse._Credentials);
@@ -1523,9 +1523,9 @@ namespace IBM.Watson.Tests
                 PrivateKey = Convert.ToBase64String(Encoding.ASCII.GetBytes("myPrivateKeyUpdated"))
             };
             service.UpdateCredentials(
-                callback: (DetailedResponse<ModelCredentials> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ModelCredentials> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateCredentials result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateCredentials result: {0}", response.Response);
                     updateCredentialsResponse = response.Result;
                     Assert.IsNotNull(updateCredentialsResponse);
                     Assert.IsNotNull(updateCredentialsResponse.CredentialDetails);
@@ -1552,9 +1552,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to CreateGateway...");
             Gateway createGatewayResponse = null;
             service.CreateGateway(
-                callback: (DetailedResponse<Gateway> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Gateway> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateGateway result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateGateway result: {0}", response.Response);
                     createGatewayResponse = response.Result;
                     gatewayId = createGatewayResponse.GatewayId;
                     Assert.IsNotNull(createGatewayResponse);
@@ -1577,9 +1577,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to GetGateway...");
             Gateway getGatewayResponse = null;
             service.GetGateway(
-                callback: (DetailedResponse<Gateway> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Gateway> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetGateway result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetGateway result: {0}", response.Response);
                     getGatewayResponse = response.Result;
                     Assert.IsNotNull(getGatewayResponse);
                     Assert.IsTrue(getGatewayResponse.GatewayId == gatewayId);
@@ -1602,9 +1602,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to ListGateways...");
             GatewayList listGatewaysResponse = null;
             service.ListGateways(
-                callback: (DetailedResponse<GatewayList> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<GatewayList> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListGateways result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListGateways result: {0}", response.Response);
                     listGatewaysResponse = response.Result;
                     Assert.IsNotNull(listGatewaysResponse);
                     Assert.IsNotNull(listGatewaysResponse.Gateways);
@@ -1627,9 +1627,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteGateway...");
             GatewayDelete deleteGatewayResponse = null;
             service.DeleteGateway(
-                callback: (DetailedResponse<GatewayDelete> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<GatewayDelete> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteGateway result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteGateway result: {0}", response.Response);
                     deleteGatewayResponse = response.Result;
                     Assert.IsNotNull(deleteGatewayResponse);
                     Assert.IsTrue(deleteGatewayResponse.GatewayId == gatewayId);
@@ -1653,9 +1653,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteCredentials...");
             DeleteCredentials deleteCredentialsResponse = null;
             service.DeleteCredentials(
-                callback: (DetailedResponse<DeleteCredentials> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DeleteCredentials> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteCredentials result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteCredentials result: {0}", response.Response);
                     deleteCredentialsResponse = response.Result;
                     Assert.IsNotNull(deleteCredentialsResponse);
                     Assert.IsTrue(deleteCredentialsResponse.CredentialId == credentialId);
@@ -1679,9 +1679,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteUserData...");
             bool isComplete = false;
             service.DeleteUserData(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteUserData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteUserData result: {0}", response.Response);
                     Assert.IsNull(error);
                     isComplete = true;
                 },
@@ -1701,9 +1701,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteTrainingExample...");
             bool isComplete = false;
             service.DeleteTrainingExample(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteTrainingExample result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteTrainingExample result: {0}", response.Response);
                     Assert.IsNull(error);
                     isComplete = true;
                 },
@@ -1726,9 +1726,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteTrainingData...");
             bool isComplete = false;
             service.DeleteTrainingData(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteTrainingData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteTrainingData result: {0}", response.Response);
                     Assert.IsNull(error);
                     isComplete = true;
                 },
@@ -1750,9 +1750,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteAllTrainingData...");
             bool isComplete = false;
             service.DeleteAllTrainingData(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteAllTrainingData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteAllTrainingData result: {0}", response.Response);
                     Assert.IsNull(error);
                     isComplete = true;
                 },
@@ -1773,9 +1773,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteDocument...");
             DeleteDocumentResponse deleteDocumentResponse = null;
             service.DeleteDocument(
-                callback: (DetailedResponse<DeleteDocumentResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DeleteDocumentResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteDocument result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteDocument result: {0}", response.Response);
                     deleteDocumentResponse = response.Result;
                     Assert.IsNotNull(deleteDocumentResponse);
                     Assert.IsNotNull(deleteDocumentResponse.DocumentId);
@@ -1801,9 +1801,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteTokenizationDictionary...");
             bool isComplete = false;
             service.DeleteTokenizationDictionary(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteTokenizationDictionary result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteTokenizationDictionary result: {0}", response.Response);
                     Assert.IsNull(error);
                     isComplete = true;
                 },
@@ -1825,9 +1825,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteStopwordList...");
             bool isComplete = false;
             service.DeleteStopwordList(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteStopwordList result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteStopwordList result: {0}", response.Response);
                     Assert.IsNull(error);
                     isComplete = true;
                 },
@@ -1848,9 +1848,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteExpansions...");
             bool isComplete = false;
             service.DeleteExpansions(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteExpansions result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteExpansions result: {0}", response.Response);
                     Assert.IsNull(error);
                     isComplete = true;
                 },
@@ -1871,9 +1871,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteJapanseCollection...");
             DeleteCollectionResponse deleteCollectionResponse = null;
             service.DeleteCollection(
-                callback: (DetailedResponse<DeleteCollectionResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DeleteCollectionResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteJapaneseCollection result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteJapaneseCollection result: {0}", response.Response);
                     deleteCollectionResponse = response.Result;
                     Assert.IsNotNull(deleteCollectionResponse);
                     Assert.IsNotNull(deleteCollectionResponse.CollectionId);
@@ -1898,9 +1898,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteCollection...");
             DeleteCollectionResponse deleteCollectionResponse = null;
             service.DeleteCollection(
-                callback: (DetailedResponse<DeleteCollectionResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DeleteCollectionResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteCollection result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteCollection result: {0}", response.Response);
                     deleteCollectionResponse = response.Result;
                     Assert.IsNotNull(deleteCollectionResponse);
                     Assert.IsNotNull(deleteCollectionResponse.CollectionId);
@@ -1925,9 +1925,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteConfiguration...");
             DeleteConfigurationResponse deleteConfigurationResponse = null;
             service.DeleteConfiguration(
-                callback: (DetailedResponse<DeleteConfigurationResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DeleteConfigurationResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteConfiguration result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteConfiguration result: {0}", response.Response);
                     deleteConfigurationResponse = response.Result;
                     Assert.IsNotNull(deleteConfigurationResponse);
                     Assert.IsNull(error);
@@ -1950,9 +1950,9 @@ namespace IBM.Watson.Tests
             Log.Debug("DiscoveryServiceV1IntegrationTests", "Attempting to DeleteEnvironment...");
             DeleteEnvironmentResponse deleteEnvironmentResponse = null;
             service.DeleteEnvironment(
-                callback: (DetailedResponse<DeleteEnvironmentResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DeleteEnvironmentResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteEnvironment result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteEnvironment result: {0}", response.Response);
                     deleteEnvironmentResponse = response.Result;
                     Assert.IsNotNull(deleteEnvironmentResponse);
                     Assert.IsNull(error);
@@ -1976,9 +1976,9 @@ namespace IBM.Watson.Tests
             try
             {
                 service.GetTokenizationDictionaryStatus(
-                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTokenizationDictionaryStatus result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "GetTokenizationDictionaryStatus result: {0}", response.Response);
                     if (getTokenizationDictionaryStatusResponse.Status == TokenDictStatusResponse.StatusValue.ACTIVE)
                     {
                         isTokenizationDictionaryReady = true;
@@ -2025,10 +2025,10 @@ namespace IBM.Watson.Tests
             }
         }
 
-        private void OnCheckStopwordsListStatus(DetailedResponse<TokenDictStatusResponse> response, IBMError error, Dictionary<string, object> customResponseData)
+        private void OnCheckStopwordsListStatus(DetailedResponse<TokenDictStatusResponse> response, IBMError error)
         {
             TokenDictStatusResponse getStopwordListStatusResponse = null;
-            Log.Debug("DiscoveryServiceV1IntegrationTests", "OnCheckStopwordsListStatus result: {0}", customResponseData["json"].ToString());
+            Log.Debug("DiscoveryServiceV1IntegrationTests", "OnCheckStopwordsListStatus result: {0}", response.Response);
             getStopwordListStatusResponse = response.Result;
 
             if (getStopwordListStatusResponse.Status == TokenDictStatusResponse.StatusValue.ACTIVE)
@@ -2048,9 +2048,9 @@ namespace IBM.Watson.Tests
         {
             ListCollectionsResponse listCollectionsResponse = null;
             service.ListCollections(
-                callback: (DetailedResponse<ListCollectionsResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ListCollectionsResponse> response, IBMError error) =>
                 {
-                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCollections result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("DiscoveryServiceV1IntegrationTests", "ListCollections result: {0}", response.Response);
                     listCollectionsResponse = response.Result;
                     Assert.IsNotNull(listCollectionsResponse);
                     Assert.IsNotNull(listCollectionsResponse.Collections);
@@ -2074,9 +2074,9 @@ namespace IBM.Watson.Tests
 
             foreach (string collectionId in collectionIdsToDelete)
                 service.DeleteCollection(
-                    callback: (DetailedResponse<DeleteCollectionResponse> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<DeleteCollectionResponse> response, IBMError error) =>
                     {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteCollection result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("DiscoveryServiceV1IntegrationTests", "DeleteCollection result: {0}", response.Response);
                         count++;
                     },
                     environmentId: environmentId,

--- a/Tests/LanguageTranslatorV3IntegrationTests.cs
+++ b/Tests/LanguageTranslatorV3IntegrationTests.cs
@@ -31,8 +31,6 @@ namespace IBM.Watson.Tests
     {
         private LanguageTranslatorService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string forcedGlossaryFilepath;
         private string englishText = "Where is the library?";
         private string spanishText = "¿Dónde está la biblioteca?";
@@ -46,7 +44,6 @@ namespace IBM.Watson.Tests
         {
             LogSystem.InstallDefaultReactors();
             forcedGlossaryFilepath = Application.dataPath + "/Watson/Tests/TestData/LanguageTranslatorV3/glossary.tmx";
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -64,8 +61,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region Translate
@@ -86,8 +82,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 text: new List<string>() { englishText },
-                modelId: englishToSpanishModel,
-                customData: customData
+                modelId: englishToSpanishModel
             );
 
             while (translateResponse == null)
@@ -111,8 +106,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(identifyResponse.Languages.Count > 0);
                     Assert.IsNull(error);
                 },
-                text: spanishText,
-                customData: customData
+                text: spanishText
             );
 
             while (identifyResponse == null)
@@ -135,8 +129,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listIdentifiableLanguagesResponse.Languages);
                     Assert.IsTrue(listIdentifiableLanguagesResponse.Languages.Count > 0);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (listIdentifiableLanguagesResponse == null)
@@ -167,8 +160,7 @@ namespace IBM.Watson.Tests
                     },
                     baseModelId: englishToFrenchModel,
                     forcedGlossary: fs,
-                    name: customModelName,
-                    customData: customData
+                    name: customModelName
                 );
 
                 while (createModelResponse == null)
@@ -195,8 +187,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getModelResponse.Name == customModelName);
                     Assert.IsNull(error);
                 },
-                modelId: customModelId,
-                customData: customData
+                modelId: customModelId
             );
 
             while (getModelResponse == null)
@@ -222,8 +213,7 @@ namespace IBM.Watson.Tests
                 },
                 source: "en",
                 target: "fr",
-                defaultModels: true,
-                customData: customData
+                defaultModels: true
             );
 
             while (listModelsResponse == null)
@@ -247,8 +237,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(deleteModelResponse.Status == "OK");
                     Assert.IsNull(error);
                 },
-                modelId: customModelId,
-                customData: customData
+                modelId: customModelId
             );
 
             while (deleteModelResponse == null)

--- a/Tests/LanguageTranslatorV3IntegrationTests.cs
+++ b/Tests/LanguageTranslatorV3IntegrationTests.cs
@@ -75,9 +75,9 @@ namespace IBM.Watson.Tests
             Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Attempting to Translate...");
             TranslationResult translateResponse = null;
             service.Translate(
-                callback: (DetailedResponse<TranslationResult> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TranslationResult> response, IBMError error) =>
                 {
-                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Translate result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Translate result: {0}", response.Response);
                     translateResponse = response.Result;
                     Assert.IsNotNull(translateResponse);
                     Assert.IsNotNull(translateResponse.Translations);
@@ -102,9 +102,9 @@ namespace IBM.Watson.Tests
             Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Attempting to Identify...");
             IdentifiedLanguages identifyResponse = null;
             service.Identify(
-                callback: (DetailedResponse<IdentifiedLanguages> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<IdentifiedLanguages> response, IBMError error) =>
                 {
-                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Identify result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Identify result: {0}", response.Response);
                     identifyResponse = response.Result;
                     Assert.IsNotNull(identifyResponse);
                     Assert.IsNotNull(identifyResponse.Languages);
@@ -127,9 +127,9 @@ namespace IBM.Watson.Tests
             Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Attempting to ListIdentifiableLanguages...");
             IdentifiableLanguages listIdentifiableLanguagesResponse = null;
             service.ListIdentifiableLanguages(
-                callback: (DetailedResponse<IdentifiableLanguages> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<IdentifiableLanguages> response, IBMError error) =>
                 {
-                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "ListIdentifiableLanguages result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "ListIdentifiableLanguages result: {0}", response.Response);
                     listIdentifiableLanguagesResponse = response.Result;
                     Assert.IsNotNull(listIdentifiableLanguagesResponse);
                     Assert.IsNotNull(listIdentifiableLanguagesResponse.Languages);
@@ -153,9 +153,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(forcedGlossaryFilepath))
             {
                 service.CreateModel(
-                    callback: (DetailedResponse<TranslationModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<TranslationModel> response, IBMError error) =>
                     {
-                        Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "CreateModel result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "CreateModel result: {0}", response.Response);
                         createModelResponse = response.Result;
                         customModelId = createModelResponse.ModelId;
                         Assert.IsNotNull(createModelResponse);
@@ -184,9 +184,9 @@ namespace IBM.Watson.Tests
             Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Attempting to GetModel...");
             TranslationModel getModelResponse = null;
             service.GetModel(
-                callback: (DetailedResponse<TranslationModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TranslationModel> response, IBMError error) =>
                 {
-                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "GetModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "GetModel result: {0}", response.Response);
                     getModelResponse = response.Result;
                     Assert.IsNotNull(getModelResponse);
                     Assert.IsTrue(getModelResponse.ModelId == customModelId);
@@ -211,9 +211,9 @@ namespace IBM.Watson.Tests
             Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Attempting to ListModels...");
             TranslationModels listModelsResponse = null;
             service.ListModels(
-                callback: (DetailedResponse<TranslationModels> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<TranslationModels> response, IBMError error) =>
                 {
-                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "ListModels result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "ListModels result: {0}", response.Response);
                     listModelsResponse = response.Result;
                     Assert.IsNotNull(listModelsResponse);
                     Assert.IsNotNull(listModelsResponse.Models);
@@ -238,9 +238,9 @@ namespace IBM.Watson.Tests
             Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "Attempting to DeleteModel...");
             DeleteModelResult deleteModelResponse = null;
             service.DeleteModel(
-                callback: (DetailedResponse<DeleteModelResult> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<DeleteModelResult> response, IBMError error) =>
                 {
-                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "DeleteModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "DeleteModel result: {0}", response.Response);
                     deleteModelResponse = response.Result;
                     Assert.IsNotNull(deleteModelResponse);
                     Assert.IsNotNull(deleteModelResponse.Status);

--- a/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
+++ b/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
@@ -30,8 +30,6 @@ namespace IBM.Watson.Tests
     public class NaturalLanguageClassifierV1IntegrationTests
     {
         private NaturalLanguageClassifierService service;
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string classifierId;
         private string createdClassifierId;
         private string classifierDataFilePath;
@@ -45,7 +43,6 @@ namespace IBM.Watson.Tests
             LogSystem.InstallDefaultReactors();
             classifierDataFilePath = Application.dataPath + "/Watson/Tests/TestData/NaturalLanguageClassifierV1/weather-data.csv";
             metadataDataFilePath = Application.dataPath + "/Watson/Tests/TestData/NaturalLanguageClassifierV1/metadata.json";
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -63,8 +60,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region ListClassifiers
@@ -83,8 +79,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listClassifiersResponse.Classifiers);
                     Assert.IsTrue(listClassifiersResponse.Classifiers.Count > 0);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (listClassifiersResponse == null)
@@ -112,9 +107,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 classifierId: classifierId,
-                text: textToClassify0,
-
-                customData: customData
+                text: textToClassify0
             );
 
             while (classifyResponse == null)
@@ -152,8 +145,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 classifierId: classifierId,
-                collection: collection,
-                customData: customData
+                collection: collection
             );
 
             while (classifyCollectionResponse == null)
@@ -184,8 +176,7 @@ namespace IBM.Watson.Tests
                         Assert.IsNull(error);
                     },
                     metadata: fs0,
-                    trainingData: fs1,
-                    customData: customData
+                    trainingData: fs1
                 );
 
                     while (createClassifierResponse == null)
@@ -213,8 +204,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getClassifierResponse.Language == "en");
                     Assert.IsNull(error);
                 },
-                classifierId: createdClassifierId,
-                customData: customData
+                classifierId: createdClassifierId
             );
 
             while (getClassifierResponse == null)
@@ -236,8 +226,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(deleteClassifierResponse);
                     Assert.IsNull(error);
                 },
-                classifierId: createdClassifierId,
-                customData: customData
+                classifierId: createdClassifierId
             );
 
             while (deleteClassifierResponse == null)

--- a/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
+++ b/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
@@ -74,9 +74,9 @@ namespace IBM.Watson.Tests
             Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "Attempting to ListClassifiers...");
             ClassifierList listClassifiersResponse = null;
             service.ListClassifiers(
-                callback: (DetailedResponse<ClassifierList> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ClassifierList> response, IBMError error) =>
                 {
-                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "ListClassifiers result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "ListClassifiers result: {0}", response.Response);
                     listClassifiersResponse = response.Result;
                     classifierId = listClassifiersResponse.Classifiers[0].ClassifierId;
                     Assert.IsNotNull(listClassifiersResponse);
@@ -99,9 +99,9 @@ namespace IBM.Watson.Tests
             Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "Attempting to Classify...");
             Classification classifyResponse = null;
             service.Classify(
-                callback: (DetailedResponse<Classification> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Classification> response, IBMError error) =>
                 {
-                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "Classify result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "Classify result: {0}", response.Response);
                     classifyResponse = response.Result;
                     Assert.IsNotNull(classifyResponse);
                     Assert.IsNotNull(classifyResponse.Classes);
@@ -141,9 +141,9 @@ namespace IBM.Watson.Tests
             };
 
             service.ClassifyCollection(
-                callback: (DetailedResponse<ClassificationCollection> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ClassificationCollection> response, IBMError error) =>
                 {
-                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "ClassifyCollection result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "ClassifyCollection result: {0}", response.Response);
                     classifyCollectionResponse = response.Result;
                     Assert.IsNotNull(classifyCollectionResponse);
                     Assert.IsNotNull(classifyCollectionResponse.Collection);
@@ -172,9 +172,9 @@ namespace IBM.Watson.Tests
                 using (FileStream fs1 = File.OpenRead(classifierDataFilePath))
                 {
                     service.CreateClassifier(
-                    callback: (DetailedResponse<Classifier> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<Classifier> response, IBMError error) =>
                     {
-                        Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "CreateClassifier result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "CreateClassifier result: {0}", response.Response);
                         createClassifierResponse = response.Result;
                         createdClassifierId = createClassifierResponse.ClassifierId;
                         Assert.IsNotNull(createClassifierResponse);
@@ -204,9 +204,9 @@ namespace IBM.Watson.Tests
             Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "Attempting to GetClassifier...");
             Classifier getClassifierResponse = null;
             service.GetClassifier(
-                callback: (DetailedResponse<Classifier> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Classifier> response, IBMError error) =>
                 {
-                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "GetClassifier result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "GetClassifier result: {0}", response.Response);
                     getClassifierResponse = response.Result;
                     Assert.IsNotNull(getClassifierResponse);
                     Assert.IsTrue(getClassifierResponse.Name == "unity-classifier-delete");
@@ -229,9 +229,9 @@ namespace IBM.Watson.Tests
             Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "Attempting to DeleteClassifier...");
             object deleteClassifierResponse = null;
             service.DeleteClassifier(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "DeleteClassifier result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "DeleteClassifier result: {0}", response.Response);
                     deleteClassifierResponse = response.Result;
                     Assert.IsNotNull(deleteClassifierResponse);
                     Assert.IsNull(error);

--- a/Tests/NaturalLanguageUnderstandingV1IntegrationTests.cs
+++ b/Tests/NaturalLanguageUnderstandingV1IntegrationTests.cs
@@ -29,8 +29,6 @@ namespace IBM.Watson.Tests
     {
         private NaturalLanguageUnderstandingService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string nluText = "Analyze various features of text content at scale. Provide text, raw HTML, or a public URL, and IBM Watson Natural Language Understanding will give you results for the features you request. The service cleans HTML content before analysis by default, so the results can ignore most advertisements and other unwanted content.";
         private string modelId;
 
@@ -38,7 +36,6 @@ namespace IBM.Watson.Tests
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -56,8 +53,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region Analyze
@@ -89,8 +85,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 features: features,
-                text: nluText,
-                customData: customData
+                text: nluText
             );
 
             while (analyzeResponse == null)
@@ -113,8 +108,7 @@ namespace IBM.Watson.Tests
         //            Assert.IsNotNull(deleteModelResponse);
         //            Assert.IsNull(error);
         //        },
-        //        modelId: modelId,
-        //        customData: customData
+        //        modelId: modelId
         //    );
 
         //    while (deleteModelResponse == null)
@@ -136,8 +130,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listModelsResponse);
                     Assert.IsNotNull(listModelsResponse.Models);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (listModelsResponse == null)

--- a/Tests/NaturalLanguageUnderstandingV1IntegrationTests.cs
+++ b/Tests/NaturalLanguageUnderstandingV1IntegrationTests.cs
@@ -81,9 +81,9 @@ namespace IBM.Watson.Tests
             };
 
             service.Analyze(
-                callback: (DetailedResponse<AnalysisResults> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<AnalysisResults> response, IBMError error) =>
                 {
-                    Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "Analyze result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "Analyze result: {0}", response.Response);
                     analyzeResponse = response.Result;
                     Assert.IsNotNull(analyzeResponse);
                     Assert.IsNull(error);
@@ -106,9 +106,9 @@ namespace IBM.Watson.Tests
         //    Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "Attempting to DeleteModel...");
         //    DeleteModelResults deleteModelResponse = null;
         //    service.DeleteModel(
-        //        callback: (DetailedResponse<DeleteModelResults> response, IBMError error, Dictionary<string, object> customResponseData) =>
+        //        callback: (DetailedResponse<DeleteModelResults> response, IBMError error) =>
         //        {
-        //            Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "DeleteModel result: {0}", customResponseData["json"].ToString());
+        //            Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "DeleteModel result: {0}", response.Response);
         //            deleteModelResponse = response.Result;
         //            Assert.IsNotNull(deleteModelResponse);
         //            Assert.IsNull(error);
@@ -129,9 +129,9 @@ namespace IBM.Watson.Tests
             Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "Attempting to ListModels...");
             ListModelsResults listModelsResponse = null;
             service.ListModels(
-                callback: (DetailedResponse<ListModelsResults> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ListModelsResults> response, IBMError error) =>
                 {
-                    Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "ListModels result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("NaturalLanguageUnderstandingServiceV1IntegrationTests", "ListModels result: {0}", response.Response);
                     listModelsResponse = response.Result;
                     Assert.IsNotNull(listModelsResponse);
                     Assert.IsNotNull(listModelsResponse.Models);

--- a/Tests/PersonalityInsightsV3IntegrationTests.cs
+++ b/Tests/PersonalityInsightsV3IntegrationTests.cs
@@ -81,9 +81,9 @@ namespace IBM.Watson.Tests
             };
 
             service.Profile(
-                callback: (DetailedResponse<Profile> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Profile> response, IBMError error) =>
                 {
-                    Log.Debug("PersonalityInsightsServiceV3IntegrationTests", "Profile result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("PersonalityInsightsServiceV3IntegrationTests", "Profile result: {0}", response.Response);
                     profileResponse = response.Result;
                     Assert.IsNotNull(profileResponse);
                     Assert.IsNotNull(profileResponse.Personality);
@@ -124,7 +124,7 @@ namespace IBM.Watson.Tests
             };
 
             service.ProfileAsCsv(
-                callback: (DetailedResponse<System.IO.MemoryStream> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<System.IO.MemoryStream> response, IBMError error) =>
                 {
                     profileAsCsvResponse = response.Result;
                     Assert.IsNotNull(profileAsCsvResponse);

--- a/Tests/PersonalityInsightsV3IntegrationTests.cs
+++ b/Tests/PersonalityInsightsV3IntegrationTests.cs
@@ -31,15 +31,12 @@ namespace IBM.Watson.Tests
     {
         private PersonalityInsightsService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string contentToProfile = "The IBM Watson™ Personality Insights service provides a Representational State Transfer (REST) Application Programming Interface (API) that enables applications to derive insights from social media, enterprise data, or other digital communications. The service uses linguistic analytics to infer individuals' intrinsic personality characteristics, including Big Five, Needs, and Values, from digital communications such as email, text messages, tweets, and forum posts. The service can automatically infer, from potentially noisy social media, portraits of individuals that reflect their personality characteristics. The service can report consumption preferences based on the results of its analysis, and for JSON content that is timestamped, it can report temporal behavior.";
 
         [OneTimeSetUp]
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -57,8 +54,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region Profile
@@ -95,8 +91,7 @@ namespace IBM.Watson.Tests
                 rawScores: true,
                 csvHeaders: true,
                 consumptionPreferences: true,
-                contentType: "text/plain",
-                customData: customData
+                contentType: "text/plain"
             );
 
             while (profileResponse == null)
@@ -144,8 +139,7 @@ namespace IBM.Watson.Tests
                 rawScores: true,
                 csvHeaders: true,
                 consumptionPreferences: true,
-                contentType: "text/plain",
-                customData: customData
+                contentType: "text/plain"
             );
 
             while (profileAsCsvResponse == null)

--- a/Tests/SpeechToTextV1IntegrationTests.cs
+++ b/Tests/SpeechToTextV1IntegrationTests.cs
@@ -32,8 +32,6 @@ namespace IBM.Watson.Tests
     public class SpeechToTextV1IntegrationTests
     {
         private SpeechToTextService service;
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string usBroadbandModel = "en-US_BroadbandModel";
         private string grammarPath;
         private string testAudioPath;
@@ -71,7 +69,6 @@ namespace IBM.Watson.Tests
             testAudioPath = Application.dataPath + "/Watson/Tests/TestData/SpeechToTextV1/test-audio.wav";
             corpusPath = Application.dataPath + "/Watson/Tests/TestData/SpeechToTextV1/theJabberwocky-utf8.txt";
             Runnable.Run(DownloadAcousticResource());
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -89,8 +86,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region GetModel
@@ -108,8 +104,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getModelResponse.Name == usBroadbandModel);
                     Assert.IsNull(error);
                 },
-                modelId: usBroadbandModel,
-                customData: customData
+                modelId: usBroadbandModel
             );
 
             while (getModelResponse == null)
@@ -132,8 +127,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listModelsResponse.Models);
                     Assert.IsTrue(listModelsResponse.Models.Count > 0);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (listModelsResponse == null)
@@ -160,8 +154,7 @@ namespace IBM.Watson.Tests
                 },
                 audio: audio,
                 model: usBroadbandModel,
-                contentType: "audio/wav",
-                customData: customData
+                contentType: "audio/wav"
             );
 
             while (recognizeResponse == null)
@@ -190,8 +183,7 @@ namespace IBM.Watson.Tests
                 },
                 audio: audio,
                 model: usBroadbandModel,
-                contentType: "auido/wav",
-                customData: customData
+                contentType: "auido/wav"
             );
 
             while (createJobResponse == null)
@@ -215,8 +207,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(checkJobResponse.Status);
                     Assert.IsNull(error);
                 },
-                id: jobId,
-                customData: customData
+                id: jobId
             );
 
             while (checkJobResponse == null)
@@ -238,8 +229,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(checkJobsResponse);
                     Assert.IsNotNull(checkJobsResponse.Recognitions);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (checkJobsResponse == null)
@@ -262,8 +252,7 @@ namespace IBM.Watson.Tests
         //            Assert.IsNull(error);
         //        },
         //        callbackUrl: callbackUrl,
-        //        userSecret: userSecret,
-        //        customData: customData
+        //        userSecret: userSecret
         //    );
 
         //    while (registerCallbackResponse == null)
@@ -285,8 +274,7 @@ namespace IBM.Watson.Tests
         //            Assert.IsNotNull(unregisterCallbackResponse);
         //            Assert.IsNull(error);
         //        },
-        //        callbackUrl: callbackUrl,
-        //        customData: customData
+        //        callbackUrl: callbackUrl
         //    );
 
         //    while (unregisterCallbackResponse == null)
@@ -313,9 +301,7 @@ namespace IBM.Watson.Tests
                 name: languageModelName,
                 baseModelName: usBroadbandModel,
                 dialect: languageModelDialect,
-                description: languageModelDescription,
-
-                customData: customData
+                description: languageModelDescription
             );
 
             while (createLanguageModelResponse == null)
@@ -341,8 +327,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getLanguageModelResponse.Dialect == languageModelDialect);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (getLanguageModelResponse == null)
@@ -366,8 +351,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listLanguageModelsResponse.Customizations.Count > 0);
                     Assert.IsNull(error);
                 },
-                language: "en-US",
-                customData: customData
+                language: "en-US"
             );
 
             while (listLanguageModelsResponse == null)
@@ -394,8 +378,7 @@ namespace IBM.Watson.Tests
                     customizationId: customizationId,
                     corpusName: corpusName,
                     corpusFile: fs,
-                    allowOverwrite: true,
-                    customData: customData
+                    allowOverwrite: true
                 );
 
                 while (!isComplete)
@@ -421,8 +404,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 customizationId: customizationId,
-                corpusName: corpusName,
-                customData: customData
+                corpusName: corpusName
             );
 
             while (getCorpusResponse == null)
@@ -446,8 +428,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listCorporaResponse._Corpora.Count > 0);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (listCorporaResponse == null)
@@ -483,8 +464,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(trainLanguageModelResponse);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (trainLanguageModelResponse == null)
@@ -523,8 +503,7 @@ namespace IBM.Watson.Tests
                 customizationId: customizationId,
                 wordName: wordName,
                 soundsLike: soundsLike,
-                displayAs: displayAs,
-                customData: customData
+                displayAs: displayAs
             );
 
             while (!isComplete)
@@ -577,9 +556,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 customizationId: customizationId,
-                words: words,
-
-                customData: customData
+                words: words
             );
 
             while (!isComplete)
@@ -603,8 +580,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 customizationId: customizationId,
-                wordName: wordName,
-                customData: customData
+                wordName: wordName
             );
 
             while (getWordResponse == null)
@@ -630,8 +606,7 @@ namespace IBM.Watson.Tests
                 },
                 customizationId: customizationId,
                 wordType: "all",
-                sort: "alphabetical",
-                customData: customData
+                sort: "alphabetical"
             );
 
             while (listWordsResponse == null)
@@ -667,8 +642,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(trainLanguageModelResponse);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (trainLanguageModelResponse == null)
@@ -708,8 +682,7 @@ namespace IBM.Watson.Tests
                 grammarName: grammarName,
                 grammarFile: File.ReadAllText(grammarPath),
                 contentType: grammarsContentType,
-                allowOverwrite: true,
-                customData: customData
+                allowOverwrite: true
             );
 
             while (!isComplete)
@@ -733,8 +706,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 customizationId: customizationId,
-                grammarName: grammarName,
-                customData: customData
+                grammarName: grammarName
             );
 
             while (getGrammarResponse == null)
@@ -758,8 +730,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listGrammarsResponse._Grammars.Count > 0);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (listGrammarsResponse == null)
@@ -795,8 +766,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(trainLanguageModelResponse);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (trainLanguageModelResponse == null)
@@ -832,8 +802,7 @@ namespace IBM.Watson.Tests
         //            Assert.IsNotNull(upgradeLanguageModelResponse);
         //            Assert.IsNull(error);
         //        },
-        //        customizationId: customizationId,
-        //        customData: customData
+        //        customizationId: customizationId
         //    );
 
         //    while (upgradeLanguageModelResponse == null)
@@ -859,8 +828,7 @@ namespace IBM.Watson.Tests
                 },
                 name: acousticModelName,
                 baseModelName: usBroadbandModel,
-                description: acousticModelDescription,
-                customData: customData
+                description: acousticModelDescription
             );
 
             while (createAcousticModelResponse == null)
@@ -886,8 +854,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getAcousticModelResponse.BaseModelName == usBroadbandModel);
                     Assert.IsNull(error);
                 },
-                customizationId: acousticModelCustomizationId,
-                customData: customData
+                customizationId: acousticModelCustomizationId
             );
 
             while (getAcousticModelResponse == null)
@@ -911,8 +878,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listAcousticModelsResponse.Customizations.Count > 0);
                     Assert.IsNull(error);
                 },
-                language: languageModelDialect,
-                customData: customData
+                language: languageModelDialect
             );
 
             while (listAcousticModelsResponse == null)
@@ -936,8 +902,7 @@ namespace IBM.Watson.Tests
         //        },
         //        customizationId: customizationId,
         //        customLanguageModelId: customLanguageModelId,
-        //        force: force,
-        //        customData: customData
+        //        force: force
         //    );
 
         //    while (upgradeAcousticModelResponse == null)
@@ -964,8 +929,7 @@ namespace IBM.Watson.Tests
                 audioResource: acousticResourceData,
                 allowOverwrite: true,
                 contentType: acousticResourceMimeType,
-                containedContentType: acousticResourceMimeType,
-                customData: customData
+                containedContentType: acousticResourceMimeType
             );
 
             while (!isComplete)
@@ -989,8 +953,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 customizationId: acousticModelCustomizationId,
-                audioName: acousticResourceName,
-                customData: customData
+                audioName: acousticResourceName
             );
 
             while (getAudioResponse == null)
@@ -1014,8 +977,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listAudioResponse.Audio.Count > 0);
                     Assert.IsNull(error);
                 },
-                customizationId: acousticModelCustomizationId,
-                customData: customData
+                customizationId: acousticModelCustomizationId
             );
 
             while (listAudioResponse == null)
@@ -1052,8 +1014,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 customizationId: acousticModelCustomizationId,
-                customLanguageModelId: customizationId,
-                customData: customData
+                customLanguageModelId: customizationId
             );
 
             while (!isComplete)
@@ -1090,8 +1051,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 customizationId: acousticModelCustomizationId,
-                audioName: acousticResourceName,
-                customData: customData
+                audioName: acousticResourceName
             );
 
             while (!isComplete)
@@ -1113,8 +1073,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                     isComplete = true;
                 },
-                customizationId: acousticModelCustomizationId,
-                customData: customData
+                customizationId: acousticModelCustomizationId
             );
 
             while (!isComplete)
@@ -1136,8 +1095,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                     isComplete = true;
                 },
-                customizationId: acousticModelCustomizationId,
-                customData: customData
+                customizationId: acousticModelCustomizationId
             );
 
             while (!isComplete)
@@ -1160,8 +1118,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 customizationId: customizationId,
-                grammarName: grammarName,
-                customData: customData
+                grammarName: grammarName
             );
 
             while (!isComplete)
@@ -1184,8 +1141,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 customizationId: customizationId,
-                wordName: wordName,
-                customData: customData
+                wordName: wordName
             );
 
             while (!isComplete)
@@ -1208,8 +1164,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(response.StatusCode == 200);
                 },
                 customizationId: customizationId,
-                corpusName: corpusName,
-                customData: customData
+                corpusName: corpusName
             );
 
             while (!isComplete)
@@ -1231,8 +1186,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                     isComplete = true;
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (!isComplete)
@@ -1254,8 +1208,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(response.StatusCode == 200);
                     isComplete = true;
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (!isComplete)
@@ -1278,8 +1231,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(response.StatusCode == 204);
                     isComplete = true;
                 },
-                id: jobId,
-                customData: customData
+                id: jobId
             );
 
             while (!isComplete)
@@ -1301,8 +1253,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);
                 },
-                customerId: "customerId",
-                customData: customData
+                customerId: "customerId"
             );
 
             while (deleteUserDataResponse == null)
@@ -1334,8 +1285,7 @@ namespace IBM.Watson.Tests
                             isLanguageModelReady = true;
                         }
                     },
-                    customizationId: customizationId,
-                    customData: customData
+                    customizationId: customizationId
                 );
             }
             catch
@@ -1373,8 +1323,7 @@ namespace IBM.Watson.Tests
                         }
                     },
                     customizationId: customizationId,
-                    corpusName: corpusName,
-                    customData: customData
+                    corpusName: corpusName
                 );
             }
             catch
@@ -1411,8 +1360,7 @@ namespace IBM.Watson.Tests
                         }
                     },
                     customizationId: customizationId,
-                    grammarName: grammarName,
-                    customData: customData
+                    grammarName: grammarName
                 );
             }
             catch
@@ -1440,17 +1388,16 @@ namespace IBM.Watson.Tests
                     {
                         getAcousticModelResponse = response.Result;
                         Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckAcousticModelStatus: {0}", getAcousticModelResponse.Status);
-                        if (getAcousticModelResponse.Status != AcousticModel.StatusValue.READY)
-                        {
-                            Runnable.Run(CheckAcousticModelStatus());
-                        }
-                        else
+                        if (getAcousticModelResponse.Status == AcousticModel.StatusValue.READY || getAcousticModelResponse.Status == AcousticModel.StatusValue.AVAILABLE)
                         {
                             isAcousticModelReady = true;
                         }
+                        else
+                        {
+                            Runnable.Run(CheckAcousticModelStatus());
+                        }
                     },
-                    customizationId: acousticModelCustomizationId,
-                    customData: customData
+                    customizationId: acousticModelCustomizationId
                 );
             }
             catch
@@ -1489,8 +1436,7 @@ namespace IBM.Watson.Tests
                         }
                     },
                     customizationId: acousticModelCustomizationId,
-                    audioName: acousticResourceName,
-                    customData: customData
+                    audioName: acousticResourceName
                 );
             }
             catch

--- a/Tests/SpeechToTextV1IntegrationTests.cs
+++ b/Tests/SpeechToTextV1IntegrationTests.cs
@@ -100,9 +100,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to GetModel...");
             SpeechModel getModelResponse = null;
             service.GetModel(
-                callback: (DetailedResponse<SpeechModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<SpeechModel> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetModel result: {0}", response.Response);
                     getModelResponse = response.Result;
                     Assert.IsNotNull(getModelResponse);
                     Assert.IsTrue(getModelResponse.Name == usBroadbandModel);
@@ -124,9 +124,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ListModels...");
             SpeechModels listModelsResponse = null;
             service.ListModels(
-                callback: (DetailedResponse<SpeechModels> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<SpeechModels> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListModels result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListModels result: {0}", response.Response);
                     listModelsResponse = response.Result;
                     Assert.IsNotNull(listModelsResponse);
                     Assert.IsNotNull(listModelsResponse.Models);
@@ -150,9 +150,9 @@ namespace IBM.Watson.Tests
             byte[] audio = File.ReadAllBytes(testAudioPath);
 
             service.Recognize(
-                callback: (DetailedResponse<SpeechRecognitionResults> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<SpeechRecognitionResults> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "Recognize result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "Recognize result: {0}", response.Response);
                     recognizeResponse = response.Result;
                     Assert.IsNotNull(recognizeResponse);
                     Assert.IsNotNull(recognizeResponse.Results);
@@ -178,9 +178,9 @@ namespace IBM.Watson.Tests
             byte[] audio = File.ReadAllBytes(testAudioPath);
 
             service.CreateJob(
-                callback: (DetailedResponse<RecognitionJob> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<RecognitionJob> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CreateJob result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CreateJob result: {0}", response.Response);
                     createJobResponse = response.Result;
                     jobId = createJobResponse.Id;
                     Assert.IsNotNull(createJobResponse);
@@ -206,9 +206,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to CheckJob...");
             RecognitionJob checkJobResponse = null;
             service.CheckJob(
-                callback: (DetailedResponse<RecognitionJob> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<RecognitionJob> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckJob result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckJob result: {0}", response.Response);
                     checkJobResponse = response.Result;
                     Assert.IsNotNull(checkJobResponse);
                     Assert.IsTrue(checkJobResponse.Id == jobId);
@@ -231,9 +231,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to CheckJobs...");
             RecognitionJobs checkJobsResponse = null;
             service.CheckJobs(
-                callback: (DetailedResponse<RecognitionJobs> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<RecognitionJobs> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckJobs result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckJobs result: {0}", response.Response);
                     checkJobsResponse = response.Result;
                     Assert.IsNotNull(checkJobsResponse);
                     Assert.IsNotNull(checkJobsResponse.Recognitions);
@@ -254,9 +254,9 @@ namespace IBM.Watson.Tests
         //    Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to RegisterCallback...");
         //    RegisterStatus registerCallbackResponse = null;
         //    service.RegisterCallback(
-        //        callback: (DetailedResponse<RegisterStatus> response, IBMError error, Dictionary<string, object> customResponseData) =>
+        //        callback: (DetailedResponse<RegisterStatus> response, IBMError error) =>
         //        {
-        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "RegisterCallback result: {0}", customResponseData["json"].ToString());
+        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "RegisterCallback result: {0}", response.Response);
         //            registerCallbackResponse = response.Result;
         //            Assert.IsNotNull(registerCallbackResponse);
         //            Assert.IsNull(error);
@@ -278,9 +278,9 @@ namespace IBM.Watson.Tests
         //    Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to UnregisterCallback...");
         //    object unregisterCallbackResponse = null;
         //    service.UnregisterCallback(
-        //        callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+        //        callback: (DetailedResponse<object> response, IBMError error) =>
         //        {
-        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "UnregisterCallback result: {0}", customResponseData["json"].ToString());
+        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "UnregisterCallback result: {0}", response.Response);
         //            unregisterCallbackResponse = response.Result;
         //            Assert.IsNotNull(unregisterCallbackResponse);
         //            Assert.IsNull(error);
@@ -301,9 +301,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to CreateLanguageModel...");
             LanguageModel createLanguageModelResponse = null;
             service.CreateLanguageModel(
-                callback: (DetailedResponse<LanguageModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<LanguageModel> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CreateLanguageModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CreateLanguageModel result: {0}", response.Response);
                     createLanguageModelResponse = response.Result;
                     customizationId = createLanguageModelResponse.CustomizationId;
                     Assert.IsNotNull(createLanguageModelResponse);
@@ -330,9 +330,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to GetLanguageModel...");
             LanguageModel getLanguageModelResponse = null;
             service.GetLanguageModel(
-                callback: (DetailedResponse<LanguageModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<LanguageModel> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetLanguageModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetLanguageModel result: {0}", response.Response);
                     getLanguageModelResponse = response.Result;
                     Assert.IsNotNull(getLanguageModelResponse);
                     Assert.IsTrue(getLanguageModelResponse.CustomizationId == customizationId);
@@ -357,9 +357,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ListLanguageModels...");
             LanguageModels listLanguageModelsResponse = null;
             service.ListLanguageModels(
-                callback: (DetailedResponse<LanguageModels> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<LanguageModels> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListLanguageModels result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListLanguageModels result: {0}", response.Response);
                     listLanguageModelsResponse = response.Result;
                     Assert.IsNotNull(listLanguageModelsResponse);
                     Assert.IsNotNull(listLanguageModelsResponse.Customizations);
@@ -384,9 +384,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(corpusPath))
             {
                 service.AddCorpus(
-                    callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<object> response, IBMError error) =>
                     {
-                        Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddCorpus result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddCorpus result: {0}", response.Response);
                         Assert.IsNull(error);
                         Assert.IsTrue(response.StatusCode == 201);
                         isComplete = true;
@@ -411,9 +411,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to GetCorpus...");
             Corpus getCorpusResponse = null;
             service.GetCorpus(
-                callback: (DetailedResponse<Corpus> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Corpus> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetCorpus result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetCorpus result: {0}", response.Response);
                     getCorpusResponse = response.Result;
                     Assert.IsNotNull(getCorpusResponse);
                     Assert.IsTrue(getCorpusResponse.Name == corpusName);
@@ -437,9 +437,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ListCorpora...");
             Corpora listCorporaResponse = null;
             service.ListCorpora(
-                callback: (DetailedResponse<Corpora> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Corpora> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListCorpora result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListCorpora result: {0}", response.Response);
                     listCorporaResponse = response.Result;
                     Assert.IsNotNull(listCorporaResponse);
                     Assert.IsNotNull(listCorporaResponse._Corpora);
@@ -476,9 +476,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to TrainLanguageModel...");
             object trainLanguageModelResponse = null;
             service.TrainLanguageModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainLanguageModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainLanguageModel result: {0}", response.Response);
                     trainLanguageModelResponse = response.Result;
                     Assert.IsNotNull(trainLanguageModelResponse);
                     Assert.IsNull(error);
@@ -513,9 +513,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to AddWord...");
             bool isComplete = false;
             service.AddWord(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddWord result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddWord result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 201);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -569,9 +569,9 @@ namespace IBM.Watson.Tests
                 }
             };
             service.AddWords(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddWords result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddWords result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 201);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -594,9 +594,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to GetWord...");
             Word getWordResponse = null;
             service.GetWord(
-                callback: (DetailedResponse<Word> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Word> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetWord result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetWord result: {0}", response.Response);
                     getWordResponse = response.Result;
                     Assert.IsNotNull(getWordResponse);
                     Assert.IsTrue(getWordResponse._Word == wordName);
@@ -619,9 +619,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ListWords...");
             Words listWordsResponse = null;
             service.ListWords(
-                callback: (DetailedResponse<Words> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Words> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListWords result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListWords result: {0}", response.Response);
                     listWordsResponse = response.Result;
                     Assert.IsNotNull(listWordsResponse);
                     Assert.IsNotNull(listWordsResponse._Words);
@@ -660,9 +660,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to TrainLanguageModel2...");
             object trainLanguageModelResponse = null;
             service.TrainLanguageModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainLanguageModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainLanguageModel result: {0}", response.Response);
                     trainLanguageModelResponse = response.Result;
                     Assert.IsNotNull(trainLanguageModelResponse);
                     Assert.IsNull(error);
@@ -697,9 +697,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to AddGrammar...");
             bool isComplete = false;
             service.AddGrammar(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddGrammar result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddGrammar result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 201);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -724,9 +724,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to GetGrammar...");
             Grammar getGrammarResponse = null;
             service.GetGrammar(
-                callback: (DetailedResponse<Grammar> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Grammar> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetGrammar result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetGrammar result: {0}", response.Response);
                     getGrammarResponse = response.Result;
                     Assert.IsNotNull(getGrammarResponse);
                     Assert.IsTrue(getGrammarResponse.Name == grammarName);
@@ -749,9 +749,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ListGrammars...");
             Grammars listGrammarsResponse = null;
             service.ListGrammars(
-                callback: (DetailedResponse<Grammars> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Grammars> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListGrammars result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListGrammars result: {0}", response.Response);
                     listGrammarsResponse = response.Result;
                     Assert.IsNotNull(listGrammarsResponse);
                     Assert.IsNotNull(listGrammarsResponse._Grammars);
@@ -788,9 +788,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to TrainLanguageModel3...");
             object trainLanguageModelResponse = null;
             service.TrainLanguageModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainLanguageModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainLanguageModel result: {0}", response.Response);
                     trainLanguageModelResponse = response.Result;
                     Assert.IsNotNull(trainLanguageModelResponse);
                     Assert.IsNull(error);
@@ -825,9 +825,9 @@ namespace IBM.Watson.Tests
         //    Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to UpgradeLanguageModel...");
         //    object upgradeLanguageModelResponse = null;
         //    service.UpgradeLanguageModel(
-        //        callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+        //        callback: (DetailedResponse<object> response, IBMError error) =>
         //        {
-        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "UpgradeLanguageModel result: {0}", customResponseData["json"].ToString());
+        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "UpgradeLanguageModel result: {0}", response.Response);
         //            upgradeLanguageModelResponse = response.Result;
         //            Assert.IsNotNull(upgradeLanguageModelResponse);
         //            Assert.IsNull(error);
@@ -848,9 +848,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to CreateAcousticModel...");
             AcousticModel createAcousticModelResponse = null;
             service.CreateAcousticModel(
-                callback: (DetailedResponse<AcousticModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<AcousticModel> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CreateAcousticModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "CreateAcousticModel result: {0}", response.Response);
                     createAcousticModelResponse = response.Result;
                     acousticModelCustomizationId = createAcousticModelResponse.CustomizationId;
                     Assert.IsNotNull(createAcousticModelResponse);
@@ -875,9 +875,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to GetAcousticModel...");
             AcousticModel getAcousticModelResponse = null;
             service.GetAcousticModel(
-                callback: (DetailedResponse<AcousticModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<AcousticModel> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetAcousticModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetAcousticModel result: {0}", response.Response);
                     getAcousticModelResponse = response.Result;
                     Assert.IsNotNull(getAcousticModelResponse);
                     Assert.IsTrue(getAcousticModelResponse.CustomizationId == acousticModelCustomizationId);
@@ -902,9 +902,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ListAcousticModels...");
             AcousticModels listAcousticModelsResponse = null;
             service.ListAcousticModels(
-                callback: (DetailedResponse<AcousticModels> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<AcousticModels> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListAcousticModels result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListAcousticModels result: {0}", response.Response);
                     listAcousticModelsResponse = response.Result;
                     Assert.IsNotNull(listAcousticModelsResponse);
                     Assert.IsNotNull(listAcousticModelsResponse.Customizations);
@@ -927,9 +927,9 @@ namespace IBM.Watson.Tests
         //    Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to UpgradeAcousticModel...");
         //    object upgradeAcousticModelResponse = null;
         //    service.UpgradeAcousticModel(
-        //        callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+        //        callback: (DetailedResponse<object> response, IBMError error) =>
         //        {
-        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "UpgradeAcousticModel result: {0}", customResponseData["json"].ToString());
+        //            Log.Debug("SpeechToTextServiceV1IntegrationTests", "UpgradeAcousticModel result: {0}", response.Response);
         //            upgradeAcousticModelResponse = response.Result;
         //            Assert.IsNotNull(upgradeAcousticModelResponse);
         //            Assert.IsNull(error);
@@ -952,9 +952,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to AddAudio...");
             bool isComplete = false;
             service.AddAudio(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddAudio result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddAudio result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 201);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -980,9 +980,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to GetAudio...");
             AudioListing getAudioResponse = null;
             service.GetAudio(
-                callback: (DetailedResponse<AudioListing> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<AudioListing> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetAudio result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "GetAudio result: {0}", response.Response);
                     getAudioResponse = response.Result;
                     Assert.IsNotNull(getAudioResponse);
                     Assert.IsTrue(getAudioResponse.Name == acousticResourceName);
@@ -1005,9 +1005,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ListAudio...");
             AudioResources listAudioResponse = null;
             service.ListAudio(
-                callback: (DetailedResponse<AudioResources> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<AudioResources> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListAudio result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ListAudio result: {0}", response.Response);
                     listAudioResponse = response.Result;
                     Assert.IsNotNull(listAudioResponse);
                     Assert.IsNotNull(listAudioResponse.Audio);
@@ -1044,9 +1044,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to TrainAcousticModel...");
             bool isComplete = false;
             service.TrainAcousticModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainAcousticModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "TrainAcousticModel result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -1082,9 +1082,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteAudio...");
             bool isComplete = false;
             service.DeleteAudio(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteAudio result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteAudio result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -1106,9 +1106,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ResetAcousticModel...");
             bool isComplete = false;
             service.ResetAcousticModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ResetAcousticModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ResetAcousticModel result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -1129,9 +1129,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteAcousticModel...");
             bool isComplete = false;
             service.DeleteAcousticModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteAcousticModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteAcousticModel result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -1152,9 +1152,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteGrammar...");
             bool isComplete = false;
             service.DeleteGrammar(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteGrammar result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteGrammar result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -1176,9 +1176,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteWord...");
             bool isComplete = false;
             service.DeleteWord(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteWord result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteWord result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -1200,9 +1200,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteCorpus...");
             bool isComplete = false;
             service.DeleteCorpus(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteCorpus result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteCorpus result: {0}", response.Response);
                     isComplete = true;
                     Assert.IsNull(error);
                     Assert.IsTrue(response.StatusCode == 200);
@@ -1224,9 +1224,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to ResetLanguageModel...");
             bool isComplete = false;
             service.ResetLanguageModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ResetLanguageModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "ResetLanguageModel result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -1247,9 +1247,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteLanguageModel...");
             bool isComplete = false;
             service.DeleteLanguageModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteLanguageModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteLanguageModel result: {0}", response.Response);
                     Assert.IsNull(error);
                     Assert.IsTrue(response.StatusCode == 200);
                     isComplete = true;
@@ -1270,9 +1270,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteJob...");
             bool isComplete = false;
             service.DeleteJob(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteJob result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteJob result: {0}", response.Response);
                     Assert.IsNull(error);
                     var statusCode = response.StatusCode;
                     Assert.IsTrue(response.StatusCode == 204);
@@ -1294,9 +1294,9 @@ namespace IBM.Watson.Tests
             Log.Debug("SpeechToTextServiceV1IntegrationTests", "Attempting to DeleteUserData...");
             object deleteUserDataResponse = null;
             service.DeleteUserData(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteUserData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("SpeechToTextServiceV1IntegrationTests", "DeleteUserData result: {0}", response.Response);
                     deleteUserDataResponse = response.Result;
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);
@@ -1321,7 +1321,7 @@ namespace IBM.Watson.Tests
             try
             {
                 service.GetLanguageModel(
-                    callback: (DetailedResponse<LanguageModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<LanguageModel> response, IBMError error) =>
                     {
                         getLanguageModelResponse = response.Result;
                         Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckLanguageModelStatus: {0}", getLanguageModelResponse.Status);
@@ -1359,7 +1359,7 @@ namespace IBM.Watson.Tests
             try
             {
                 service.GetCorpus(
-                    callback: (DetailedResponse<Corpus> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<Corpus> response, IBMError error) =>
                     {
                         getCorpusResponse = response.Result;
                         Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckCorpusStatus: {0}", getCorpusResponse.Status);
@@ -1398,7 +1398,7 @@ namespace IBM.Watson.Tests
             try
             {
                 service.GetGrammar(
-                    callback: (DetailedResponse<Grammar> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<Grammar> response, IBMError error) =>
                     {
                         getGrammarResponse = response.Result;
                         if (getGrammarResponse.Status != Grammar.StatusValue.ANALYZED)
@@ -1436,7 +1436,7 @@ namespace IBM.Watson.Tests
             try
             {
                 service.GetAcousticModel(
-                    callback: (DetailedResponse<AcousticModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<AcousticModel> response, IBMError error) =>
                     {
                         getAcousticModelResponse = response.Result;
                         Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckAcousticModelStatus: {0}", getAcousticModelResponse.Status);
@@ -1474,7 +1474,7 @@ namespace IBM.Watson.Tests
             try
             {
                 service.GetAudio(
-                    callback: (DetailedResponse<AudioListing> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<AudioListing> response, IBMError error) =>
                     {
                         getAudioResponse = response.Result;
                         Log.Debug("SpeechToTextServiceV1IntegrationTests", "CheckAudioStatus: {0}", getAudioResponse.Status);

--- a/Tests/TextToSpeechIntegrationTests.cs
+++ b/Tests/TextToSpeechIntegrationTests.cs
@@ -78,9 +78,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to GetVoice...");
             Voice getVoiceResponse = null;
             service.GetVoice(
-                callback: (DetailedResponse<Voice> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Voice> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetVoice result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetVoice result: {0}", response.Response);
                     getVoiceResponse = response.Result;
                     Assert.IsNotNull(getVoiceResponse);
                     Assert.IsTrue(getVoiceResponse.Name == allisionVoice);
@@ -102,9 +102,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to ListVoices...");
             Voices listVoicesResponse = null;
             service.ListVoices(
-                callback: (DetailedResponse<Voices> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Voices> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "ListVoices result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "ListVoices result: {0}", response.Response);
                     listVoicesResponse = response.Result;
                     Assert.IsNotNull(listVoicesResponse);
                     Assert.IsNotNull(listVoicesResponse._Voices);
@@ -127,7 +127,7 @@ namespace IBM.Watson.Tests
             byte[] synthesizeResponse = null;
             AudioClip clip = null;
             service.Synthesize(
-                callback: (DetailedResponse<byte[]> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<byte[]> response, IBMError error) =>
                 {
                     synthesizeResponse = response.Result;
                     Assert.IsNotNull(synthesizeResponse);
@@ -156,9 +156,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to GetPronunciation...");
             Pronunciation getPronunciationResponse = null;
             service.GetPronunciation(
-                callback: (DetailedResponse<Pronunciation> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Pronunciation> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetPronunciation result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetPronunciation result: {0}", response.Response);
                     getPronunciationResponse = response.Result;
                     Assert.IsNotNull(getPronunciationResponse);
                     Assert.IsNotNull(getPronunciationResponse._Pronunciation);
@@ -182,9 +182,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to CreateVoiceModel...");
             VoiceModel createVoiceModelResponse = null;
             service.CreateVoiceModel(
-                callback: (DetailedResponse<VoiceModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<VoiceModel> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "CreateVoiceModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "CreateVoiceModel result: {0}", response.Response);
                     createVoiceModelResponse = response.Result;
                     customizationId = createVoiceModelResponse.CustomizationId;
                     Assert.IsNotNull(createVoiceModelResponse);
@@ -210,9 +210,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to GetVoiceModel...");
             VoiceModel getVoiceModelResponse = null;
             service.GetVoiceModel(
-                callback: (DetailedResponse<VoiceModel> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<VoiceModel> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetVoiceModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetVoiceModel result: {0}", response.Response);
                     getVoiceModelResponse = response.Result;
                     Assert.IsNotNull(getVoiceModelResponse);
                     Assert.IsTrue(getVoiceModelResponse.CustomizationId == customizationId);
@@ -237,9 +237,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to ListVoiceModels...");
             VoiceModels listVoiceModelsResponse = null;
             service.ListVoiceModels(
-                callback: (DetailedResponse<VoiceModels> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<VoiceModels> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "ListVoiceModels result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "ListVoiceModels result: {0}", response.Response);
                     listVoiceModelsResponse = response.Result;
                     Assert.IsNotNull(listVoiceModelsResponse);
                     Assert.IsNotNull(listVoiceModelsResponse.Customizations);
@@ -262,9 +262,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to UpdateVoiceModel...");
             object updateVoiceModelResponse = null;
             service.UpdateVoiceModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "UpdateVoiceModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "UpdateVoiceModel result: {0}", response.Response);
                     updateVoiceModelResponse = response.Result;
                     Assert.IsNotNull(updateVoiceModelResponse);
                     Assert.IsNull(error);
@@ -287,9 +287,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to AddWord...");
             bool isComplete = false;
             service.AddWord(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "AddWord result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "AddWord result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -331,9 +331,9 @@ namespace IBM.Watson.Tests
             };
 
             service.AddWords(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "AddWords result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "AddWords result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -355,9 +355,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to GetWord...");
             Translation getWordResponse = null;
             service.GetWord(
-                callback: (DetailedResponse<Translation> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Translation> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetWord result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "GetWord result: {0}", response.Response);
                     getWordResponse = response.Result;
                     Assert.IsNotNull(getWordResponse);
                     Assert.IsTrue(getWordResponse._Translation == customWordTranslation);
@@ -380,9 +380,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to ListWords...");
             Words listWordsResponse = null;
             service.ListWords(
-                callback: (DetailedResponse<Words> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Words> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "ListWords result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "ListWords result: {0}", response.Response);
                     listWordsResponse = response.Result;
                     Assert.IsNotNull(listWordsResponse);
                     Assert.IsNotNull(listWordsResponse._Words);
@@ -405,9 +405,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to DeleteWord...");
             bool isComplete = false;
             service.DeleteWord(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "DeleteWord result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "DeleteWord result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 204);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -429,9 +429,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to DeleteVoiceModel...");
             bool isComplete = false;
             service.DeleteVoiceModel(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "DeleteVoiceModel result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "DeleteVoiceModel result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 204);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -452,9 +452,9 @@ namespace IBM.Watson.Tests
             Log.Debug("TextToSpeechServiceV1IntegrationTests", "Attempting to DeleteUserData...");
             object deleteUserDataResponse = null;
             service.DeleteUserData(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "DeleteUserData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("TextToSpeechServiceV1IntegrationTests", "DeleteUserData result: {0}", response.Response);
                     deleteUserDataResponse = response.Result;
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);

--- a/Tests/TextToSpeechIntegrationTests.cs
+++ b/Tests/TextToSpeechIntegrationTests.cs
@@ -31,8 +31,6 @@ namespace IBM.Watson.Tests
     public class TextToSpeechV1IntegrationTests
     {
         private TextToSpeechService service;
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string allisionVoice = "en-US_AllisonVoice";
         private string synthesizeText = "Hello, welcome to the Watson Unity SDK!";
         private string synthesizeMimeType = "audio/wav";
@@ -49,7 +47,6 @@ namespace IBM.Watson.Tests
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -67,8 +64,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region GetVoice
@@ -86,8 +82,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getVoiceResponse.Name == allisionVoice);
                     Assert.IsNull(error);
                 },
-                voice: allisionVoice,
-                customData: customData
+                voice: allisionVoice
             );
 
             while (getVoiceResponse == null)
@@ -110,8 +105,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(listVoicesResponse._Voices);
                     Assert.IsTrue(listVoicesResponse._Voices.Count > 0);
                     Assert.IsNull(error);
-                },
-                customData: customData
+                }
             );
 
             while (listVoicesResponse == null)
@@ -138,8 +132,7 @@ namespace IBM.Watson.Tests
                 },
                 text: synthesizeText,
                 voice: allisionVoice,
-                accept: synthesizeMimeType,
-                customData: customData
+                accept: synthesizeMimeType
             );
 
             while (synthesizeResponse == null)
@@ -166,8 +159,7 @@ namespace IBM.Watson.Tests
                 },
                 text: synthesizeText,
                 voice: allisionVoice,
-                format: "ipa",
-                customData: customData
+                format: "ipa"
             );
 
             while (getPronunciationResponse == null)
@@ -193,9 +185,7 @@ namespace IBM.Watson.Tests
                 },
                 name: voiceModelName,
                 language: voiceModelLanguage,
-                description: voiceModelDescription,
-
-                customData: customData
+                description: voiceModelDescription
             );
 
             while (createVoiceModelResponse == null)
@@ -221,8 +211,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getVoiceModelResponse.Description == voiceModelDescription);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (getVoiceModelResponse == null)
@@ -246,8 +235,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listVoiceModelsResponse.Customizations.Count > 0);
                     Assert.IsNull(error);
                 },
-                language: voiceModelLanguage,
-                customData: customData
+                language: voiceModelLanguage
             );
 
             while (listVoiceModelsResponse == null)
@@ -271,8 +259,7 @@ namespace IBM.Watson.Tests
                 },
                 customizationId: customizationId,
                 name: voiceModelNameUpdated,
-                description: voiceModelDescriptionUpdated,
-                customData: customData
+                description: voiceModelDescriptionUpdated
             );
 
             while (updateVoiceModelResponse == null)
@@ -296,8 +283,7 @@ namespace IBM.Watson.Tests
                 },
                 customizationId: customizationId,
                 word: customWord,
-                translation: customWordTranslation,
-                customData: customData
+                translation: customWordTranslation
             );
 
             while (!isComplete)
@@ -339,8 +325,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 customizationId: customizationId,
-                words: words,
-                customData: customData
+                words: words
             );
 
             while (!isComplete)
@@ -364,8 +349,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                 },
                 customizationId: customizationId,
-                word: customWord,
-                customData: customData
+                word: customWord
             );
 
             while (getWordResponse == null)
@@ -389,8 +373,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listWordsResponse._Words.Count > 0);
                     Assert.IsNull(error);
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (listWordsResponse == null)
@@ -413,8 +396,7 @@ namespace IBM.Watson.Tests
                     isComplete = true;
                 },
                 customizationId: customizationId,
-                word: customWord,
-                customData: customData
+                word: customWord
             );
 
             while (!isComplete)
@@ -436,8 +418,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                     isComplete = true;
                 },
-                customizationId: customizationId,
-                customData: customData
+                customizationId: customizationId
             );
 
             while (!isComplete)
@@ -459,8 +440,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);
                 },
-                customerId: "customerId",
-                customData: customData
+                customerId: "customerId"
             );
 
             while (deleteUserDataResponse == null)

--- a/Tests/ToneAnalyzerV3IntegrationTests.cs
+++ b/Tests/ToneAnalyzerV3IntegrationTests.cs
@@ -71,9 +71,9 @@ namespace IBM.Watson.Tests
                 Text = inputText
             };
             service.Tone(
-                callback: (DetailedResponse<ToneAnalysis> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<ToneAnalysis> response, IBMError error) =>
                 {
-                    Log.Debug("ToneAnalyzerServiceV3IntegrationTests", "Tone result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("ToneAnalyzerServiceV3IntegrationTests", "Tone result: {0}", response.Response);
                     toneResponse = response.Result;
                     Assert.IsNotNull(toneResponse);
                     Assert.IsNotNull(toneResponse.SentencesTone);
@@ -107,9 +107,9 @@ namespace IBM.Watson.Tests
                 }
             };
             service.ToneChat(
-                callback: (DetailedResponse<UtteranceAnalyses> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<UtteranceAnalyses> response, IBMError error) =>
                 {
-                    Log.Debug("ToneAnalyzerServiceV3IntegrationTests", "ToneChat result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("ToneAnalyzerServiceV3IntegrationTests", "ToneChat result: {0}", response.Response);
                     toneChatResponse = response.Result;
                     Assert.IsNotNull(toneChatResponse);
                     Assert.IsNotNull(toneChatResponse.UtterancesTone);

--- a/Tests/ToneAnalyzerV3IntegrationTests.cs
+++ b/Tests/ToneAnalyzerV3IntegrationTests.cs
@@ -29,8 +29,6 @@ namespace IBM.Watson.Tests
     {
         private ToneAnalyzerService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string inputText = "Hello! Welcome to IBM Watson! How can I help you?";
         private string chatUser = "testChatUser";
 
@@ -38,7 +36,6 @@ namespace IBM.Watson.Tests
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
         }
 
         [UnitySetUp]
@@ -56,8 +53,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region Tone
@@ -83,8 +79,7 @@ namespace IBM.Watson.Tests
                 toneInput: toneInput,
                 contentLanguage: "en",
                 acceptLanguage: "en",
-                contentType: "text/plain",
-                customData: customData
+                contentType: "text/plain"
             );
 
             while (toneResponse == null)
@@ -117,8 +112,7 @@ namespace IBM.Watson.Tests
                 },
                 utterances: utterances,
                 contentLanguage: "en",
-                acceptLanguage: "en",
-                customData: customData
+                acceptLanguage: "en"
             );
 
             while (toneChatResponse == null)

--- a/Tests/VisualRecognitionV3IntegrationTests.cs
+++ b/Tests/VisualRecognitionV3IntegrationTests.cs
@@ -33,8 +33,6 @@ namespace IBM.Watson.Tests
     {
         private VisualRecognitionService service;
         private string versionDate = "2019-02-13";
-        private Dictionary<string, object> customData;
-        private Dictionary<string, string> customHeaders = new Dictionary<string, string>();
         private string giraffePositiveExamplesFilepath;
         private string turtlePositiveExamplesFilepath;
         private string negativeExamplesFilepath;
@@ -52,7 +50,6 @@ namespace IBM.Watson.Tests
         public void OneTimeSetup()
         {
             LogSystem.InstallDefaultReactors();
-            customHeaders.Add("X-Watson-Test", "1");
 
             giraffePositiveExamplesFilepath = Application.dataPath + "/Watson/Tests/TestData/VisualRecognitionV3/giraffe_positive_examples.zip";
             turtlePositiveExamplesFilepath = Application.dataPath + "/Watson/Tests/TestData/VisualRecognitionV3/turtle_positive_examples.zip";
@@ -78,8 +75,7 @@ namespace IBM.Watson.Tests
         [SetUp]
         public void TestSetup()
         {
-            customData = new Dictionary<string, object>();
-            customData.Add(Constants.String.CUSTOM_REQUEST_HEADERS, customHeaders);
+            service.WithHeader("X-Watson-Test", "1");
         }
 
         #region Classify
@@ -103,8 +99,7 @@ namespace IBM.Watson.Tests
                         Assert.IsNull(error);
                     },
                     imagesFile: fs,
-                    imagesFileContentType: turtleImageContentType,
-                    customData: customData
+                    imagesFileContentType: turtleImageContentType
                 );
 
                 while (classifyResponse == null)
@@ -134,8 +129,7 @@ namespace IBM.Watson.Tests
                         Assert.IsNull(error);
                     },
                     imagesFile: fs,
-                    imagesFileContentType: obamaImageContentType,
-                    customData: customData
+                    imagesFileContentType: obamaImageContentType
                 );
 
                 while (detectFacesResponse == null)
@@ -172,8 +166,7 @@ namespace IBM.Watson.Tests
                         },
                         name: classifierName,
                         positiveExamples: positiveExamples,
-                        negativeExamples: fs1,
-                        customData: customData
+                        negativeExamples: fs1
                     );
 
                     while (createClassifierResponse == null)
@@ -198,8 +191,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(getClassifierResponse.ClassifierId == classifierId);
                     Assert.IsNull(error);
                 },
-                classifierId: classifierId,
-                customData: customData
+                classifierId: classifierId
             );
 
             while (getClassifierResponse == null)
@@ -223,8 +215,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(listClassifiersResponse._Classifiers.Count > 0);
                     Assert.IsNull(error);
                 },
-                verbose: true,
-                customData: customData
+                verbose: true
             );
 
             while (listClassifiersResponse == null)
@@ -267,8 +258,7 @@ namespace IBM.Watson.Tests
                         Assert.IsNull(error);
                     },
                     classifierId: classifierId,
-                    positiveExamples: positiveExamples,
-                    customData: customData
+                    positiveExamples: positiveExamples
                 );
 
                 while (updateClassifierResponse == null)
@@ -311,8 +301,7 @@ namespace IBM.Watson.Tests
                         fs.Close();
                     }
                 },
-                classifierId: classifierId,
-                customData: customData
+                classifierId: classifierId
             );
 
             while (getCoreMlModelResponse == null)
@@ -334,8 +323,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNull(error);
                     isComplete = true;
                 },
-                classifierId: classifierId,
-                customData: customData
+                classifierId: classifierId
             );
 
             while (!isComplete)
@@ -357,8 +345,7 @@ namespace IBM.Watson.Tests
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);
                 },
-                customerId: "customerId",
-                customData: customData
+                customerId: "customerId"
             );
 
             while (deleteUserDataResponse == null)
@@ -390,8 +377,7 @@ namespace IBM.Watson.Tests
                             Runnable.Run(CheckClassifierStatus());
                         }
                     },
-                    classifierId: classifierId,
-                    customData: customData
+                    classifierId: classifierId
                 );
             }
             catch

--- a/Tests/VisualRecognitionV3IntegrationTests.cs
+++ b/Tests/VisualRecognitionV3IntegrationTests.cs
@@ -91,9 +91,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(turtleImageFilepath))
             {
                 service.Classify(
-                    callback: (DetailedResponse<ClassifiedImages> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<ClassifiedImages> response, IBMError error) =>
                     {
-                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Classify result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Classify result: {0}", response.Response);
                         classifyResponse = response.Result;
                         Assert.IsNotNull(classifyResponse);
                         Assert.IsNotNull(classifyResponse.Images);
@@ -122,9 +122,9 @@ namespace IBM.Watson.Tests
             using (FileStream fs = File.OpenRead(obamaImageFilepath))
             {
                 service.DetectFaces(
-                    callback: (DetailedResponse<DetectedFaces> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<DetectedFaces> response, IBMError error) =>
                     {
-                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DetectFaces result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DetectFaces result: {0}", response.Response);
                         detectFacesResponse = response.Result;
                         Assert.IsNotNull(detectFacesResponse);
                         Assert.IsNotNull(detectFacesResponse.Images);
@@ -157,9 +157,9 @@ namespace IBM.Watson.Tests
                     Dictionary<string, FileStream> positiveExamples = new Dictionary<string, FileStream>();
                     positiveExamples.Add("giraffe_positive_examples", fs0);
                     service.CreateClassifier(
-                        callback: (DetailedResponse<Classifier> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                        callback: (DetailedResponse<Classifier> response, IBMError error) =>
                         {
-                            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "CreateClassifier result: {0}", customResponseData["json"].ToString());
+                            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "CreateClassifier result: {0}", response.Response);
                             createClassifierResponse = response.Result;
                             classifierId = createClassifierResponse.ClassifierId;
                             Assert.IsNotNull(createClassifierResponse);
@@ -190,9 +190,9 @@ namespace IBM.Watson.Tests
             Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to GetClassifier...");
             Classifier getClassifierResponse = null;
             service.GetClassifier(
-                callback: (DetailedResponse<Classifier> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Classifier> response, IBMError error) =>
                 {
-                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "GetClassifier result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "GetClassifier result: {0}", response.Response);
                     getClassifierResponse = response.Result;
                     Assert.IsNotNull(getClassifierResponse);
                     Assert.IsTrue(getClassifierResponse.ClassifierId == classifierId);
@@ -214,9 +214,9 @@ namespace IBM.Watson.Tests
             Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to ListClassifiers...");
             Classifiers listClassifiersResponse = null;
             service.ListClassifiers(
-                callback: (DetailedResponse<Classifiers> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<Classifiers> response, IBMError error) =>
                 {
-                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "ListClassifiers result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "ListClassifiers result: {0}", response.Response);
                     listClassifiersResponse = response.Result;
                     Assert.IsNotNull(listClassifiersResponse);
                     Assert.IsNotNull(listClassifiersResponse._Classifiers);
@@ -257,9 +257,9 @@ namespace IBM.Watson.Tests
                 Dictionary<string, FileStream> positiveExamples = new Dictionary<string, FileStream>();
                 positiveExamples.Add("turtles_positive_examples", fs);
                 service.UpdateClassifier(
-                    callback: (DetailedResponse<Classifier> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<Classifier> response, IBMError error) =>
                     {
-                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "UpdateClassifier result: {0}", customResponseData["json"].ToString());
+                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "UpdateClassifier result: {0}", response.Response);
                         updateClassifierResponse = response.Result;
                         Assert.IsNotNull(updateClassifierResponse);
                         Assert.IsNotNull(updateClassifierResponse.Classes);
@@ -298,7 +298,7 @@ namespace IBM.Watson.Tests
             Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to GetCoreMlModel...");
             byte[] getCoreMlModelResponse = null;
             service.GetCoreMlModel(
-                callback: (DetailedResponse<byte[]> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<byte[]> response, IBMError error) =>
                 {
                     getCoreMlModelResponse = response.Result;
                     Assert.IsNotNull(getCoreMlModelResponse);
@@ -327,9 +327,9 @@ namespace IBM.Watson.Tests
             Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to DeleteClassifier...");
             bool isComplete = false;
             service.DeleteClassifier(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DeleteClassifier result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DeleteClassifier result: {0}", response.Response);
                     Assert.IsTrue(response.StatusCode == 200);
                     Assert.IsNull(error);
                     isComplete = true;
@@ -350,9 +350,9 @@ namespace IBM.Watson.Tests
             Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to DeleteUserData...");
             object deleteUserDataResponse = null;
             service.DeleteUserData(
-                callback: (DetailedResponse<object> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DeleteUserData result: {0}", customResponseData["json"].ToString());
+                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DeleteUserData result: {0}", response.Response);
                     deleteUserDataResponse = response.Result;
                     Assert.IsNotNull(deleteUserDataResponse);
                     Assert.IsNull(error);
@@ -377,7 +377,7 @@ namespace IBM.Watson.Tests
             try
             {
                 service.GetClassifier(
-                    callback: (DetailedResponse<Classifier> response, IBMError error, Dictionary<string, object> customResponseData) =>
+                    callback: (DetailedResponse<Classifier> response, IBMError error) =>
                     {
                         getClassifierResponse = response.Result;
                         Log.Debug("VisualRecognitionServiceV3IntegrationTests", "CheckClassifierStatus: {0}", getClassifierResponse.Status);


### PR DESCRIPTION
### Summary
This pull request removes dependency of a customData object. Custom request headers are no set directly on the service instance for the call. Response headers and response json are returned in the DetailedResponse object.