### PR TITLE
File type and Synthesized Filename parameters

### DIFF
--- a/Scripts/Services/Assistant/V1/AssistantService.cs
+++ b/Scripts/Services/Assistant/V1/AssistantService.cs
@@ -136,9 +136,12 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="input">An input object that includes the input text. (optional)</param>
-        /// <param name="intents">An array of intents recognized in the user input, sorted in descending order of
-        /// confidence. (optional)</param>
-        /// <param name="entities">An array of entities identified in the user input. (optional)</param>
+        /// <param name="intents">Intents to use when evaluating the user input. Include intents from the previous
+        /// response to continue using those intents rather than trying to recognize intents in the new input.
+        /// (optional)</param>
+        /// <param name="entities">Entities to use when evaluating the message. Include entities from the previous
+        /// response to continue using those entities rather than detecting entities in the new input.
+        /// (optional)</param>
         /// <param name="alternateIntents">Whether to return more than one intent. A value of `true` indicates that all
         /// matching intents are returned. (optional, default to false)</param>
         /// <param name="context">State information for the conversation. To maintain state, include the context from
@@ -519,8 +522,7 @@ namespace IBM.Watson.Assistant.V1
         /// This operation is limited to 500 requests per 30 minutes. For more information, see **Rate limiting**.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned workspaces will be sorted. To reverse the sort order,
@@ -1009,8 +1011,7 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="export">Whether to include all element content in the returned data. If **export**=`false`, the
         /// returned data includes only information about the element itself. If **export**=`true`, all content,
         /// including subelements, is included. (optional, default to false)</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned intents will be sorted. To reverse the sort order, prefix
@@ -1468,8 +1469,7 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="intent">The intent name.</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned examples will be sorted. To reverse the sort order,
@@ -1915,8 +1915,7 @@ namespace IBM.Watson.Assistant.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned counterexamples will be sorted. To reverse the sort
@@ -2377,8 +2376,7 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="export">Whether to include all element content in the returned data. If **export**=`false`, the
         /// returned data includes only information about the element itself. If **export**=`true`, all content,
         /// including subelements, is included. (optional, default to false)</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned entities will be sorted. To reverse the sort order,
@@ -2958,8 +2956,7 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="export">Whether to include all element content in the returned data. If **export**=`false`, the
         /// returned data includes only information about the element itself. If **export**=`true`, all content,
         /// including subelements, is included. (optional, default to false)</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned entity values will be sorted. To reverse the sort order,
@@ -3442,8 +3439,7 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
         /// <param name="entity">The name of the entity.</param>
         /// <param name="value">The text of the entity value.</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned entity value synonyms will be sorted. To reverse the sort
@@ -3949,8 +3945,7 @@ namespace IBM.Watson.Assistant.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="workspaceId">Unique identifier of the workspace.</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="includeCount">Whether to include information about the number of records returned. (optional,
         /// default to false)</param>
         /// <param name="sort">The attribute by which returned dialog nodes will be sorted. To reverse the sort order,
@@ -4210,8 +4205,7 @@ namespace IBM.Watson.Assistant.V1
         /// <param name="sort">How to sort the returned log events. You can sort by **request_timestamp**. To reverse
         /// the sort order, prefix the parameter value with a minus sign (`-`). (optional, default to
         /// request_timestamp)</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <returns><see cref="LogCollection" />LogCollection</returns>
         public bool ListAllLogs(Callback<LogCollection> callback, string filter, string sort = null, long? pageLimit = null, string cursor = null)
@@ -4310,8 +4304,7 @@ namespace IBM.Watson.Assistant.V1
         /// For more information, see the
         /// [documentation](https://cloud.ibm.com/docs/services/assistant/filter-reference.html#filter-reference-syntax).
         /// (optional)</param>
-        /// <param name="pageLimit">The number of records to return in each page of results. (optional, default to
-        /// 100)</param>
+        /// <param name="pageLimit">The number of records to return in each page of results. (optional)</param>
         /// <param name="cursor">A token identifying the page of results to retrieve. (optional)</param>
         /// <returns><see cref="LogCollection" />LogCollection</returns>
         public bool ListLogs(Callback<LogCollection> callback, string workspaceId, string sort = null, string filter = null, long? pageLimit = null, string cursor = null)

--- a/Scripts/Services/Assistant/V1/Model/MessageRequest.cs
+++ b/Scripts/Services/Assistant/V1/Model/MessageRequest.cs
@@ -22,9 +22,9 @@ using Newtonsoft.Json.Linq;
 namespace IBM.Watson.Assistant.V1.Model
 {
     /// <summary>
-    /// BaseMessage.
+    /// A request sent to the workspace, including the user input and context.
     /// </summary>
-    public class BaseMessage
+    public class MessageRequest
     {
         /// <summary>
         /// An input object that includes the input text.
@@ -32,12 +32,14 @@ namespace IBM.Watson.Assistant.V1.Model
         [JsonProperty("input", NullValueHandling = NullValueHandling.Ignore)]
         public JObject Input { get; set; }
         /// <summary>
-        /// An array of intents recognized in the user input, sorted in descending order of confidence.
+        /// Intents to use when evaluating the user input. Include intents from the previous response to continue using
+        /// those intents rather than trying to recognize intents in the new input.
         /// </summary>
         [JsonProperty("intents", NullValueHandling = NullValueHandling.Ignore)]
         public List<JObject> Intents { get; set; }
         /// <summary>
-        /// An array of entities identified in the user input.
+        /// Entities to use when evaluating the message. Include entities from the previous response to continue using
+        /// those entities rather than detecting entities in the new input.
         /// </summary>
         [JsonProperty("entities", NullValueHandling = NullValueHandling.Ignore)]
         public List<JObject> Entities { get; set; }

--- a/Scripts/Services/Assistant/V1/Model/MessageRequest.cs.meta
+++ b/Scripts/Services/Assistant/V1/Model/MessageRequest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3db39cd2d1c699842a633e53d748df1d
+guid: f3fad2fc11b4c264ba72d5e6f8680b2a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Scripts/Services/Assistant/V1/Model/ModelLog.cs
+++ b/Scripts/Services/Assistant/V1/Model/ModelLog.cs
@@ -28,7 +28,7 @@ namespace IBM.Watson.Assistant.V1.Model
         /// A request sent to the workspace, including the user input and context.
         /// </summary>
         [JsonProperty("request", NullValueHandling = NullValueHandling.Ignore)]
-        public BaseMessage Request { get; set; }
+        public MessageRequest Request { get; set; }
         /// <summary>
         /// The response sent by the workspace, including the output text, detected intents and entities, and context.
         /// </summary>

--- a/Scripts/Services/CompareComply/V1/CompareComplyService.cs
+++ b/Scripts/Services/CompareComply/V1/CompareComplyService.cs
@@ -133,18 +133,21 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="file">The file to convert.</param>
+        /// <param name="filename">The filename for file.</param>
         /// <param name="modelId">The analysis model to be used by the service. For the `/v1/element_classification` and
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="HTMLReturn" />HTMLReturn</returns>
-        public bool ConvertToHtml(Callback<HTMLReturn> callback, System.IO.FileStream file, string modelId = null, string fileContentType = null)
+        public bool ConvertToHtml(Callback<HTMLReturn> callback, System.IO.MemoryStream file, string filename, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ConvertToHtml`");
             if (file == null)
                 throw new ArgumentNullException("`file` is required for `ConvertToHtml`");
+            if (string.IsNullOrEmpty(filename))
+                throw new ArgumentNullException("`filename` is required for `ConvertToHtml`");
 
             RequestObject<HTMLReturn> req = new RequestObject<HTMLReturn>
             {
@@ -169,7 +172,7 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, file.Name, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
             }
             if (!string.IsNullOrEmpty(modelId))
             {
@@ -218,13 +221,14 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="file">The file to classify.</param>
+        /// <param name="filename">The filename for file. (optional)</param>
         /// <param name="modelId">The analysis model to be used by the service. For the `/v1/element_classification` and
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="ClassifyReturn" />ClassifyReturn</returns>
-        public bool ClassifyElements(Callback<ClassifyReturn> callback, System.IO.FileStream file, string modelId = null, string fileContentType = null)
+        public bool ClassifyElements(Callback<ClassifyReturn> callback, System.IO.MemoryStream file, string filename = null, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ClassifyElements`");
@@ -254,7 +258,7 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, file.Name, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
             }
             if (!string.IsNullOrEmpty(modelId))
             {
@@ -303,13 +307,14 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="file">The file on which to run table extraction.</param>
+        /// <param name="filename">The filename for file. (optional)</param>
         /// <param name="modelId">The analysis model to be used by the service. For the `/v1/element_classification` and
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="TableReturn" />TableReturn</returns>
-        public bool ExtractTables(Callback<TableReturn> callback, System.IO.FileStream file, string modelId = null, string fileContentType = null)
+        public bool ExtractTables(Callback<TableReturn> callback, System.IO.MemoryStream file, string filename = null, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ExtractTables`");
@@ -339,7 +344,7 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, file.Name, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
             }
             if (!string.IsNullOrEmpty(modelId))
             {
@@ -388,7 +393,9 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="file1">The first file to compare.</param>
+        /// <param name="file1Filename">The filename for file1. (optional)</param>
         /// <param name="file2">The second file to compare.</param>
+        /// <param name="file2Filename">The filename for file2. (optional)</param>
         /// <param name="file1Label">A text label for the first file. (optional, default to file_1)</param>
         /// <param name="file2Label">A text label for the second file. (optional, default to file_2)</param>
         /// <param name="modelId">The analysis model to be used by the service. For the `/v1/element_classification` and
@@ -398,7 +405,7 @@ namespace IBM.Watson.CompareComply.V1
         /// <param name="file1ContentType">The content type of file1. (optional)</param>
         /// <param name="file2ContentType">The content type of file2. (optional)</param>
         /// <returns><see cref="CompareReturn" />CompareReturn</returns>
-        public bool CompareDocuments(Callback<CompareReturn> callback, System.IO.FileStream file1, System.IO.FileStream file2, string file1Label = null, string file2Label = null, string modelId = null, string file1ContentType = null, string file2ContentType = null)
+        public bool CompareDocuments(Callback<CompareReturn> callback, System.IO.MemoryStream file1, System.IO.MemoryStream file2, string file1Filename = null, string file2Filename = null, string file1Label = null, string file2Label = null, string modelId = null, string file1ContentType = null, string file2ContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CompareDocuments`");
@@ -430,11 +437,11 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file1 != null)
             {
-                req.Forms["file_1"] = new RESTConnector.Form(file1, file1.Name, file1ContentType);
+                req.Forms["file_1"] = new RESTConnector.Form(file1, file1Filename, file1ContentType);
             }
             if (file2 != null)
             {
-                req.Forms["file_2"] = new RESTConnector.Form(file2, file2.Name, file2ContentType);
+                req.Forms["file_2"] = new RESTConnector.Form(file2, file2Filename, file2ContentType);
             }
             if (!string.IsNullOrEmpty(file1Label))
             {
@@ -909,6 +916,7 @@ namespace IBM.Watson.CompareComply.V1
         /// <param name="inputCredentialsFile">A JSON file containing the input Cloud Object Storage credentials. At a
         /// minimum, the credentials must enable `READ` permissions on the bucket defined by the `input_bucket_name`
         /// parameter.</param>
+        /// <param name="inputCredentialsFilename">The filename for inputCredentialsFile. (optional)</param>
         /// <param name="inputBucketLocation">The geographical location of the Cloud Object Storage input bucket as
         /// listed on the **Endpoint** tab of your Cloud Object Storage instance; for example, `us-geo`, `eu-geo`, or
         /// `ap-geo`.</param>
@@ -916,6 +924,7 @@ namespace IBM.Watson.CompareComply.V1
         /// <param name="outputCredentialsFile">A JSON file that lists the Cloud Object Storage output credentials. At a
         /// minimum, the credentials must enable `READ` and `WRITE` permissions on the bucket defined by the
         /// `output_bucket_name` parameter.</param>
+        /// <param name="outputCredentialsFilename">The filename for outputCredentialsFile. (optional)</param>
         /// <param name="outputBucketLocation">The geographical location of the Cloud Object Storage output bucket as
         /// listed on the **Endpoint** tab of your Cloud Object Storage instance; for example, `us-geo`, `eu-geo`, or
         /// `ap-geo`.</param>
@@ -925,7 +934,7 @@ namespace IBM.Watson.CompareComply.V1
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <returns><see cref="BatchStatus" />BatchStatus</returns>
-        public bool CreateBatch(Callback<BatchStatus> callback, string function, System.IO.FileStream inputCredentialsFile, string inputBucketLocation, string inputBucketName, System.IO.FileStream outputCredentialsFile, string outputBucketLocation, string outputBucketName, string modelId = null)
+        public bool CreateBatch(Callback<BatchStatus> callback, string function, System.IO.MemoryStream inputCredentialsFile, string inputBucketLocation, string inputBucketName, System.IO.MemoryStream outputCredentialsFile, string outputBucketLocation, string outputBucketName, string inputCredentialsFilename = null, string outputCredentialsFilename = null, string modelId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateBatch`");
@@ -967,7 +976,7 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (inputCredentialsFile != null)
             {
-                req.Forms["input_credentials_file"] = new RESTConnector.Form(inputCredentialsFile, inputCredentialsFile.Name, "application/json");
+                req.Forms["input_credentials_file"] = new RESTConnector.Form(inputCredentialsFile, inputCredentialsFilename, "application/json");
             }
             if (!string.IsNullOrEmpty(inputBucketLocation))
             {
@@ -979,7 +988,7 @@ namespace IBM.Watson.CompareComply.V1
             }
             if (outputCredentialsFile != null)
             {
-                req.Forms["output_credentials_file"] = new RESTConnector.Form(outputCredentialsFile, outputCredentialsFile.Name, "application/json");
+                req.Forms["output_credentials_file"] = new RESTConnector.Form(outputCredentialsFile, outputCredentialsFilename, "application/json");
             }
             if (!string.IsNullOrEmpty(outputBucketLocation))
             {

--- a/Scripts/Services/CompareComply/V1/CompareComplyService.cs
+++ b/Scripts/Services/CompareComply/V1/CompareComplyService.cs
@@ -221,14 +221,13 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="file">The file to classify.</param>
-        /// <param name="filename">The filename for file. (optional)</param>
         /// <param name="modelId">The analysis model to be used by the service. For the `/v1/element_classification` and
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="ClassifyReturn" />ClassifyReturn</returns>
-        public bool ClassifyElements(Callback<ClassifyReturn> callback, System.IO.MemoryStream file, string filename = null, string modelId = null, string fileContentType = null)
+        public bool ClassifyElements(Callback<ClassifyReturn> callback, System.IO.MemoryStream file, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ClassifyElements`");
@@ -258,7 +257,7 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, null, fileContentType);
             }
             if (!string.IsNullOrEmpty(modelId))
             {
@@ -307,14 +306,13 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="file">The file on which to run table extraction.</param>
-        /// <param name="filename">The filename for file. (optional)</param>
         /// <param name="modelId">The analysis model to be used by the service. For the `/v1/element_classification` and
         /// `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`.
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="TableReturn" />TableReturn</returns>
-        public bool ExtractTables(Callback<TableReturn> callback, System.IO.MemoryStream file, string filename = null, string modelId = null, string fileContentType = null)
+        public bool ExtractTables(Callback<TableReturn> callback, System.IO.MemoryStream file, string modelId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `ExtractTables`");
@@ -344,7 +342,7 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, null, fileContentType);
             }
             if (!string.IsNullOrEmpty(modelId))
             {
@@ -393,9 +391,7 @@ namespace IBM.Watson.CompareComply.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="file1">The first file to compare.</param>
-        /// <param name="file1Filename">The filename for file1. (optional)</param>
         /// <param name="file2">The second file to compare.</param>
-        /// <param name="file2Filename">The filename for file2. (optional)</param>
         /// <param name="file1Label">A text label for the first file. (optional, default to file_1)</param>
         /// <param name="file2Label">A text label for the second file. (optional, default to file_2)</param>
         /// <param name="modelId">The analysis model to be used by the service. For the `/v1/element_classification` and
@@ -405,7 +401,7 @@ namespace IBM.Watson.CompareComply.V1
         /// <param name="file1ContentType">The content type of file1. (optional)</param>
         /// <param name="file2ContentType">The content type of file2. (optional)</param>
         /// <returns><see cref="CompareReturn" />CompareReturn</returns>
-        public bool CompareDocuments(Callback<CompareReturn> callback, System.IO.MemoryStream file1, System.IO.MemoryStream file2, string file1Filename = null, string file2Filename = null, string file1Label = null, string file2Label = null, string modelId = null, string file1ContentType = null, string file2ContentType = null)
+        public bool CompareDocuments(Callback<CompareReturn> callback, System.IO.MemoryStream file1, System.IO.MemoryStream file2, string file1Label = null, string file2Label = null, string modelId = null, string file1ContentType = null, string file2ContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CompareDocuments`");
@@ -437,11 +433,11 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file1 != null)
             {
-                req.Forms["file_1"] = new RESTConnector.Form(file1, file1Filename, file1ContentType);
+                req.Forms["file_1"] = new RESTConnector.Form(file1, null, file1ContentType);
             }
             if (file2 != null)
             {
-                req.Forms["file_2"] = new RESTConnector.Form(file2, file2Filename, file2ContentType);
+                req.Forms["file_2"] = new RESTConnector.Form(file2, null, file2ContentType);
             }
             if (!string.IsNullOrEmpty(file1Label))
             {
@@ -767,7 +763,7 @@ namespace IBM.Watson.CompareComply.V1
         /// specified, the service filters the output to include only feedback that has at least one `nature`:`party`
         /// pair from the list unchanged. (optional)</param>
         /// <param name="pageLimit">An optional integer specifying the number of documents that you want the service to
-        /// return. (optional, default to 10)</param>
+        /// return. (optional)</param>
         /// <param name="cursor">An optional string that returns the set of documents after the previous set. Use this
         /// parameter with the `page_limit` parameter. (optional)</param>
         /// <param name="sort">An optional comma-separated list of fields in the document to sort on. You can optionally
@@ -916,7 +912,6 @@ namespace IBM.Watson.CompareComply.V1
         /// <param name="inputCredentialsFile">A JSON file containing the input Cloud Object Storage credentials. At a
         /// minimum, the credentials must enable `READ` permissions on the bucket defined by the `input_bucket_name`
         /// parameter.</param>
-        /// <param name="inputCredentialsFilename">The filename for inputCredentialsFile. (optional)</param>
         /// <param name="inputBucketLocation">The geographical location of the Cloud Object Storage input bucket as
         /// listed on the **Endpoint** tab of your Cloud Object Storage instance; for example, `us-geo`, `eu-geo`, or
         /// `ap-geo`.</param>
@@ -924,7 +919,6 @@ namespace IBM.Watson.CompareComply.V1
         /// <param name="outputCredentialsFile">A JSON file that lists the Cloud Object Storage output credentials. At a
         /// minimum, the credentials must enable `READ` and `WRITE` permissions on the bucket defined by the
         /// `output_bucket_name` parameter.</param>
-        /// <param name="outputCredentialsFilename">The filename for outputCredentialsFile. (optional)</param>
         /// <param name="outputBucketLocation">The geographical location of the Cloud Object Storage output bucket as
         /// listed on the **Endpoint** tab of your Cloud Object Storage instance; for example, `us-geo`, `eu-geo`, or
         /// `ap-geo`.</param>
@@ -934,7 +928,7 @@ namespace IBM.Watson.CompareComply.V1
         /// These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests.
         /// (optional)</param>
         /// <returns><see cref="BatchStatus" />BatchStatus</returns>
-        public bool CreateBatch(Callback<BatchStatus> callback, string function, System.IO.MemoryStream inputCredentialsFile, string inputBucketLocation, string inputBucketName, System.IO.MemoryStream outputCredentialsFile, string outputBucketLocation, string outputBucketName, string inputCredentialsFilename = null, string outputCredentialsFilename = null, string modelId = null)
+        public bool CreateBatch(Callback<BatchStatus> callback, string function, System.IO.MemoryStream inputCredentialsFile, string inputBucketLocation, string inputBucketName, System.IO.MemoryStream outputCredentialsFile, string outputBucketLocation, string outputBucketName, string modelId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateBatch`");
@@ -976,7 +970,7 @@ namespace IBM.Watson.CompareComply.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (inputCredentialsFile != null)
             {
-                req.Forms["input_credentials_file"] = new RESTConnector.Form(inputCredentialsFile, inputCredentialsFilename, "application/json");
+                req.Forms["input_credentials_file"] = new RESTConnector.Form(inputCredentialsFile, null, "application/json");
             }
             if (!string.IsNullOrEmpty(inputBucketLocation))
             {
@@ -988,7 +982,7 @@ namespace IBM.Watson.CompareComply.V1
             }
             if (outputCredentialsFile != null)
             {
-                req.Forms["output_credentials_file"] = new RESTConnector.Form(outputCredentialsFile, outputCredentialsFilename, "application/json");
+                req.Forms["output_credentials_file"] = new RESTConnector.Form(outputCredentialsFile, null, "application/json");
             }
             if (!string.IsNullOrEmpty(outputBucketLocation))
             {

--- a/Scripts/Services/Discovery/V1/DiscoveryService.cs
+++ b/Scripts/Services/Discovery/V1/DiscoveryService.cs
@@ -1043,6 +1043,7 @@ namespace IBM.Watson.Discovery.V1
         /// See the `GET /configurations/{configuration_id}` operation for an example configuration. (optional)</param>
         /// <param name="file">The content of the document to ingest. The maximum supported file size is 50 megabytes.
         /// Files larger than 50 megabytes is rejected. (optional)</param>
+        /// <param name="filename">The filename for file. (optional)</param>
         /// <param name="metadata">If you're using the Data Crawler to upload your documents, you can test a document
         /// against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1
         /// MB. Metadata parts larger than 1 MB are rejected.
@@ -1058,7 +1059,7 @@ namespace IBM.Watson.Discovery.V1
         /// rejected. (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="TestDocument" />TestDocument</returns>
-        public bool TestConfigurationInEnvironment(Callback<TestDocument> callback, string environmentId, string configuration = null, System.IO.FileStream file = null, string metadata = null, string step = null, string configurationId = null, string fileContentType = null)
+        public bool TestConfigurationInEnvironment(Callback<TestDocument> callback, string environmentId, string configuration = null, System.IO.MemoryStream file = null, string filename = null, string metadata = null, string step = null, string configurationId = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `TestConfigurationInEnvironment`");
@@ -1092,7 +1093,7 @@ namespace IBM.Watson.Discovery.V1
             }
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, file.Name, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
             }
             if (!string.IsNullOrEmpty(metadata))
             {
@@ -1720,8 +1721,9 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="stopwordFile">The content of the stopword list to ingest.</param>
+        /// <param name="stopwordFilename">The filename for stopwordFile.</param>
         /// <returns><see cref="TokenDictStatusResponse" />TokenDictStatusResponse</returns>
-        public bool CreateStopwordList(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, System.IO.FileStream stopwordFile)
+        public bool CreateStopwordList(Callback<TokenDictStatusResponse> callback, string environmentId, string collectionId, System.IO.MemoryStream stopwordFile, string stopwordFilename)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateStopwordList`");
@@ -1731,6 +1733,8 @@ namespace IBM.Watson.Discovery.V1
                 throw new ArgumentNullException("`collectionId` is required for `CreateStopwordList`");
             if (stopwordFile == null)
                 throw new ArgumentNullException("`stopwordFile` is required for `CreateStopwordList`");
+            if (string.IsNullOrEmpty(stopwordFilename))
+                throw new ArgumentNullException("`stopwordFilename` is required for `CreateStopwordList`");
 
             RequestObject<TokenDictStatusResponse> req = new RequestObject<TokenDictStatusResponse>
             {
@@ -1755,7 +1759,7 @@ namespace IBM.Watson.Discovery.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (stopwordFile != null)
             {
-                req.Forms["stopword_file"] = new RESTConnector.Form(stopwordFile, stopwordFile.Name, "application/octet-stream");
+                req.Forms["stopword_file"] = new RESTConnector.Form(stopwordFile, stopwordFilename, "application/octet-stream");
             }
 
             req.OnResponse = OnCreateStopwordListResponse;
@@ -2353,6 +2357,7 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="file">The content of the document to ingest. The maximum supported file size is 50 megabytes.
         /// Files larger than 50 megabytes is rejected. (optional)</param>
+        /// <param name="filename">The filename for file. (optional)</param>
         /// <param name="metadata">If you're using the Data Crawler to upload your documents, you can test a document
         /// against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1
         /// MB. Metadata parts larger than 1 MB are rejected.
@@ -2362,7 +2367,7 @@ namespace IBM.Watson.Discovery.V1
         /// } ```. (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="DocumentAccepted" />DocumentAccepted</returns>
-        public bool AddDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, System.IO.FileStream file = null, string metadata = null, string fileContentType = null)
+        public bool AddDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, System.IO.MemoryStream file = null, string filename = null, string metadata = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddDocument`");
@@ -2394,7 +2399,7 @@ namespace IBM.Watson.Discovery.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, file.Name, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
             }
             if (!string.IsNullOrEmpty(metadata))
             {
@@ -2604,6 +2609,7 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="documentId">The ID of the document.</param>
         /// <param name="file">The content of the document to ingest. The maximum supported file size is 50 megabytes.
         /// Files larger than 50 megabytes is rejected. (optional)</param>
+        /// <param name="filename">The filename for file. (optional)</param>
         /// <param name="metadata">If you're using the Data Crawler to upload your documents, you can test a document
         /// against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1
         /// MB. Metadata parts larger than 1 MB are rejected.
@@ -2613,7 +2619,7 @@ namespace IBM.Watson.Discovery.V1
         /// } ```. (optional)</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <returns><see cref="DocumentAccepted" />DocumentAccepted</returns>
-        public bool UpdateDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, string documentId, System.IO.FileStream file = null, string metadata = null, string fileContentType = null)
+        public bool UpdateDocument(Callback<DocumentAccepted> callback, string environmentId, string collectionId, string documentId, System.IO.MemoryStream file = null, string filename = null, string metadata = null, string fileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateDocument`");
@@ -2647,7 +2653,7 @@ namespace IBM.Watson.Discovery.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (file != null)
             {
-                req.Forms["file"] = new RESTConnector.Form(file, file.Name, fileContentType);
+                req.Forms["file"] = new RESTConnector.Form(file, filename, fileContentType);
             }
             if (!string.IsNullOrEmpty(metadata))
             {

--- a/Scripts/Services/Discovery/V1/DiscoveryService.cs
+++ b/Scripts/Services/Discovery/V1/DiscoveryService.cs
@@ -137,7 +137,7 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="name">Name that identifies the environment.</param>
-        /// <param name="description">Description of the environment. (optional)</param>
+        /// <param name="description">Description of the environment. (optional, default to )</param>
         /// <param name="size">Size of the environment. In the Lite plan the default and only accepted value is `LT`, in
         /// all other plans the default is `S`. (optional)</param>
         /// <returns><see cref="ModelEnvironment" />ModelEnvironment</returns>
@@ -512,8 +512,8 @@ namespace IBM.Watson.Discovery.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
-        /// <param name="name">Name that identifies the environment. (optional)</param>
-        /// <param name="description">Description of the environment. (optional)</param>
+        /// <param name="name">Name that identifies the environment. (optional, default to )</param>
+        /// <param name="description">Description of the environment. (optional, default to )</param>
         /// <param name="size">Size that the environment should be increased to. Environment size cannot be modified
         /// when using a Lite plan. Environment size can only increased and not decreased. (optional)</param>
         /// <returns><see cref="ModelEnvironment" />ModelEnvironment</returns>
@@ -1149,9 +1149,9 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="name">The name of the collection to be created.</param>
-        /// <param name="description">A description of the collection. (optional)</param>
+        /// <param name="description">A description of the collection. (optional, default to )</param>
         /// <param name="configurationId">The ID of the configuration in which the collection is to be created.
-        /// (optional)</param>
+        /// (optional, default to )</param>
         /// <param name="language">The language of the documents stored in the collection, in the form of an ISO 639-1
         /// language code. (optional, default to en)</param>
         /// <returns><see cref="Collection" />Collection</returns>
@@ -1534,9 +1534,9 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="environmentId">The ID of the environment.</param>
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="name">The name of the collection.</param>
-        /// <param name="description">A description of the collection. (optional)</param>
+        /// <param name="description">A description of the collection. (optional, default to )</param>
         /// <param name="configurationId">The ID of the configuration in which the collection is to be updated.
-        /// (optional)</param>
+        /// (optional, default to )</param>
         /// <returns><see cref="Collection" />Collection</returns>
         public bool UpdateCollection(Callback<Collection> callback, string environmentId, string collectionId, string name, string description = null, string configurationId = null)
         {
@@ -2720,7 +2720,7 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="aggregation">An aggregation search that returns an exact answer by combining query search with
         /// filters. Useful for applications to build lists, tables, and time series. For a full list of possible
         /// aggregations, see the Query reference. (optional)</param>
-        /// <param name="count">Number of results to return. (optional, default to 10)</param>
+        /// <param name="count">Number of results to return. (optional)</param>
         /// <param name="returnFields">A comma-separated list of the portion of the document hierarchy to return.
         /// (optional)</param>
         /// <param name="offset">The number of query results to skip at the beginning. For example, if the total number
@@ -2735,10 +2735,9 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="passagesFields">A comma-separated list of fields that passages are drawn from. If this
         /// parameter not specified, then all top-level fields are included. (optional)</param>
         /// <param name="passagesCount">The maximum number of passages to return. The search returns fewer passages if
-        /// the requested total is not found. The default is `10`. The maximum is `100`. (optional, default to
-        /// 10)</param>
+        /// the requested total is not found. The default is `10`. The maximum is `100`. (optional)</param>
         /// <param name="passagesCharacters">The approximate number of characters that any one passage will have.
-        /// (optional, default to 400)</param>
+        /// (optional)</param>
         /// <param name="deduplicate">When `true`, and used with a Watson Discovery News collection, duplicate results
         /// (based on the contents of the **title** field) are removed. Duplicate comparison is limited to the current
         /// query only; **offset** is not considered. This parameter is currently Beta functionality. (optional, default
@@ -2902,7 +2901,7 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="aggregation">An aggregation search that returns an exact answer by combining query search with
         /// filters. Useful for applications to build lists, tables, and time series. For a full list of possible
         /// aggregations, see the Query reference. (optional)</param>
-        /// <param name="count">Number of results to return. (optional, default to 10)</param>
+        /// <param name="count">Number of results to return. (optional)</param>
         /// <param name="returnFields">A comma-separated list of the portion of the document hierarchy to return.
         /// (optional)</param>
         /// <param name="offset">The number of query results to skip at the beginning. For example, if the total number
@@ -3073,7 +3072,7 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="aggregation">An aggregation search that returns an exact answer by combining query search with
         /// filters. Useful for applications to build lists, tables, and time series. For a full list of possible
         /// aggregations, see the Query reference. (optional)</param>
-        /// <param name="count">Number of results to return. (optional, default to 10)</param>
+        /// <param name="count">Number of results to return. (optional)</param>
         /// <param name="returnFields">A comma-separated list of the portion of the document hierarchy to return.
         /// (optional)</param>
         /// <param name="offset">The number of query results to skip at the beginning. For example, if the total number
@@ -3088,10 +3087,9 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="passagesFields">A comma-separated list of fields that passages are drawn from. If this
         /// parameter not specified, then all top-level fields are included. (optional)</param>
         /// <param name="passagesCount">The maximum number of passages to return. The search returns fewer passages if
-        /// the requested total is not found. The default is `10`. The maximum is `100`. (optional, default to
-        /// 10)</param>
+        /// the requested total is not found. The default is `10`. The maximum is `100`. (optional)</param>
         /// <param name="passagesCharacters">The approximate number of characters that any one passage will have.
-        /// (optional, default to 400)</param>
+        /// (optional)</param>
         /// <param name="deduplicate">When `true`, and used with a Watson Discovery News collection, duplicate results
         /// (based on the contents of the **title** field) are removed. Duplicate comparison is limited to the current
         /// query only; **offset** is not considered. This parameter is currently Beta functionality. (optional, default
@@ -3359,7 +3357,7 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="aggregation">An aggregation search that returns an exact answer by combining query search with
         /// filters. Useful for applications to build lists, tables, and time series. For a full list of possible
         /// aggregations, see the Query reference. (optional)</param>
-        /// <param name="count">Number of results to return. (optional, default to 10)</param>
+        /// <param name="count">Number of results to return. (optional)</param>
         /// <param name="returnFields">A comma-separated list of the portion of the document hierarchy to return.
         /// (optional)</param>
         /// <param name="offset">The number of query results to skip at the beginning. For example, if the total number
@@ -3373,9 +3371,9 @@ namespace IBM.Watson.Discovery.V1
         /// <param name="passagesFields">A comma-separated list of fields that passages are drawn from. If this
         /// parameter not specified, then all top-level fields are included. (optional)</param>
         /// <param name="passagesCount">The maximum number of passages to return. The search returns fewer passages if
-        /// the requested total is not found. (optional, default to 10)</param>
+        /// the requested total is not found. (optional)</param>
         /// <param name="passagesCharacters">The approximate number of characters that any one passage will have.
-        /// (optional, default to 400)</param>
+        /// (optional)</param>
         /// <param name="deduplicateField">When specified, duplicate results based on the field specified are removed
         /// from the returned results. Duplicate comparison is limited to the current query only, **offset** is not
         /// considered. This parameter is currently Beta functionality. (optional)</param>
@@ -4954,7 +4952,7 @@ namespace IBM.Watson.Discovery.V1
         /// an individual word or unigram within the query string.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="count">Number of results to return. (optional, default to 10)</param>
+        /// <param name="count">Number of results to return. (optional)</param>
         /// <returns><see cref="MetricTokenResponse" />MetricTokenResponse</returns>
         public bool GetMetricsQueryTokenEvent(Callback<MetricTokenResponse> callback, long? count = null)
         {
@@ -5035,7 +5033,7 @@ namespace IBM.Watson.Discovery.V1
         /// text, but with the most relevant documents listed first. Use a query search when you want to find the most
         /// relevant search results. You cannot use **natural_language_query** and **query** at the same time.
         /// (optional)</param>
-        /// <param name="count">Number of results to return. (optional, default to 10)</param>
+        /// <param name="count">Number of results to return. (optional)</param>
         /// <param name="offset">The number of query results to skip at the beginning. For example, if the total number
         /// of results that are returned is 10 and the offset is 8, it returns the last two results. (optional)</param>
         /// <param name="sort">A comma-separated list of fields in the document to sort on. You can optionally specify a

--- a/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
+++ b/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
@@ -383,16 +383,14 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// overwrite the domain translaton data, including high frequency or high confidence phrase translations. You
         /// can upload only one glossary with a file size less than 10 MB per call. A forced glossary should contain
         /// single words or short phrases. (optional)</param>
-        /// <param name="forcedGlossaryFilename">The filename for forcedGlossary. (optional)</param>
         /// <param name="parallelCorpus">A TMX file with parallel sentences for source and target language. You can
         /// upload multiple parallel_corpus files in one request. All uploaded parallel_corpus files combined, your
         /// parallel corpus must contain at least 5,000 parallel sentences to train successfully. (optional)</param>
-        /// <param name="parallelCorpusFilename">The filename for parallelCorpus. (optional)</param>
         /// <param name="name">An optional model name that you can use to identify the model. Valid characters are
         /// letters, numbers, dashes, underscores, spaces and apostrophes. The maximum length is 32 characters.
         /// (optional)</param>
         /// <returns><see cref="TranslationModel" />TranslationModel</returns>
-        public bool CreateModel(Callback<TranslationModel> callback, string baseModelId, System.IO.MemoryStream forcedGlossary = null, string forcedGlossaryFilename = null, System.IO.MemoryStream parallelCorpus = null, string parallelCorpusFilename = null, string name = null)
+        public bool CreateModel(Callback<TranslationModel> callback, string baseModelId, System.IO.MemoryStream forcedGlossary = null, System.IO.MemoryStream parallelCorpus = null, string name = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateModel`");
@@ -422,11 +420,11 @@ namespace IBM.Watson.LanguageTranslator.V3
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (forcedGlossary != null)
             {
-                req.Forms["forced_glossary"] = new RESTConnector.Form(forcedGlossary, forcedGlossaryFilename, "application/octet-stream");
+                req.Forms["forced_glossary"] = new RESTConnector.Form(forcedGlossary, null, "application/octet-stream");
             }
             if (parallelCorpus != null)
             {
-                req.Forms["parallel_corpus"] = new RESTConnector.Form(parallelCorpus, parallelCorpusFilename, "application/octet-stream");
+                req.Forms["parallel_corpus"] = new RESTConnector.Form(parallelCorpus, null, "application/octet-stream");
             }
             if (!string.IsNullOrEmpty(baseModelId))
             {

--- a/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
+++ b/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
@@ -383,14 +383,16 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// overwrite the domain translaton data, including high frequency or high confidence phrase translations. You
         /// can upload only one glossary with a file size less than 10 MB per call. A forced glossary should contain
         /// single words or short phrases. (optional)</param>
+        /// <param name="forcedGlossaryFilename">The filename for forcedGlossary. (optional)</param>
         /// <param name="parallelCorpus">A TMX file with parallel sentences for source and target language. You can
         /// upload multiple parallel_corpus files in one request. All uploaded parallel_corpus files combined, your
         /// parallel corpus must contain at least 5,000 parallel sentences to train successfully. (optional)</param>
+        /// <param name="parallelCorpusFilename">The filename for parallelCorpus. (optional)</param>
         /// <param name="name">An optional model name that you can use to identify the model. Valid characters are
         /// letters, numbers, dashes, underscores, spaces and apostrophes. The maximum length is 32 characters.
         /// (optional)</param>
         /// <returns><see cref="TranslationModel" />TranslationModel</returns>
-        public bool CreateModel(Callback<TranslationModel> callback, string baseModelId, System.IO.FileStream forcedGlossary = null, System.IO.FileStream parallelCorpus = null, string name = null)
+        public bool CreateModel(Callback<TranslationModel> callback, string baseModelId, System.IO.MemoryStream forcedGlossary = null, string forcedGlossaryFilename = null, System.IO.MemoryStream parallelCorpus = null, string parallelCorpusFilename = null, string name = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateModel`");
@@ -420,11 +422,11 @@ namespace IBM.Watson.LanguageTranslator.V3
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (forcedGlossary != null)
             {
-                req.Forms["forced_glossary"] = new RESTConnector.Form(forcedGlossary, forcedGlossary.Name, "application/octet-stream");
+                req.Forms["forced_glossary"] = new RESTConnector.Form(forcedGlossary, forcedGlossaryFilename, "application/octet-stream");
             }
             if (parallelCorpus != null)
             {
-                req.Forms["parallel_corpus"] = new RESTConnector.Form(parallelCorpus, parallelCorpus.Name, "application/octet-stream");
+                req.Forms["parallel_corpus"] = new RESTConnector.Form(parallelCorpus, parallelCorpusFilename, "application/octet-stream");
             }
             if (!string.IsNullOrEmpty(baseModelId))
             {

--- a/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
+++ b/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
@@ -284,13 +284,11 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         ///
         /// Supported languages are English (`en`), Arabic (`ar`), French (`fr`), German, (`de`), Italian (`it`),
         /// Japanese (`ja`), Korean (`ko`), Brazilian Portuguese (`pt`), and Spanish (`es`).</param>
-        /// <param name="metadataFilename">The filename for trainingMetadata. (optional)</param>
         /// <param name="trainingData">Training data in CSV format. Each text value must have at least one class. The
         /// data can include up to 3,000 classes and 20,000 records. For details, see [Data
         /// preparation](https://cloud.ibm.com/docs/services/natural-language-classifier/using-your-data.html).</param>
-        /// <param name="trainingDataFilename">The filename for trainingData. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool CreateClassifier(Callback<Classifier> callback, System.IO.MemoryStream metadata, System.IO.MemoryStream trainingData, string metadataFilename = null, string trainingDataFilename = null)
+        public bool CreateClassifier(Callback<Classifier> callback, System.IO.MemoryStream metadata, System.IO.MemoryStream trainingData)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateClassifier`");
@@ -321,11 +319,11 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (metadata != null)
             {
-                req.Forms["training_metadata"] = new RESTConnector.Form(metadata, metadataFilename, "application/json");
+                req.Forms["training_metadata"] = new RESTConnector.Form(metadata, null, "application/json");
             }
             if (trainingData != null)
             {
-                req.Forms["training_data"] = new RESTConnector.Form(trainingData, trainingDataFilename, "text/csv");
+                req.Forms["training_data"] = new RESTConnector.Form(trainingData, null, "text/csv");
             }
 
             req.OnResponse = OnCreateClassifierResponse;

--- a/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
+++ b/Scripts/Services/NaturalLanguageClassifier/V1/NaturalLanguageClassifierService.cs
@@ -284,11 +284,13 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
         ///
         /// Supported languages are English (`en`), Arabic (`ar`), French (`fr`), German, (`de`), Italian (`it`),
         /// Japanese (`ja`), Korean (`ko`), Brazilian Portuguese (`pt`), and Spanish (`es`).</param>
+        /// <param name="metadataFilename">The filename for trainingMetadata. (optional)</param>
         /// <param name="trainingData">Training data in CSV format. Each text value must have at least one class. The
         /// data can include up to 3,000 classes and 20,000 records. For details, see [Data
         /// preparation](https://cloud.ibm.com/docs/services/natural-language-classifier/using-your-data.html).</param>
+        /// <param name="trainingDataFilename">The filename for trainingData. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool CreateClassifier(Callback<Classifier> callback, System.IO.FileStream metadata, System.IO.FileStream trainingData)
+        public bool CreateClassifier(Callback<Classifier> callback, System.IO.MemoryStream metadata, System.IO.MemoryStream trainingData, string metadataFilename = null, string trainingDataFilename = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateClassifier`");
@@ -319,11 +321,11 @@ namespace IBM.Watson.NaturalLanguageClassifier.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (metadata != null)
             {
-                req.Forms["training_metadata"] = new RESTConnector.Form(metadata, metadata.Name, "application/json");
+                req.Forms["training_metadata"] = new RESTConnector.Form(metadata, metadataFilename, "application/json");
             }
             if (trainingData != null)
             {
-                req.Forms["training_data"] = new RESTConnector.Form(trainingData, trainingData.Name, "text/csv");
+                req.Forms["training_data"] = new RESTConnector.Form(trainingData, trainingDataFilename, "text/csv");
             }
 
             req.OnResponse = OnCreateClassifierResponse;

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResults.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResults.cs
@@ -44,7 +44,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
         /// API usage information for the request.
         /// </summary>
         [JsonProperty("usage", NullValueHandling = NullValueHandling.Ignore)]
-        public Usage Usage { get; set; }
+        public AnalysisResultsUsage Usage { get; set; }
         /// <summary>
         /// The general concepts referenced or alluded to in the analyzed text.
         /// </summary>
@@ -74,7 +74,7 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
         /// Webpage metadata, such as the author and the title of the page.
         /// </summary>
         [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
-        public MetadataResult Metadata { get; set; }
+        public AnalysisResultsMetadata Metadata { get; set; }
         /// <summary>
         /// The relationships between entities in the content.
         /// </summary>

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsMetadata.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsMetadata.cs
@@ -21,10 +21,9 @@ using Newtonsoft.Json;
 namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
 {
     /// <summary>
-    /// The authors, publication date, title, prominent page image, and RSS/ATOM feeds of the webpage. Supports URL and
-    /// HTML input types.
+    /// Webpage metadata, such as the author and the title of the page.
     /// </summary>
-    public class MetadataResult
+    public class AnalysisResultsMetadata
     {
         /// <summary>
         /// The authors of the document.

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsMetadata.cs.meta
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsMetadata.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 28b445c1551e2bd48a4e7e7fe11323dd
+guid: 705725f11bec8d54fa51fffd54a4fef8
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsUsage.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsUsage.cs
@@ -15,30 +15,29 @@
 *
 */
 
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
 {
     /// <summary>
-    /// SemanticRolesSubject.
+    /// API usage information for the request.
     /// </summary>
-    public class SemanticRolesSubject
+    public class AnalysisResultsUsage
     {
         /// <summary>
-        /// Text that corresponds to the subject role.
+        /// Number of features used in the API call.
         /// </summary>
-        [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
-        public string Text { get; set; }
+        [JsonProperty("features", NullValueHandling = NullValueHandling.Ignore)]
+        public long? Features { get; set; }
         /// <summary>
-        /// An array of extracted entities.
+        /// Number of text characters processed.
         /// </summary>
-        [JsonProperty("entities", NullValueHandling = NullValueHandling.Ignore)]
-        public List<SemanticRolesEntity> Entities { get; set; }
+        [JsonProperty("text_characters", NullValueHandling = NullValueHandling.Ignore)]
+        public long? TextCharacters { get; set; }
         /// <summary>
-        /// An array of extracted keywords.
+        /// Number of 10,000-character units processed.
         /// </summary>
-        [JsonProperty("keywords", NullValueHandling = NullValueHandling.Ignore)]
-        public List<SemanticRolesKeyword> Keywords { get; set; }
+        [JsonProperty("text_units", NullValueHandling = NullValueHandling.Ignore)]
+        public long? TextUnits { get; set; }
     }
 }

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsUsage.cs.meta
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/AnalysisResultsUsage.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e6db9b017c90052409118d49f9071f14
+guid: d45dfb8dbc7dd0343acfc0a4aa8ac1de
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResult.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResult.cs
@@ -33,16 +33,16 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
         /// The extracted subject from the sentence.
         /// </summary>
         [JsonProperty("subject", NullValueHandling = NullValueHandling.Ignore)]
-        public SemanticRolesSubject Subject { get; set; }
+        public SemanticRolesResultSubject Subject { get; set; }
         /// <summary>
         /// The extracted action from the sentence.
         /// </summary>
         [JsonProperty("action", NullValueHandling = NullValueHandling.Ignore)]
-        public SemanticRolesAction Action { get; set; }
+        public SemanticRolesResultAction Action { get; set; }
         /// <summary>
         /// The extracted object from the sentence.
         /// </summary>
         [JsonProperty("object", NullValueHandling = NullValueHandling.Ignore)]
-        public SemanticRolesObject _Object { get; set; }
+        public SemanticRolesResultObject _Object { get; set; }
     }
 }

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultAction.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultAction.cs
@@ -20,24 +20,24 @@ using Newtonsoft.Json;
 namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
 {
     /// <summary>
-    /// Usage information.
+    /// The extracted action from the sentence.
     /// </summary>
-    public class Usage
+    public class SemanticRolesResultAction
     {
         /// <summary>
-        /// Number of features used in the API call.
+        /// Analyzed text that corresponds to the action.
         /// </summary>
-        [JsonProperty("features", NullValueHandling = NullValueHandling.Ignore)]
-        public long? Features { get; set; }
+        [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
+        public string Text { get; set; }
         /// <summary>
-        /// Number of text characters processed.
+        /// normalized version of the action.
         /// </summary>
-        [JsonProperty("text_characters", NullValueHandling = NullValueHandling.Ignore)]
-        public long? TextCharacters { get; set; }
+        [JsonProperty("normalized", NullValueHandling = NullValueHandling.Ignore)]
+        public string Normalized { get; set; }
         /// <summary>
-        /// Number of 10,000-character units processed.
+        /// Gets or Sets Verb
         /// </summary>
-        [JsonProperty("text_units", NullValueHandling = NullValueHandling.Ignore)]
-        public long? TextUnits { get; set; }
+        [JsonProperty("verb", NullValueHandling = NullValueHandling.Ignore)]
+        public SemanticRolesVerb Verb { get; set; }
     }
 }

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultAction.cs.meta
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultAction.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c0d056af6321b764aaaa13853e176c8a
+guid: 41023e1f237be464e8eff5c59b533db7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultObject.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultObject.cs
@@ -15,29 +15,25 @@
 *
 */
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
 {
     /// <summary>
-    /// SemanticRolesAction.
+    /// The extracted object from the sentence.
     /// </summary>
-    public class SemanticRolesAction
+    public class SemanticRolesResultObject
     {
         /// <summary>
-        /// Analyzed text that corresponds to the action.
+        /// Object text.
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
         /// <summary>
-        /// normalized version of the action.
+        /// An array of extracted keywords.
         /// </summary>
-        [JsonProperty("normalized", NullValueHandling = NullValueHandling.Ignore)]
-        public string Normalized { get; set; }
-        /// <summary>
-        /// Gets or Sets Verb
-        /// </summary>
-        [JsonProperty("verb", NullValueHandling = NullValueHandling.Ignore)]
-        public SemanticRolesVerb Verb { get; set; }
+        [JsonProperty("keywords", NullValueHandling = NullValueHandling.Ignore)]
+        public List<SemanticRolesKeyword> Keywords { get; set; }
     }
 }

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultObject.cs.meta
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultObject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a77ae7897490557449db83ce64dc588e
+guid: 5a6e62e48a4c3a947b17da1b33b1e612
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultSubject.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultSubject.cs
@@ -21,15 +21,20 @@ using Newtonsoft.Json;
 namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
 {
     /// <summary>
-    /// SemanticRolesObject.
+    /// The extracted subject from the sentence.
     /// </summary>
-    public class SemanticRolesObject
+    public class SemanticRolesResultSubject
     {
         /// <summary>
-        /// Object text.
+        /// Text that corresponds to the subject role.
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
+        /// <summary>
+        /// An array of extracted entities.
+        /// </summary>
+        [JsonProperty("entities", NullValueHandling = NullValueHandling.Ignore)]
+        public List<SemanticRolesEntity> Entities { get; set; }
         /// <summary>
         /// An array of extracted keywords.
         /// </summary>

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultSubject.cs.meta
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/SemanticRolesResultSubject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b4aabbd67e364164086fcb75207ff197
+guid: 50582881f6accae4c9e7c874705b2d51
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Scripts/Services/SpeechToText/V1/Model/SpeechRecognitionAlternative.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/SpeechRecognitionAlternative.cs
@@ -42,7 +42,7 @@ namespace IBM.Watson.SpeechToText.V1.Model
         /// `[[\"hello\",0.0,1.2],[\"world\",1.2,2.5]]`. Timestamps are returned only for the best alternative.
         /// </summary>
         [JsonProperty("timestamps", NullValueHandling = NullValueHandling.Ignore)]
-        public List<string> Timestamps { get; set; }
+        public string[][] Timestamps { get; set; }
         /// <summary>
         /// A confidence score for each word of the transcript as a list of lists. Each inner list consists of two
         /// elements: the word and its confidence score in the range of 0.0 to 1.0, for example:
@@ -50,6 +50,6 @@ namespace IBM.Watson.SpeechToText.V1.Model
         /// only with results marked as final.
         /// </summary>
         [JsonProperty("word_confidence", NullValueHandling = NullValueHandling.Ignore)]
-        public List<string> WordConfidence { get; set; }
+        public string[][] WordConfidence { get; set; }
     }
 }

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
@@ -366,8 +366,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="inactivityTimeout">The time in seconds after which, if only silence (no speech) is detected in
         /// streaming audio, the connection is closed with a 400 error. The parameter is useful for stopping audio
         /// submission from a live microphone when a user simply walks away. Use `-1` for infinity. See [Inactivity
-        /// timeout](https://cloud.ibm.com/docs/services/speech-to-text/input.html#timeouts-inactivity). (optional,
-        /// default to 30)</param>
+        /// timeout](https://cloud.ibm.com/docs/services/speech-to-text/input.html#timeouts-inactivity).
+        /// (optional)</param>
         /// <param name="keywords">An array of keyword strings to spot in the audio. Each keyword string can include one
         /// or more string tokens. Keywords are spotted only in the final results, not in interim hypotheses. If you
         /// specify any keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords.
@@ -383,8 +383,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="maxAlternatives">The maximum number of alternative transcripts that the service is to return.
         /// By default, the service returns a single transcript. If you specify a value of `0`, the service uses the
         /// default value, `1`. See [Maximum
-        /// alternatives](https://cloud.ibm.com/docs/services/speech-to-text/output.html#max_alternatives). (optional,
-        /// default to 1)</param>
+        /// alternatives](https://cloud.ibm.com/docs/services/speech-to-text/output.html#max_alternatives).
+        /// (optional)</param>
         /// <param name="wordAlternativesThreshold">A confidence value that is the lower bound for identifying a
         /// hypothesis as a possible word alternative (also known as "Confusion Networks"). An alternative word is
         /// considered if its confidence is greater than or equal to the threshold. Specify a probability between 0.0
@@ -901,8 +901,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="inactivityTimeout">The time in seconds after which, if only silence (no speech) is detected in
         /// streaming audio, the connection is closed with a 400 error. The parameter is useful for stopping audio
         /// submission from a live microphone when a user simply walks away. Use `-1` for infinity. See [Inactivity
-        /// timeout](https://cloud.ibm.com/docs/services/speech-to-text/input.html#timeouts-inactivity). (optional,
-        /// default to 30)</param>
+        /// timeout](https://cloud.ibm.com/docs/services/speech-to-text/input.html#timeouts-inactivity).
+        /// (optional)</param>
         /// <param name="keywords">An array of keyword strings to spot in the audio. Each keyword string can include one
         /// or more string tokens. Keywords are spotted only in the final results, not in interim hypotheses. If you
         /// specify any keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords.
@@ -918,8 +918,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="maxAlternatives">The maximum number of alternative transcripts that the service is to return.
         /// By default, the service returns a single transcript. If you specify a value of `0`, the service uses the
         /// default value, `1`. See [Maximum
-        /// alternatives](https://cloud.ibm.com/docs/services/speech-to-text/output.html#max_alternatives). (optional,
-        /// default to 1)</param>
+        /// alternatives](https://cloud.ibm.com/docs/services/speech-to-text/output.html#max_alternatives).
+        /// (optional)</param>
         /// <param name="wordAlternativesThreshold">A confidence value that is the lower bound for identifying a
         /// hypothesis as a possible word alternative (also known as "Confusion Networks"). An alternative word is
         /// considered if its confidence is greater than or equal to the threshold. Specify a probability between 0.0
@@ -1880,8 +1880,7 @@ namespace IBM.Watson.SpeechToText.V1
         /// phrases.
         ///
         /// The value that you assign is used for all recognition requests that use the model. You can override it for
-        /// any recognition request by specifying a customization weight for that request. (optional, default to
-        /// 0.3)</param>
+        /// any recognition request by specifying a customization weight for that request. (optional)</param>
         /// <returns><see cref="object" />object</returns>
         public bool TrainLanguageModel(Callback<object> callback, string customizationId, string wordTypeToAdd = null, double? customizationWeight = null)
         {
@@ -2100,12 +2099,11 @@ namespace IBM.Watson.SpeechToText.V1
         /// encoding](https://cloud.ibm.com/docs/services/speech-to-text/language-resource.html#charEncoding).
         ///
         /// With the `curl` command, use the `--data-binary` option to upload the file for the request.</param>
-        /// <param name="corpusFilename">The filename for corpusFile. (optional)</param>
         /// <param name="allowOverwrite">If `true`, the specified corpus overwrites an existing corpus with the same
         /// name. If `false`, the request fails if a corpus with the same name already exists. The parameter has no
         /// effect if a corpus with the same name does not already exist. (optional, default to false)</param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddCorpus(Callback<object> callback, string customizationId, string corpusName, System.IO.MemoryStream corpusFile, string corpusFilename = null, bool? allowOverwrite = null)
+        public bool AddCorpus(Callback<object> callback, string customizationId, string corpusName, System.IO.MemoryStream corpusFile, bool? allowOverwrite = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddCorpus`");
@@ -2138,7 +2136,7 @@ namespace IBM.Watson.SpeechToText.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (corpusFile != null)
             {
-                req.Forms["corpus_file"] = new RESTConnector.Form(corpusFile, corpusFilename, "text/plain");
+                req.Forms["corpus_file"] = new RESTConnector.Form(corpusFile, null, "text/plain");
             }
             if (allowOverwrite != null)
             {

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
@@ -2100,11 +2100,12 @@ namespace IBM.Watson.SpeechToText.V1
         /// encoding](https://cloud.ibm.com/docs/services/speech-to-text/language-resource.html#charEncoding).
         ///
         /// With the `curl` command, use the `--data-binary` option to upload the file for the request.</param>
+        /// <param name="corpusFilename">The filename for corpusFile. (optional)</param>
         /// <param name="allowOverwrite">If `true`, the specified corpus overwrites an existing corpus with the same
         /// name. If `false`, the request fails if a corpus with the same name already exists. The parameter has no
         /// effect if a corpus with the same name does not already exist. (optional, default to false)</param>
         /// <returns><see cref="object" />object</returns>
-        public bool AddCorpus(Callback<object> callback, string customizationId, string corpusName, System.IO.FileStream corpusFile, bool? allowOverwrite = null)
+        public bool AddCorpus(Callback<object> callback, string customizationId, string corpusName, System.IO.MemoryStream corpusFile, string corpusFilename = null, bool? allowOverwrite = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `AddCorpus`");
@@ -2137,7 +2138,7 @@ namespace IBM.Watson.SpeechToText.V1
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (corpusFile != null)
             {
-                req.Forms["corpus_file"] = new RESTConnector.Form(corpusFile, corpusFile.Name, "text/plain");
+                req.Forms["corpus_file"] = new RESTConnector.Form(corpusFile, corpusFilename, "text/plain");
             }
             if (allowOverwrite != null)
             {

--- a/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
+++ b/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
@@ -420,7 +420,7 @@ namespace IBM.Watson.VisualRecognition.V3
                 foreach (KeyValuePair<string, System.IO.MemoryStream> entry in positiveExamples)
                 {
                     var partName = string.Format("{0}_positive_examples", entry.Key);
-                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file", "application/octet-stream");
+                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file.zip", "application/octet-stream");
                 }
             }
             if (negativeExamples != null)
@@ -742,7 +742,7 @@ namespace IBM.Watson.VisualRecognition.V3
                 foreach (KeyValuePair<string, System.IO.MemoryStream> entry in positiveExamples)
                 {
                     var partName = string.Format("{0}_positive_examples", entry.Key);
-                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file", "application/octet-stream");
+                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file.zip", "application/octet-stream");
                 }
             }
             if (negativeExamples != null)

--- a/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
+++ b/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
@@ -144,7 +144,7 @@ namespace IBM.Watson.VisualRecognition.V3
         ///
         /// You can also include images with the **images_file** parameter. (optional)</param>
         /// <param name="threshold">The minimum score a class must have to be displayed in the response. Set the
-        /// threshold to `0.0` to return all identified classes. (optional, default to 0.5)</param>
+        /// threshold to `0.0` to return all identified classes. (optional)</param>
         /// <param name="owners">The categories of classifiers to apply. The **classifier_ids** parameter overrides
         /// **owners**, so make sure that **classifier_ids** is empty.
         /// - Use `IBM` to classify against the `default` general classifier. You get the same result if both
@@ -373,13 +373,14 @@ namespace IBM.Watson.VisualRecognition.V3
         /// The maximum number of images is 10,000 images or 100 MB per .zip file.
         ///
         /// Encode special characters in the file name in UTF-8.</param>
+        /// <param name="positiveExamplesFilename">The filename for positiveExamples.</param>
         /// <param name="negativeExamples">A .zip file of images that do not depict the visual subject of any of the
         /// classes of the new classifier. Must contain a minimum of 10 images.
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
         /// <param name="negativeExamplesFilename">The filename for negativeExamples. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool CreateClassifier(Callback<Classifier> callback, string name, Dictionary<string, System.IO.MemoryStream> positiveExamples, System.IO.MemoryStream negativeExamples = null, string negativeExamplesFilename = null)
+        public bool CreateClassifier(Callback<Classifier> callback, string name, Dictionary<string, System.IO.MemoryStream> positiveExamples, string positiveExamplesFilename, System.IO.MemoryStream negativeExamples = null, string negativeExamplesFilename = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateClassifier`");
@@ -389,6 +390,8 @@ namespace IBM.Watson.VisualRecognition.V3
                 throw new ArgumentNullException("`positiveExamples` is required for `CreateClassifier`");
             if (positiveExamples.Count == 0)
                 throw new ArgumentException("`positiveExamples` must contain at least one dictionary entry");
+            if (string.IsNullOrEmpty(positiveExamplesFilename))
+                throw new ArgumentNullException("`positiveExamplesFilename` is required for `CreateClassifier`");
 
             RequestObject<Classifier> req = new RequestObject<Classifier>
             {
@@ -703,13 +706,14 @@ namespace IBM.Watson.VisualRecognition.V3
         /// The maximum number of images is 10,000 images or 100 MB per .zip file.
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
+        /// <param name="positiveExamplesFilename">The filename for positiveExamples. (optional)</param>
         /// <param name="negativeExamples">A .zip file of images that do not depict the visual subject of any of the
         /// classes of the new classifier. Must contain a minimum of 10 images.
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
         /// <param name="negativeExamplesFilename">The filename for negativeExamples. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, System.IO.MemoryStream> positiveExamples = null, System.IO.MemoryStream negativeExamples = null, string negativeExamplesFilename = null)
+        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, System.IO.MemoryStream> positiveExamples = null, string positiveExamplesFilename = null, System.IO.MemoryStream negativeExamples = null, string negativeExamplesFilename = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateClassifier`");

--- a/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
+++ b/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
@@ -363,8 +363,9 @@ namespace IBM.Watson.VisualRecognition.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="name">The name of the new classifier. Encode special characters in UTF-8.</param>
-        /// <param name="positiveExamples">A .zip file of images that depict the visual subject of a class in the new
-        /// classifier. You can include more than one positive example file in a call.
+        /// <param name="positiveExamples">A dictionary that contains the value for each classname. The value is a .zip
+        /// file of images that depict the visual subject of a class in the new classifier. You can include more than
+        /// one positive example file in a call.
         ///
         /// Specify the parameter name by appending `_positive_examples` to the class name. For example,
         /// `goldenretriever_positive_examples` creates the class **goldenretriever**.
@@ -423,7 +424,7 @@ namespace IBM.Watson.VisualRecognition.V3
                 foreach (KeyValuePair<string, System.IO.MemoryStream> entry in positiveExamples)
                 {
                     var partName = string.Format("{0}_positive_examples", entry.Key);
-                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file.zip", "application/octet-stream");
+                    req.Forms[partName] = new RESTConnector.Form(entry.Value, entry.Key + ".zip", "application/octet-stream");
                 }
             }
             if (negativeExamples != null)
@@ -591,16 +592,19 @@ namespace IBM.Watson.VisualRecognition.V3
             }
             response.StatusCode = resp.HttpResponseCode;
 
-            try
+            if (resp.Success)
             {
-                string json = Encoding.UTF8.GetString(resp.Data);
-                response.Result = JsonConvert.DeserializeObject<Classifier>(json);
-                response.Response = json;
-            }
-            catch (Exception e)
-            {
-                Log.Error("VisualRecognitionService.OnGetClassifierResponse()", "Exception: {0}", e.ToString());
-                resp.Success = false;
+                try
+                {
+                    string json = Encoding.UTF8.GetString(resp.Data);
+                    response.Result = JsonConvert.DeserializeObject<Classifier>(json);
+                    response.Response = json;
+                }
+                catch (Exception e)
+                {
+                    Log.Error("VisualRecognitionService.OnGetClassifierResponse()", "Exception: {0}", e.ToString());
+                    resp.Success = false;
+                }
             }
 
             if (((RequestObject<Classifier>)req).Callback != null)
@@ -695,9 +699,9 @@ namespace IBM.Watson.VisualRecognition.V3
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="classifierId">The ID of the classifier.</param>
-        /// <param name="positiveExamples">A .zip file of images that depict the visual subject of a class in the
-        /// classifier. The positive examples create or update classes in the classifier. You can include more than one
-        /// positive example file in a call.
+        /// <param name="positiveExamples">A dictionary that contains the value for each classname. The value is a .zip
+        /// file of images that depict the visual subject of a class in the classifier. The positive examples create or
+        /// update classes in the classifier. You can include more than one positive example file in a call.
         ///
         /// Specify the parameter name by appending `_positive_examples` to the class name. For example,
         /// `goldenretriever_positive_examples` creates the class `goldenretriever`.
@@ -746,7 +750,7 @@ namespace IBM.Watson.VisualRecognition.V3
                 foreach (KeyValuePair<string, System.IO.MemoryStream> entry in positiveExamples)
                 {
                     var partName = string.Format("{0}_positive_examples", entry.Key);
-                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file.zip", "application/octet-stream");
+                    req.Forms[partName] = new RESTConnector.Form(entry.Value, entry.Key + ".zip", "application/octet-stream");
                 }
             }
             if (negativeExamples != null)

--- a/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
+++ b/Scripts/Services/VisualRecognition/V3/VisualRecognitionService.cs
@@ -137,6 +137,7 @@ namespace IBM.Watson.VisualRecognition.V3
         /// non-ASCII characters.
         ///
         /// You can also include an image with the **url** parameter. (optional)</param>
+        /// <param name="imagesFilename">The filename for imagesFile. (optional)</param>
         /// <param name="url">The URL of an image (.gif, .jpg, .png, .tif) to analyze. The minimum recommended pixel
         /// density is 32X32 pixels, but the service tends to perform better with images that are at least 224 x 224
         /// pixels. The maximum image size is 10 MB.
@@ -163,7 +164,7 @@ namespace IBM.Watson.VisualRecognition.V3
         /// (optional, default to en)</param>
         /// <param name="imagesFileContentType">The content type of imagesFile. (optional)</param>
         /// <returns><see cref="ClassifiedImages" />ClassifiedImages</returns>
-        public bool Classify(Callback<ClassifiedImages> callback, System.IO.FileStream imagesFile = null, string url = null, float? threshold = null, List<string> owners = null, List<string> classifierIds = null, string acceptLanguage = null, string imagesFileContentType = null)
+        public bool Classify(Callback<ClassifiedImages> callback, System.IO.MemoryStream imagesFile = null, string imagesFilename = null, string url = null, float? threshold = null, List<string> owners = null, List<string> classifierIds = null, string acceptLanguage = null, string imagesFileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `Classify`");
@@ -191,7 +192,7 @@ namespace IBM.Watson.VisualRecognition.V3
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (imagesFile != null)
             {
-                req.Forms["images_file"] = new RESTConnector.Form(imagesFile, imagesFile.Name, imagesFileContentType);
+                req.Forms["images_file"] = new RESTConnector.Form(imagesFile, imagesFilename, imagesFileContentType);
             }
             if (!string.IsNullOrEmpty(url))
             {
@@ -269,6 +270,7 @@ namespace IBM.Watson.VisualRecognition.V3
         /// UTF-8 encoding if it encounters non-ASCII characters.
         ///
         /// You can also include an image with the **url** parameter. (optional)</param>
+        /// <param name="imagesFilename">The filename for imagesFile. (optional)</param>
         /// <param name="url">The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum
         /// recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at
         /// least 224 x 224 pixels. The maximum image size is 10 MB. Redirects are followed, so you can use a shortened
@@ -279,7 +281,7 @@ namespace IBM.Watson.VisualRecognition.V3
         /// (optional, default to en)</param>
         /// <param name="imagesFileContentType">The content type of imagesFile. (optional)</param>
         /// <returns><see cref="DetectedFaces" />DetectedFaces</returns>
-        public bool DetectFaces(Callback<DetectedFaces> callback, System.IO.FileStream imagesFile = null, string url = null, string acceptLanguage = null, string imagesFileContentType = null)
+        public bool DetectFaces(Callback<DetectedFaces> callback, System.IO.MemoryStream imagesFile = null, string imagesFilename = null, string url = null, string acceptLanguage = null, string imagesFileContentType = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `DetectFaces`");
@@ -307,7 +309,7 @@ namespace IBM.Watson.VisualRecognition.V3
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (imagesFile != null)
             {
-                req.Forms["images_file"] = new RESTConnector.Form(imagesFile, imagesFile.Name, imagesFileContentType);
+                req.Forms["images_file"] = new RESTConnector.Form(imagesFile, imagesFilename, imagesFileContentType);
             }
             if (!string.IsNullOrEmpty(url))
             {
@@ -375,8 +377,9 @@ namespace IBM.Watson.VisualRecognition.V3
         /// classes of the new classifier. Must contain a minimum of 10 images.
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
+        /// <param name="negativeExamplesFilename">The filename for negativeExamples. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool CreateClassifier(Callback<Classifier> callback, string name, Dictionary<string, System.IO.FileStream> positiveExamples, System.IO.FileStream negativeExamples = null)
+        public bool CreateClassifier(Callback<Classifier> callback, string name, Dictionary<string, System.IO.MemoryStream> positiveExamples, System.IO.MemoryStream negativeExamples = null, string negativeExamplesFilename = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `CreateClassifier`");
@@ -414,15 +417,15 @@ namespace IBM.Watson.VisualRecognition.V3
             }
             if (positiveExamples != null && positiveExamples.Count > 0)
             {
-                foreach (KeyValuePair<string, System.IO.FileStream> entry in positiveExamples)
+                foreach (KeyValuePair<string, System.IO.MemoryStream> entry in positiveExamples)
                 {
                     var partName = string.Format("{0}_positive_examples", entry.Key);
-                    req.Forms[partName] = new RESTConnector.Form(entry.Value, entry.Value.Name, "application/octet-stream");
+                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file", "application/octet-stream");
                 }
             }
             if (negativeExamples != null)
             {
-                req.Forms["negative_examples"] = new RESTConnector.Form(negativeExamples, negativeExamples.Name, "application/octet-stream");
+                req.Forms["negative_examples"] = new RESTConnector.Form(negativeExamples, negativeExamplesFilename, "application/octet-stream");
             }
 
             req.OnResponse = OnCreateClassifierResponse;
@@ -704,8 +707,9 @@ namespace IBM.Watson.VisualRecognition.V3
         /// classes of the new classifier. Must contain a minimum of 10 images.
         ///
         /// Encode special characters in the file name in UTF-8. (optional)</param>
+        /// <param name="negativeExamplesFilename">The filename for negativeExamples. (optional)</param>
         /// <returns><see cref="Classifier" />Classifier</returns>
-        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, System.IO.FileStream> positiveExamples = null, System.IO.FileStream negativeExamples = null)
+        public bool UpdateClassifier(Callback<Classifier> callback, string classifierId, Dictionary<string, System.IO.MemoryStream> positiveExamples = null, System.IO.MemoryStream negativeExamples = null, string negativeExamplesFilename = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `UpdateClassifier`");
@@ -735,15 +739,15 @@ namespace IBM.Watson.VisualRecognition.V3
             req.Forms = new Dictionary<string, RESTConnector.Form>();
             if (positiveExamples != null && positiveExamples.Count > 0)
             {
-                foreach (KeyValuePair<string, System.IO.FileStream> entry in positiveExamples)
+                foreach (KeyValuePair<string, System.IO.MemoryStream> entry in positiveExamples)
                 {
                     var partName = string.Format("{0}_positive_examples", entry.Key);
-                    req.Forms[partName] = new RESTConnector.Form(entry.Value, entry.Value.Name, "application/octet-stream");
+                    req.Forms[partName] = new RESTConnector.Form(entry.Value, "file", "application/octet-stream");
                 }
             }
             if (negativeExamples != null)
             {
-                req.Forms["negative_examples"] = new RESTConnector.Form(negativeExamples, negativeExamples.Name, "application/octet-stream");
+                req.Forms["negative_examples"] = new RESTConnector.Form(negativeExamples, negativeExamplesFilename, "application/octet-stream");
             }
 
             req.OnResponse = OnUpdateClassifierResponse;

--- a/Tests/CompareComplyV1IntegrationTests.cs
+++ b/Tests/CompareComplyV1IntegrationTests.cs
@@ -125,7 +125,6 @@ namespace IBM.Watson.Tests
                             Assert.IsNull(error);
                         },
                         file: ms,
-                        filename: "contract_A.pdf",
                         modelId: "contracts",
                         fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath))
                     );
@@ -159,7 +158,6 @@ namespace IBM.Watson.Tests
                         },
                         file: ms,
                         modelId: "tables",
-                        filename: "TestTable.pdf",
                         fileContentType: Utility.GetMimeType(Path.GetExtension(tableFilepath))
                     );
 
@@ -197,8 +195,6 @@ namespace IBM.Watson.Tests
                             },
                             file1: ms0,
                             file2: ms1,
-                            file1Filename: "contract_A.pdf",
-                            file2Filename: "contract_B.pdf",
                             file1Label: "Contract A",
                             file2Label: "Contract B",
                             modelId: "contracts",
@@ -422,8 +418,6 @@ namespace IBM.Watson.Tests
                             outputCredentialsFile: msOutput,
                             outputBucketLocation: "us-south",
                             outputBucketName: "compare-comply-integration-test-bucket-output",
-                            inputCredentialsFilename: "cloud-object-storage-credentials-input.json",
-                            outputCredentialsFilename: "cloud-object-storage-credentials-output.json",
                             modelId: "contracts"
                         );
                         }

--- a/Tests/CompareComplyV1IntegrationTests.cs
+++ b/Tests/CompareComplyV1IntegrationTests.cs
@@ -79,22 +79,27 @@ namespace IBM.Watson.Tests
             HTMLReturn convertToHtmlResponse = null;
             using (FileStream fs = File.OpenRead(contractAFilepath))
             {
-                service.ConvertToHtml(
-                    callback: (DetailedResponse<HTMLReturn> response, IBMError error) =>
-                    {
-                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ConvertToHtml result: {0}", response.Response);
-                        convertToHtmlResponse = response.Result;
-                        Assert.IsNotNull(convertToHtmlResponse);
-                        Assert.IsNotNull(convertToHtmlResponse.Html);
-                        Assert.IsNull(error);
-                    },
-                    file: fs,
-                    modelId: "contracts",
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath))
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.ConvertToHtml(
+                        callback: (DetailedResponse<HTMLReturn> response, IBMError error) =>
+                        {
+                            Log.Debug("CompareComplyServiceV1IntegrationTests", "ConvertToHtml result: {0}", response.Response);
+                            convertToHtmlResponse = response.Result;
+                            Assert.IsNotNull(convertToHtmlResponse);
+                            Assert.IsNotNull(convertToHtmlResponse.Html);
+                            Assert.IsNull(error);
+                        },
+                        file: ms,
+                        filename: "contract_A.pdf",
+                        modelId: "contracts",
+                        fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath))
+                    );
 
-                while (convertToHtmlResponse == null)
-                    yield return null;
+                    while (convertToHtmlResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion
@@ -107,22 +112,27 @@ namespace IBM.Watson.Tests
             ClassifyReturn classifyElementsResponse = null;
             using (FileStream fs = File.OpenRead(contractAFilepath))
             {
-                service.ClassifyElements(
-                    callback: (DetailedResponse<ClassifyReturn> response, IBMError error) =>
-                    {
-                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ClassifyElements result: {0}", response.Response);
-                        classifyElementsResponse = response.Result;
-                        Assert.IsNotNull(classifyElementsResponse);
-                        Assert.IsNotNull(classifyElementsResponse.Elements);
-                        Assert.IsNull(error);
-                    },
-                    file: fs,
-                    modelId: "contracts",
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath))
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.ClassifyElements(
+                        callback: (DetailedResponse<ClassifyReturn> response, IBMError error) =>
+                        {
+                            Log.Debug("CompareComplyServiceV1IntegrationTests", "ClassifyElements result: {0}", response.Response);
+                            classifyElementsResponse = response.Result;
+                            Assert.IsNotNull(classifyElementsResponse);
+                            Assert.IsNotNull(classifyElementsResponse.Elements);
+                            Assert.IsNull(error);
+                        },
+                        file: ms,
+                        filename: "contract_A.pdf",
+                        modelId: "contracts",
+                        fileContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath))
+                    );
 
-                while (classifyElementsResponse == null)
-                    yield return null;
+                    while (classifyElementsResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion
@@ -135,22 +145,27 @@ namespace IBM.Watson.Tests
             TableReturn extractTablesResponse = null;
             using (FileStream fs = File.OpenRead(tableFilepath))
             {
-                service.ExtractTables(
-                    callback: (DetailedResponse<TableReturn> response, IBMError error) =>
-                    {
-                        Log.Debug("CompareComplyServiceV1IntegrationTests", "ExtractTables result: {0}", response.Response);
-                        extractTablesResponse = response.Result;
-                        Assert.IsNotNull(extractTablesResponse);
-                        Assert.IsNotNull(extractTablesResponse.Tables);
-                        Assert.IsNull(error);
-                    },
-                    file: fs,
-                    modelId: "tables",
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(tableFilepath))
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.ExtractTables(
+                        callback: (DetailedResponse<TableReturn> response, IBMError error) =>
+                        {
+                            Log.Debug("CompareComplyServiceV1IntegrationTests", "ExtractTables result: {0}", response.Response);
+                            extractTablesResponse = response.Result;
+                            Assert.IsNotNull(extractTablesResponse);
+                            Assert.IsNotNull(extractTablesResponse.Tables);
+                            Assert.IsNull(error);
+                        },
+                        file: ms,
+                        modelId: "tables",
+                        filename: "TestTable.pdf",
+                        fileContentType: Utility.GetMimeType(Path.GetExtension(tableFilepath))
+                    );
 
-                while (extractTablesResponse == null)
-                    yield return null;
+                    while (extractTablesResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion
@@ -165,26 +180,36 @@ namespace IBM.Watson.Tests
             {
                 using (FileStream fs1 = File.OpenRead(contractBFilepath))
                 {
-                    service.CompareDocuments(
-                        callback: (DetailedResponse<CompareReturn> response, IBMError error) =>
+                    using (MemoryStream ms0 = new MemoryStream())
+                    {
+                        using (MemoryStream ms1 = new MemoryStream())
                         {
-                            Log.Debug("CompareComplyServiceV1IntegrationTests", "CompareDocuments result: {0}", response.Response);
-                            compareDocumentsResponse = response.Result;
-                            Assert.IsNotNull(compareDocumentsResponse);
-                            Assert.IsNotNull(compareDocumentsResponse.Documents);
-                            Assert.IsNull(error);
-                        },
-                        file1: fs0,
-                        file2: fs1,
-                        file1Label: "Contract A",
-                        file2Label: "Contract B",
-                        modelId: "contracts",
-                        file1ContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath)),
-                        file2ContentType: Utility.GetMimeType(Path.GetExtension(contractBFilepath))
-                    );
+                            fs0.CopyTo(ms0);
+                            fs1.CopyTo(ms1);
+                            service.CompareDocuments(
+                            callback: (DetailedResponse<CompareReturn> response, IBMError error) =>
+                            {
+                                Log.Debug("CompareComplyServiceV1IntegrationTests", "CompareDocuments result: {0}", response.Response);
+                                compareDocumentsResponse = response.Result;
+                                Assert.IsNotNull(compareDocumentsResponse);
+                                Assert.IsNotNull(compareDocumentsResponse.Documents);
+                                Assert.IsNull(error);
+                            },
+                            file1: ms0,
+                            file2: ms1,
+                            file1Filename: "contract_A.pdf",
+                            file2Filename: "contract_B.pdf",
+                            file1Label: "Contract A",
+                            file2Label: "Contract B",
+                            modelId: "contracts",
+                            file1ContentType: Utility.GetMimeType(Path.GetExtension(contractAFilepath)),
+                            file2ContentType: Utility.GetMimeType(Path.GetExtension(contractBFilepath))
+                        );
 
-                    while (compareDocumentsResponse == null)
-                        yield return null;
+                            while (compareDocumentsResponse == null)
+                                yield return null;
+                        }
+                    }
                 }
             }
         }
@@ -374,25 +399,37 @@ namespace IBM.Watson.Tests
             {
                 using (FileStream fsOutput = File.OpenRead(objectStorageCredentialsOutputFilepath))
                 {
-                    service.CreateBatch(
-                        callback: (DetailedResponse<BatchStatus> response, IBMError error) =>
+                    using (MemoryStream msInput = new MemoryStream())
+                    {
+                        using (MemoryStream msOutput = new MemoryStream())
                         {
-                            Log.Debug("CompareComplyServiceV1IntegrationTests", "CreateBatch result: {0}", response.Response);
-                            createBatchResponse = response.Result;
-                            createdBatchId = createBatchResponse.BatchId;
-                            Assert.IsNotNull(createBatchResponse);
-                            Assert.IsNotNull(createdBatchId);
-                            Assert.IsNull(error);
-                        },
-                        function: "html_conversion",
-                        inputCredentialsFile: fsInput,
-                        inputBucketLocation: "us-south",
-                        inputBucketName: "compare-comply-integration-test-bucket-input",
-                        outputCredentialsFile: fsOutput,
-                        outputBucketLocation: "us-south",
-                        outputBucketName: "compare-comply-integration-test-bucket-output",
-                        modelId: "contracts"
-                    );
+                            fsInput.CopyTo(msInput);
+                            fsOutput.CopyTo(msOutput);
+                            service.CreateBatch(
+                            callback: (DetailedResponse<BatchStatus> response, IBMError error) =>
+                            {
+                                Log.Debug("CompareComplyServiceV1IntegrationTests", "CreateBatch result: {0}", response.Response);
+                                createBatchResponse = response.Result;
+                                createdBatchId = createBatchResponse.BatchId;
+                                Assert.IsNotNull(createBatchResponse);
+                                Assert.IsNotNull(createdBatchId);
+                                Assert.IsNull(error);
+                            },
+                            function: "html_conversion",
+                            inputCredentialsFile: msInput,
+                            inputBucketLocation: "us-south",
+                            inputBucketName: "compare-comply-integration-test-bucket-input",
+                            outputCredentialsFile: msOutput,
+                            outputBucketLocation: "us-south",
+                            outputBucketName: "compare-comply-integration-test-bucket-output",
+                            inputCredentialsFilename: "cloud-object-storage-credentials-input.json",
+                            outputCredentialsFilename: "cloud-object-storage-credentials-output.json",
+                            modelId: "contracts"
+                        );
+                        }
+                    }
+
+
                 }
             }
             while (createBatchResponse == null)

--- a/Tests/DiscoveryV1IntegrationTests.cs
+++ b/Tests/DiscoveryV1IntegrationTests.cs
@@ -330,7 +330,8 @@ namespace IBM.Watson.Tests
                         environmentId: environmentId,
                         configurationId: createdConfigurationId,
                         file: ms,
-                        fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
+                        fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath)),
+                        filename: Path.GetFileName(watsonBeatsJeopardyHtmlFilePath)
                     );
 
                     while (testConfigurationInEnvironmentResponse == null)

--- a/Tests/DiscoveryV1IntegrationTests.cs
+++ b/Tests/DiscoveryV1IntegrationTests.cs
@@ -314,24 +314,28 @@ namespace IBM.Watson.Tests
             TestDocument testConfigurationInEnvironmentResponse = null;
             using (FileStream fs = File.OpenRead(watsonBeatsJeopardyHtmlFilePath))
             {
-                service.TestConfigurationInEnvironment(
-                    callback: (DetailedResponse<TestDocument> response, IBMError error) =>
-                    {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "TestConfigurationInEnvironment result: {0}", response.Response);
-                        testConfigurationInEnvironmentResponse = response.Result;
-                        Assert.IsNotNull(testConfigurationInEnvironmentResponse);
-                        Assert.IsNotNull(testConfigurationInEnvironmentResponse.Status);
-                        Assert.IsNotNull(testConfigurationInEnvironmentResponse.Snapshots);
-                        Assert.IsNull(error);
-                    },
-                    environmentId: environmentId,
-                    configurationId: createdConfigurationId,
-                    file: fs,
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.TestConfigurationInEnvironment(
+                        callback: (DetailedResponse<TestDocument> response, IBMError error) =>
+                        {
+                            Log.Debug("DiscoveryServiceV1IntegrationTests", "TestConfigurationInEnvironment result: {0}", response.Response);
+                            testConfigurationInEnvironmentResponse = response.Result;
+                            Assert.IsNotNull(testConfigurationInEnvironmentResponse);
+                            Assert.IsNotNull(testConfigurationInEnvironmentResponse.Status);
+                            Assert.IsNotNull(testConfigurationInEnvironmentResponse.Snapshots);
+                            Assert.IsNull(error);
+                        },
+                        environmentId: environmentId,
+                        configurationId: createdConfigurationId,
+                        file: ms,
+                        fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
+                    );
 
-                while (testConfigurationInEnvironmentResponse == null)
-                    yield return null;
+                    while (testConfigurationInEnvironmentResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion
@@ -582,23 +586,28 @@ namespace IBM.Watson.Tests
             TokenDictStatusResponse createStopwordListResponse = null;
             using (FileStream fs = File.OpenRead(stopwordsFilePath))
             {
-                service.CreateStopwordList(
-                    callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error) =>
-                    {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateStopwordList result: {0}", response.Response);
-                        createStopwordListResponse = response.Result;
-                        Assert.IsNotNull(createStopwordListResponse);
-                        Assert.IsNotNull(createStopwordListResponse.Status);
-                        Assert.IsTrue(createStopwordListResponse.Type == "stopwords");
-                        Assert.IsNull(error);
-                    },
-                    environmentId: environmentId,
-                    collectionId: collectionId,
-                    stopwordFile: fs
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.CreateStopwordList(
+                        callback: (DetailedResponse<TokenDictStatusResponse> response, IBMError error) =>
+                        {
+                            Log.Debug("DiscoveryServiceV1IntegrationTests", "CreateStopwordList result: {0}", response.Response);
+                            createStopwordListResponse = response.Result;
+                            Assert.IsNotNull(createStopwordListResponse);
+                            Assert.IsNotNull(createStopwordListResponse.Status);
+                            Assert.IsTrue(createStopwordListResponse.Type == "stopwords");
+                            Assert.IsNull(error);
+                        },
+                        environmentId: environmentId,
+                        collectionId: collectionId,
+                        stopwordFile: ms,
+                        stopwordFilename: Path.GetFileName(stopwordsFilePath)
+                    );
 
-                while (createStopwordListResponse == null)
-                    yield return null;
+                    while (createStopwordListResponse == null)
+                        yield return null;
+                }
             }
 
             isStopwordsListReady = false;
@@ -749,24 +758,29 @@ namespace IBM.Watson.Tests
             DocumentAccepted addDocumentResponse = null;
             using (FileStream fs = File.OpenRead(watsonBeatsJeopardyHtmlFilePath))
             {
-                service.AddDocument(
-                    callback: (DetailedResponse<DocumentAccepted> response, IBMError error) =>
-                    {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "AddDocument result: {0}", response.Response);
-                        addDocumentResponse = response.Result;
-                        addedDocumentId = addDocumentResponse.DocumentId;
-                        Assert.IsNotNull(addDocumentResponse);
-                        Assert.IsNotNull(addedDocumentId);
-                        Assert.IsNull(error);
-                    },
-                    environmentId: environmentId,
-                    collectionId: collectionId,
-                    file: fs,
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.AddDocument(
+                        callback: (DetailedResponse<DocumentAccepted> response, IBMError error) =>
+                        {
+                            Log.Debug("DiscoveryServiceV1IntegrationTests", "AddDocument result: {0}", response.Response);
+                            addDocumentResponse = response.Result;
+                            addedDocumentId = addDocumentResponse.DocumentId;
+                            Assert.IsNotNull(addDocumentResponse);
+                            Assert.IsNotNull(addedDocumentId);
+                            Assert.IsNull(error);
+                        },
+                        environmentId: environmentId,
+                        collectionId: collectionId,
+                        file: ms,
+                        fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath)),
+                        filename: Path.GetFileName(watsonBeatsJeopardyHtmlFilePath)
+                    );
 
-                while (addDocumentResponse == null)
-                    yield return null;
+                    while (addDocumentResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion
@@ -804,24 +818,29 @@ namespace IBM.Watson.Tests
             DocumentAccepted updateDocumentResponse = null;
             using (FileStream fs = File.OpenRead(watsonBeatsJeopardyHtmlFilePath))
             {
-                service.UpdateDocument(
-                    callback: (DetailedResponse<DocumentAccepted> response, IBMError error) =>
-                    {
-                        Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateDocument result: {0}", response.Response);
-                        updateDocumentResponse = response.Result;
-                        Assert.IsNotNull(updateDocumentResponse);
-                        Assert.IsTrue(updateDocumentResponse.DocumentId == addedDocumentId);
-                        Assert.IsNull(error);
-                    },
-                    environmentId: environmentId,
-                    collectionId: collectionId,
-                    documentId: addedDocumentId,
-                    file: fs,
-                    fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath))
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.UpdateDocument(
+                        callback: (DetailedResponse<DocumentAccepted> response, IBMError error) =>
+                        {
+                            Log.Debug("DiscoveryServiceV1IntegrationTests", "UpdateDocument result: {0}", response.Response);
+                            updateDocumentResponse = response.Result;
+                            Assert.IsNotNull(updateDocumentResponse);
+                            Assert.IsTrue(updateDocumentResponse.DocumentId == addedDocumentId);
+                            Assert.IsNull(error);
+                        },
+                        environmentId: environmentId,
+                        collectionId: collectionId,
+                        documentId: addedDocumentId,
+                        file: ms,
+                        fileContentType: Utility.GetMimeType(Path.GetExtension(watsonBeatsJeopardyHtmlFilePath)),
+                        filename: Path.GetFileName(watsonBeatsJeopardyHtmlFilePath)
+                    );
 
-                while (updateDocumentResponse == null)
-                    yield return null;
+                    while (updateDocumentResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion

--- a/Tests/LanguageTranslatorV3IntegrationTests.cs
+++ b/Tests/LanguageTranslatorV3IntegrationTests.cs
@@ -145,26 +145,31 @@ namespace IBM.Watson.Tests
             TranslationModel createModelResponse = null;
             using (FileStream fs = File.OpenRead(forcedGlossaryFilepath))
             {
-                service.CreateModel(
-                    callback: (DetailedResponse<TranslationModel> response, IBMError error) =>
-                    {
-                        Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "CreateModel result: {0}", response.Response);
-                        createModelResponse = response.Result;
-                        customModelId = createModelResponse.ModelId;
-                        Assert.IsNotNull(createModelResponse);
-                        Assert.IsNotNull(customModelId);
-                        Assert.IsTrue(createModelResponse.Source == "en");
-                        Assert.IsTrue(createModelResponse.Target == "fr");
-                        Assert.IsTrue(createModelResponse.Name == customModelName);
-                        Assert.IsNull(error);
-                    },
-                    baseModelId: englishToFrenchModel,
-                    forcedGlossary: fs,
-                    name: customModelName
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.CreateModel(
+                        callback: (DetailedResponse<TranslationModel> response, IBMError error) =>
+                        {
+                            Log.Debug("LanguageTranslatorServiceV3IntegrationTests", "CreateModel result: {0}", response.Response);
+                            createModelResponse = response.Result;
+                            customModelId = createModelResponse.ModelId;
+                            Assert.IsNotNull(createModelResponse);
+                            Assert.IsNotNull(customModelId);
+                            Assert.IsTrue(createModelResponse.Source == "en");
+                            Assert.IsTrue(createModelResponse.Target == "fr");
+                            Assert.IsTrue(createModelResponse.Name == customModelName);
+                            Assert.IsNull(error);
+                        },
+                        baseModelId: englishToFrenchModel,
+                        forcedGlossary: ms,
+                        name: customModelName,
+                        forcedGlossaryFilename: Path.GetFileName(forcedGlossaryFilepath)
+                    );
 
-                while (createModelResponse == null)
-                    yield return null;
+                    while (createModelResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion

--- a/Tests/LanguageTranslatorV3IntegrationTests.cs
+++ b/Tests/LanguageTranslatorV3IntegrationTests.cs
@@ -163,8 +163,7 @@ namespace IBM.Watson.Tests
                         },
                         baseModelId: englishToFrenchModel,
                         forcedGlossary: ms,
-                        name: customModelName,
-                        forcedGlossaryFilename: Path.GetFileName(forcedGlossaryFilepath)
+                        name: customModelName
                     );
 
                     while (createModelResponse == null)

--- a/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
+++ b/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
@@ -163,24 +163,34 @@ namespace IBM.Watson.Tests
             {
                 using (FileStream fs1 = File.OpenRead(classifierDataFilePath))
                 {
-                    service.CreateClassifier(
-                    callback: (DetailedResponse<Classifier> response, IBMError error) =>
+                    using (MemoryStream ms0 = new MemoryStream())
                     {
-                        Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "CreateClassifier result: {0}", response.Response);
-                        createClassifierResponse = response.Result;
-                        createdClassifierId = createClassifierResponse.ClassifierId;
-                        Assert.IsNotNull(createClassifierResponse);
-                        Assert.IsNotNull(createdClassifierId);
-                        Assert.IsTrue(createClassifierResponse.Name == "unity-classifier-delete");
-                        Assert.IsTrue(createClassifierResponse.Language == "en");
-                        Assert.IsNull(error);
-                    },
-                    metadata: fs0,
-                    trainingData: fs1
-                );
+                        using (MemoryStream ms1 = new MemoryStream())
+                        {
+                            fs0.CopyTo(ms0);
+                            fs1.CopyTo(ms1);
+                            service.CreateClassifier(
+                                callback: (DetailedResponse<Classifier> response, IBMError error) =>
+                                {
+                                    Log.Debug("NaturalLanguageClassifierServiceV1IntegrationTests", "CreateClassifier result: {0}", response.Response);
+                                    createClassifierResponse = response.Result;
+                                    createdClassifierId = createClassifierResponse.ClassifierId;
+                                    Assert.IsNotNull(createClassifierResponse);
+                                    Assert.IsNotNull(createdClassifierId);
+                                    Assert.IsTrue(createClassifierResponse.Name == "unity-classifier-delete");
+                                    Assert.IsTrue(createClassifierResponse.Language == "en");
+                                    Assert.IsNull(error);
+                                },
+                                metadata: ms0,
+                                trainingData: ms1,
+                                metadataFilename: Path.GetFileName(metadataDataFilePath),
+                                trainingDataFilename: Path.GetFileName(classifierDataFilePath)
+                            );
 
-                    while (createClassifierResponse == null)
-                        yield return null;
+                            while (createClassifierResponse == null)
+                                yield return null;
+                        }
+                    }
                 }
             }
         }

--- a/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
+++ b/Tests/NaturalLanguageClassifierV1IntegrationTests.cs
@@ -182,9 +182,7 @@ namespace IBM.Watson.Tests
                                     Assert.IsNull(error);
                                 },
                                 metadata: ms0,
-                                trainingData: ms1,
-                                metadataFilename: Path.GetFileName(metadataDataFilePath),
-                                trainingDataFilename: Path.GetFileName(classifierDataFilePath)
+                                trainingData: ms1
                             );
 
                             while (createClassifierResponse == null)

--- a/Tests/SpeechToTextV1IntegrationTests.cs
+++ b/Tests/SpeechToTextV1IntegrationTests.cs
@@ -367,22 +367,27 @@ namespace IBM.Watson.Tests
             bool isComplete = false;
             using (FileStream fs = File.OpenRead(corpusPath))
             {
-                service.AddCorpus(
-                    callback: (DetailedResponse<object> response, IBMError error) =>
-                    {
-                        Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddCorpus result: {0}", response.Response);
-                        Assert.IsNull(error);
-                        Assert.IsTrue(response.StatusCode == 201);
-                        isComplete = true;
-                    },
-                    customizationId: customizationId,
-                    corpusName: corpusName,
-                    corpusFile: fs,
-                    allowOverwrite: true
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.AddCorpus(
+                        callback: (DetailedResponse<object> response, IBMError error) =>
+                        {
+                            Log.Debug("SpeechToTextServiceV1IntegrationTests", "AddCorpus result: {0}", response.Response);
+                            Assert.IsNull(error);
+                            Assert.IsTrue(response.StatusCode == 201);
+                            isComplete = true;
+                        },
+                        customizationId: customizationId,
+                        corpusName: corpusName,
+                        corpusFile: ms,
+                        allowOverwrite: true,
+                        corpusFilename: Path.GetFileName(corpusPath)
+                    );
 
-                while (!isComplete)
-                    yield return null;
+                    while (!isComplete)
+                        yield return null;
+                }
             }
         }
         #endregion

--- a/Tests/SpeechToTextV1IntegrationTests.cs
+++ b/Tests/SpeechToTextV1IntegrationTests.cs
@@ -381,8 +381,7 @@ namespace IBM.Watson.Tests
                         customizationId: customizationId,
                         corpusName: corpusName,
                         corpusFile: ms,
-                        allowOverwrite: true,
-                        corpusFilename: Path.GetFileName(corpusPath)
+                        allowOverwrite: true
                     );
 
                     while (!isComplete)

--- a/Tests/VisualRecognitionV3IntegrationTests.cs
+++ b/Tests/VisualRecognitionV3IntegrationTests.cs
@@ -95,7 +95,7 @@ namespace IBM.Watson.Tests
                             fs0.CopyTo(ms0);
                             fs1.CopyTo(ms1);
                             Dictionary<string, MemoryStream> positiveExamples = new Dictionary<string, MemoryStream>();
-                            positiveExamples.Add("giraffe_positive_examples", ms0);
+                            positiveExamples.Add("giraffe", ms0);
                             service.CreateClassifier(
                                 callback: (DetailedResponse<Classifier> response, IBMError error) =>
                                 {
@@ -112,7 +112,9 @@ namespace IBM.Watson.Tests
                                 },
                                 name: classifierName,
                                 positiveExamples: positiveExamples,
-                                negativeExamples: ms1
+                                negativeExamples: ms1,
+                                positiveExamplesFilename: Path.GetFileName(giraffePositiveExamplesFilepath),
+                                negativeExamplesFilename: Path.GetFileName(negativeExamplesFilepath)
                             );
 
                             while (createClassifierResponse == null)

--- a/Tests/VisualRecognitionV3IntegrationTests.cs
+++ b/Tests/VisualRecognitionV3IntegrationTests.cs
@@ -78,78 +78,8 @@ namespace IBM.Watson.Tests
             service.WithHeader("X-Watson-Test", "1");
         }
 
-        #region Classify
-        [UnityTest, Order(0)]
-        public IEnumerator TestClassify()
-        {
-            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to Classify...");
-            ClassifiedImages classifyResponse = null;
-            using (FileStream fs = File.OpenRead(turtleImageFilepath))
-            {
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    fs.CopyTo(ms);
-                    service.Classify(
-                    callback: (DetailedResponse<ClassifiedImages> response, IBMError error) =>
-                    {
-                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Classify result: {0}", response.Response);
-                        classifyResponse = response.Result;
-                        Assert.IsNotNull(classifyResponse);
-                        Assert.IsNotNull(classifyResponse.Images);
-                        Assert.IsTrue(classifyResponse.Images.Count > 0);
-                        Assert.IsNotNull(classifyResponse.Images[0].Classifiers);
-                        Assert.IsTrue(classifyResponse.Images[0].Classifiers.Count > 0);
-                        Assert.IsNull(error);
-                    },
-                    imagesFile: ms,
-                    imagesFileContentType: turtleImageContentType,
-                    imagesFilename: Path.GetFileName(turtleImageFilepath)
-                );
-
-                    while (classifyResponse == null)
-                        yield return null;
-                }
-            }
-        }
-        #endregion
-
-        #region DetectFaces
-        [UnityTest, Order(1)]
-        public IEnumerator TestDetectFaces()
-        {
-            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to DetectFaces...");
-            DetectedFaces detectFacesResponse = null;
-            using (FileStream fs = File.OpenRead(obamaImageFilepath))
-            {
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    fs.CopyTo(ms);
-                    service.DetectFaces(
-                        callback: (DetailedResponse<DetectedFaces> response, IBMError error) =>
-                        {
-                            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DetectFaces result: {0}", response.Response);
-                            detectFacesResponse = response.Result;
-                            Assert.IsNotNull(detectFacesResponse);
-                            Assert.IsNotNull(detectFacesResponse.Images);
-                            Assert.IsTrue(detectFacesResponse.Images.Count > 0);
-                            Assert.IsNotNull(detectFacesResponse.Images[0].Faces);
-                            Assert.IsTrue(detectFacesResponse.Images[0].Faces.Count > 0);
-                            Assert.IsNull(error);
-                        },
-                        imagesFile: ms,
-                        imagesFileContentType: obamaImageContentType,
-                        imagesFilename: Path.GetFileName(obamaImageFilepath)
-                    );
-
-                    while (detectFacesResponse == null)
-                        yield return null;
-                }
-            }
-        }
-        #endregion
-
         #region CreateClassifier
-        [UnityTest, Order(2)]
+        [UnityTest, Order(0)]
         public IEnumerator TestCreateClassifier()
         {
             Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to CreateClassifier...");
@@ -189,6 +119,76 @@ namespace IBM.Watson.Tests
                                 yield return null;
                         }
                     }
+                }
+            }
+        }
+        #endregion
+
+        #region Classify
+        [UnityTest, Order(1)]
+        public IEnumerator TestClassify()
+        {
+            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to Classify...");
+            ClassifiedImages classifyResponse = null;
+            using (FileStream fs = File.OpenRead(turtleImageFilepath))
+            {
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.Classify(
+                    callback: (DetailedResponse<ClassifiedImages> response, IBMError error) =>
+                    {
+                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Classify result: {0}", response.Response);
+                        classifyResponse = response.Result;
+                        Assert.IsNotNull(classifyResponse);
+                        Assert.IsNotNull(classifyResponse.Images);
+                        Assert.IsTrue(classifyResponse.Images.Count > 0);
+                        Assert.IsNotNull(classifyResponse.Images[0].Classifiers);
+                        Assert.IsTrue(classifyResponse.Images[0].Classifiers.Count > 0);
+                        Assert.IsNull(error);
+                    },
+                    imagesFile: ms,
+                    imagesFileContentType: turtleImageContentType,
+                    imagesFilename: Path.GetFileName(turtleImageFilepath)
+                );
+
+                    while (classifyResponse == null)
+                        yield return null;
+                }
+            }
+        }
+        #endregion
+
+        #region DetectFaces
+        [UnityTest, Order(2)]
+        public IEnumerator TestDetectFaces()
+        {
+            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to DetectFaces...");
+            DetectedFaces detectFacesResponse = null;
+            using (FileStream fs = File.OpenRead(obamaImageFilepath))
+            {
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.DetectFaces(
+                        callback: (DetailedResponse<DetectedFaces> response, IBMError error) =>
+                        {
+                            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DetectFaces result: {0}", response.Response);
+                            detectFacesResponse = response.Result;
+                            Assert.IsNotNull(detectFacesResponse);
+                            Assert.IsNotNull(detectFacesResponse.Images);
+                            Assert.IsTrue(detectFacesResponse.Images.Count > 0);
+                            Assert.IsNotNull(detectFacesResponse.Images[0].Faces);
+                            Assert.IsTrue(detectFacesResponse.Images[0].Faces.Count > 0);
+                            Assert.IsNull(error);
+                        },
+                        imagesFile: ms,
+                        imagesFileContentType: obamaImageContentType,
+                        imagesFilename: Path.GetFileName(obamaImageFilepath)
+                    );
+
+                    while (detectFacesResponse == null)
+                        yield return null;
                 }
             }
         }

--- a/Tests/VisualRecognitionV3IntegrationTests.cs
+++ b/Tests/VisualRecognitionV3IntegrationTests.cs
@@ -86,7 +86,10 @@ namespace IBM.Watson.Tests
             ClassifiedImages classifyResponse = null;
             using (FileStream fs = File.OpenRead(turtleImageFilepath))
             {
-                service.Classify(
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.Classify(
                     callback: (DetailedResponse<ClassifiedImages> response, IBMError error) =>
                     {
                         Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Classify result: {0}", response.Response);
@@ -98,12 +101,14 @@ namespace IBM.Watson.Tests
                         Assert.IsTrue(classifyResponse.Images[0].Classifiers.Count > 0);
                         Assert.IsNull(error);
                     },
-                    imagesFile: fs,
-                    imagesFileContentType: turtleImageContentType
+                    imagesFile: ms,
+                    imagesFileContentType: turtleImageContentType,
+                    imagesFilename: Path.GetFileName(turtleImageFilepath)
                 );
 
-                while (classifyResponse == null)
-                    yield return null;
+                    while (classifyResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion
@@ -116,24 +121,29 @@ namespace IBM.Watson.Tests
             DetectedFaces detectFacesResponse = null;
             using (FileStream fs = File.OpenRead(obamaImageFilepath))
             {
-                service.DetectFaces(
-                    callback: (DetailedResponse<DetectedFaces> response, IBMError error) =>
-                    {
-                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DetectFaces result: {0}", response.Response);
-                        detectFacesResponse = response.Result;
-                        Assert.IsNotNull(detectFacesResponse);
-                        Assert.IsNotNull(detectFacesResponse.Images);
-                        Assert.IsTrue(detectFacesResponse.Images.Count > 0);
-                        Assert.IsNotNull(detectFacesResponse.Images[0].Faces);
-                        Assert.IsTrue(detectFacesResponse.Images[0].Faces.Count > 0);
-                        Assert.IsNull(error);
-                    },
-                    imagesFile: fs,
-                    imagesFileContentType: obamaImageContentType
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    service.DetectFaces(
+                        callback: (DetailedResponse<DetectedFaces> response, IBMError error) =>
+                        {
+                            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "DetectFaces result: {0}", response.Response);
+                            detectFacesResponse = response.Result;
+                            Assert.IsNotNull(detectFacesResponse);
+                            Assert.IsNotNull(detectFacesResponse.Images);
+                            Assert.IsTrue(detectFacesResponse.Images.Count > 0);
+                            Assert.IsNotNull(detectFacesResponse.Images[0].Faces);
+                            Assert.IsTrue(detectFacesResponse.Images[0].Faces.Count > 0);
+                            Assert.IsNull(error);
+                        },
+                        imagesFile: ms,
+                        imagesFileContentType: obamaImageContentType,
+                        imagesFilename: Path.GetFileName(obamaImageFilepath)
+                    );
 
-                while (detectFacesResponse == null)
-                    yield return null;
+                    while (detectFacesResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion
@@ -148,29 +158,37 @@ namespace IBM.Watson.Tests
             {
                 using (FileStream fs1 = File.OpenRead(negativeExamplesFilepath))
                 {
-                    Dictionary<string, FileStream> positiveExamples = new Dictionary<string, FileStream>();
-                    positiveExamples.Add("giraffe_positive_examples", fs0);
-                    service.CreateClassifier(
-                        callback: (DetailedResponse<Classifier> response, IBMError error) =>
+                    using (MemoryStream ms0 = new MemoryStream())
+                    {
+                        using (MemoryStream ms1 = new MemoryStream())
                         {
-                            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "CreateClassifier result: {0}", response.Response);
-                            createClassifierResponse = response.Result;
-                            classifierId = createClassifierResponse.ClassifierId;
-                            Assert.IsNotNull(createClassifierResponse);
-                            Assert.IsNotNull(classifierId);
-                            Assert.IsTrue(createClassifierResponse.Name == classifierName);
-                            Assert.IsNotNull(createClassifierResponse.Classes);
-                            Assert.IsTrue(createClassifierResponse.Classes.Count > 0);
-                            Assert.IsTrue(createClassifierResponse.Classes[0].ClassName == "giraffe");
-                            Assert.IsNull(error);
-                        },
-                        name: classifierName,
-                        positiveExamples: positiveExamples,
-                        negativeExamples: fs1
-                    );
+                            fs0.CopyTo(ms0);
+                            fs1.CopyTo(ms1);
+                            Dictionary<string, MemoryStream> positiveExamples = new Dictionary<string, MemoryStream>();
+                            positiveExamples.Add("giraffe_positive_examples", ms0);
+                            service.CreateClassifier(
+                                callback: (DetailedResponse<Classifier> response, IBMError error) =>
+                                {
+                                    Log.Debug("VisualRecognitionServiceV3IntegrationTests", "CreateClassifier result: {0}", response.Response);
+                                    createClassifierResponse = response.Result;
+                                    classifierId = createClassifierResponse.ClassifierId;
+                                    Assert.IsNotNull(createClassifierResponse);
+                                    Assert.IsNotNull(classifierId);
+                                    Assert.IsTrue(createClassifierResponse.Name == classifierName);
+                                    Assert.IsNotNull(createClassifierResponse.Classes);
+                                    Assert.IsTrue(createClassifierResponse.Classes.Count > 0);
+                                    Assert.IsTrue(createClassifierResponse.Classes[0].ClassName == "giraffe");
+                                    Assert.IsNull(error);
+                                },
+                                name: classifierName,
+                                positiveExamples: positiveExamples,
+                                negativeExamples: ms1
+                            );
 
-                    while (createClassifierResponse == null)
-                        yield return null;
+                            while (createClassifierResponse == null)
+                                yield return null;
+                        }
+                    }
                 }
             }
         }
@@ -244,25 +262,29 @@ namespace IBM.Watson.Tests
             Log.Debug("VisualRecognitionServiceV3IntegrationTests", "Attempting to UpdateClassifier...");
             using (FileStream fs = File.OpenRead(turtlePositiveExamplesFilepath))
             {
-                Classifier updateClassifierResponse = null;
-                Dictionary<string, FileStream> positiveExamples = new Dictionary<string, FileStream>();
-                positiveExamples.Add("turtles_positive_examples", fs);
-                service.UpdateClassifier(
-                    callback: (DetailedResponse<Classifier> response, IBMError error) =>
-                    {
-                        Log.Debug("VisualRecognitionServiceV3IntegrationTests", "UpdateClassifier result: {0}", response.Response);
-                        updateClassifierResponse = response.Result;
-                        Assert.IsNotNull(updateClassifierResponse);
-                        Assert.IsNotNull(updateClassifierResponse.Classes);
-                        Assert.IsTrue(updateClassifierResponse.Classes.Count > 0);
-                        Assert.IsNull(error);
-                    },
-                    classifierId: classifierId,
-                    positiveExamples: positiveExamples
-                );
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    fs.CopyTo(ms);
+                    Classifier updateClassifierResponse = null;
+                    Dictionary<string, MemoryStream> positiveExamples = new Dictionary<string, MemoryStream>();
+                    positiveExamples.Add("turtles_positive_examples", ms);
+                    service.UpdateClassifier(
+                        callback: (DetailedResponse<Classifier> response, IBMError error) =>
+                        {
+                            Log.Debug("VisualRecognitionServiceV3IntegrationTests", "UpdateClassifier result: {0}", response.Response);
+                            updateClassifierResponse = response.Result;
+                            Assert.IsNotNull(updateClassifierResponse);
+                            Assert.IsNotNull(updateClassifierResponse.Classes);
+                            Assert.IsTrue(updateClassifierResponse.Classes.Count > 0);
+                            Assert.IsNull(error);
+                        },
+                        classifierId: classifierId,
+                        positiveExamples: positiveExamples
+                    );
 
-                while (updateClassifierResponse == null)
-                    yield return null;
+                    while (updateClassifierResponse == null)
+                        yield return null;
+                }
             }
         }
         #endregion


### PR DESCRIPTION
### Summary

This pull request changes `file` type from `FileStream` to the more genreic `MemoryStream` so the user doesn't need to have data saved on disk. Since we now cannot get the filename from a `MemoryStream` I implemented synthesized filenames that some of the other SDKs use. Previously the SDK took byte[].

Additionally the SDK was regenerated using the latest OAS3 API definitions.