### PR TITLE
feat(regenerate): updates for regular release 4

### DIFF
--- a/Scripts/Services/Assistant/V1/Model/RuntimeEntity.cs
+++ b/Scripts/Services/Assistant/V1/Model/RuntimeEntity.cs
@@ -37,12 +37,12 @@ namespace IBM.Watson.Assistant.V1.Model
         [JsonProperty("location", NullValueHandling = NullValueHandling.Ignore)]
         public List<long?> Location { get; set; }
         /// <summary>
-        /// The term in the input text that was recognized as an entity value.
+        /// The entity value that was recognized in the user input.
         /// </summary>
         [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
         public string Value { get; set; }
         /// <summary>
-        /// A decimal percentage that represents Watson's confidence in the entity.
+        /// A decimal percentage that represents Watson's confidence in the recognized entity.
         /// </summary>
         [JsonProperty("confidence", NullValueHandling = NullValueHandling.Ignore)]
         public float? Confidence { get; set; }
@@ -56,5 +56,12 @@ namespace IBM.Watson.Assistant.V1.Model
         /// </summary>
         [JsonProperty("groups", NullValueHandling = NullValueHandling.Ignore)]
         public List<CaptureGroup> Groups { get; set; }
+        /// <summary>
+        /// An object containing detailed information about the entity recognized in the user input.
+        ///
+        /// This property is a part of the new system entities, which are a beta feature.
+        /// </summary>
+        [JsonProperty("interpretation", NullValueHandling = NullValueHandling.Ignore)]
+        public RuntimeEntityInterpretation Interpretation { get; set; }
     }
 }

--- a/Scripts/Services/Assistant/V1/Model/RuntimeEntityInterpretation.cs
+++ b/Scripts/Services/Assistant/V1/Model/RuntimeEntityInterpretation.cs
@@ -1,0 +1,234 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Newtonsoft.Json;
+
+namespace IBM.Watson.Assistant.V1.Model
+{
+    /// <summary>
+    /// RuntimeEntityInterpretation.
+    /// </summary>
+    public class RuntimeEntityInterpretation
+    {
+        /// <summary>
+        /// The precision or duration of a time range specified by a recognized `@sys-time` or `@sys-date` entity.
+        /// </summary>
+        public class GranularityValue
+        {
+            /// <summary>
+            /// Constant DAY for day
+            /// </summary>
+            public const string DAY = "day";
+            /// <summary>
+            /// Constant FORTNIGHT for fortnight
+            /// </summary>
+            public const string FORTNIGHT = "fortnight";
+            /// <summary>
+            /// Constant HOUR for hour
+            /// </summary>
+            public const string HOUR = "hour";
+            /// <summary>
+            /// Constant INSTANT for instant
+            /// </summary>
+            public const string INSTANT = "instant";
+            /// <summary>
+            /// Constant MINUTE for minute
+            /// </summary>
+            public const string MINUTE = "minute";
+            /// <summary>
+            /// Constant MONTH for month
+            /// </summary>
+            public const string MONTH = "month";
+            /// <summary>
+            /// Constant QUARTER for quarter
+            /// </summary>
+            public const string QUARTER = "quarter";
+            /// <summary>
+            /// Constant SECOND for second
+            /// </summary>
+            public const string SECOND = "second";
+            /// <summary>
+            /// Constant WEEK for week
+            /// </summary>
+            public const string WEEK = "week";
+            /// <summary>
+            /// Constant WEEKEND for weekend
+            /// </summary>
+            public const string WEEKEND = "weekend";
+            /// <summary>
+            /// Constant YEAR for year
+            /// </summary>
+            public const string YEAR = "year";
+            
+        }
+
+        /// <summary>
+        /// The precision or duration of a time range specified by a recognized `@sys-time` or `@sys-date` entity.
+        /// Constants for possible values can be found using RuntimeEntityInterpretation.GranularityValue
+        /// </summary>
+        [JsonProperty("granularity", NullValueHandling = NullValueHandling.Ignore)]
+        public string Granularity { get; set; }
+        /// <summary>
+        /// The calendar used to represent a recognized date (for example, `Gregorian`).
+        /// </summary>
+        [JsonProperty("calendar_type", NullValueHandling = NullValueHandling.Ignore)]
+        public string CalendarType { get; set; }
+        /// <summary>
+        /// A unique identifier used to associate a recognized time and date. If the user input contains a date and time
+        /// that are mentioned together (for example, `Today at 5`, the same **datetime_link** value is returned for
+        /// both the `@sys-date` and `@sys-time` entities).
+        /// </summary>
+        [JsonProperty("datetime_link", NullValueHandling = NullValueHandling.Ignore)]
+        public string DatetimeLink { get; set; }
+        /// <summary>
+        /// A locale-specific holiday name (such as `thanksgiving` or `christmas`). This property is included when a
+        /// `@sys-date` entity is recognized based on a holiday name in the user input.
+        /// </summary>
+        [JsonProperty("festival", NullValueHandling = NullValueHandling.Ignore)]
+        public string Festival { get; set; }
+        /// <summary>
+        /// A unique identifier used to associate multiple recognized `@sys-date`, `@sys-time`, or `@sys-number`
+        /// entities that are recognized as a range of values in the user's input (for example, `from July 4 until July
+        /// 14` or `from 20 to 25`).
+        /// </summary>
+        [JsonProperty("range_link", NullValueHandling = NullValueHandling.Ignore)]
+        public string RangeLink { get; set; }
+        /// <summary>
+        /// The word in the user input that indicates that a `sys-date` or `sys-time` entity is part of an implied range
+        /// where only one date or time is specified (for example, `since` or `until`).
+        /// </summary>
+        [JsonProperty("range_modifier", NullValueHandling = NullValueHandling.Ignore)]
+        public string RangeModifier { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative day, represented numerically as an offset from the current date (for
+        /// example, `-1` for `yesterday` or `10` for `in ten days`).
+        /// </summary>
+        [JsonProperty("relative_day", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeDay { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative month, represented numerically as an offset from the current month (for
+        /// example, `1` for `next month` or `-3` for `three months ago`).
+        /// </summary>
+        [JsonProperty("relative_month", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeMonth { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative week, represented numerically as an offset from the current week (for
+        /// example, `2` for `in two weeks` or `-1` for `last week).
+        /// </summary>
+        [JsonProperty("relative_week", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeWeek { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative date range for a weekend, represented numerically as an offset from the
+        /// current weekend (for example, `0` for `this weekend` or `-1` for `last weekend`).
+        /// </summary>
+        [JsonProperty("relative_weekend", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeWeekend { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative year, represented numerically as an offset from the current year (for
+        /// example, `1` for `next year` or `-5` for `five years ago`).
+        /// </summary>
+        [JsonProperty("relative_year", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeYear { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific date, represented numerically as the date within the month (for example,
+        /// `30` for `June 30`.).
+        /// </summary>
+        [JsonProperty("specific_day", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificDay { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific day of the week as a lowercase string (for example, `monday`).
+        /// </summary>
+        [JsonProperty("specific_day_of_week", NullValueHandling = NullValueHandling.Ignore)]
+        public string SpecificDayOfWeek { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific month, represented numerically (for example, `7` for `July`).
+        /// </summary>
+        [JsonProperty("specific_month", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificMonth { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific quarter, represented numerically (for example, `3` for `the third
+        /// quarter`).
+        /// </summary>
+        [JsonProperty("specific_quarter", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificQuarter { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific year (for example, `2016`).
+        /// </summary>
+        [JsonProperty("specific_year", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificYear { get; set; }
+        /// <summary>
+        /// A recognized numeric value, represented as an integer or double.
+        /// </summary>
+        [JsonProperty("numeric_value", NullValueHandling = NullValueHandling.Ignore)]
+        public float? NumericValue { get; set; }
+        /// <summary>
+        /// The type of numeric value recognized in the user input (`integer` or `rational`).
+        /// </summary>
+        [JsonProperty("subtype", NullValueHandling = NullValueHandling.Ignore)]
+        public string Subtype { get; set; }
+        /// <summary>
+        /// A recognized term for a time that was mentioned as a part of the day in the user's input (for example,
+        /// `morning` or `afternoon`). In addition, the returned entity value is set to a specific time:
+        ///
+        /// - `09:00:00` for `morning`
+        /// - `15:00:00` for `afternoon`
+        /// - `18:00:00` for `evening`
+        /// - `22:00:00` for `night`
+        /// - `00:00:00` for `midnight`.
+        /// </summary>
+        [JsonProperty("part_of_day", NullValueHandling = NullValueHandling.Ignore)]
+        public string PartOfDay { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative hour, represented numerically as an offset from the current hour (for
+        /// example, `3` for `in three hours` or `-1` for `an hour ago`).
+        /// </summary>
+        [JsonProperty("relative_hour", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeHour { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative time, represented numerically as an offset in minutes from the current
+        /// time (for example, `5` for `in five minutes` or `-15` for `fifteen minutes ago`).
+        /// </summary>
+        [JsonProperty("relative_minute", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeMinute { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative time, represented numerically as an offset in seconds from the current
+        /// time (for example, `10` for `in ten seconds` or `-30` for `thirty seconds ago`).
+        /// </summary>
+        [JsonProperty("relative_second", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeSecond { get; set; }
+        /// <summary>
+        /// A recognized specific hour mentioned as part of a time value (for example, `10` for `10:15 AM`.).
+        /// </summary>
+        [JsonProperty("specific_hour", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificHour { get; set; }
+        /// <summary>
+        /// A recognized specific minute mentioned as part of a time value (for example, `15` for `10:15 AM`.).
+        /// </summary>
+        [JsonProperty("specific_minute", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificMinute { get; set; }
+        /// <summary>
+        /// A recognized specific second mentioned as part of a time value (for example, `30` for `10:15:30 AM`.).
+        /// </summary>
+        [JsonProperty("specific_second", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificSecond { get; set; }
+        /// <summary>
+        /// A recognized time zone mentioned as part of a time value (for example, `EST`).
+        /// </summary>
+        [JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)]
+        public string Timezone { get; set; }
+    }
+}

--- a/Scripts/Services/Assistant/V2/Model/DialogRuntimeResponseGeneric.cs
+++ b/Scripts/Services/Assistant/V2/Model/DialogRuntimeResponseGeneric.cs
@@ -151,5 +151,16 @@ namespace IBM.Watson.Assistant.V2.Model
         /// </summary>
         [JsonProperty("suggestions", NullValueHandling = NullValueHandling.Ignore)]
         public List<DialogSuggestion> Suggestions { get; set; }
+        /// <summary>
+        /// The title or introductory text to show before the response. This text is defined in the search skill
+        /// configuration.
+        /// </summary>
+        [JsonProperty("header", NullValueHandling = NullValueHandling.Ignore)]
+        public string Header { get; set; }
+        /// <summary>
+        /// An array of objects containing search results.
+        /// </summary>
+        [JsonProperty("results", NullValueHandling = NullValueHandling.Ignore)]
+        public List<SearchResult> Results { get; set; }
     }
 }

--- a/Scripts/Services/Assistant/V2/Model/RuntimeEntity.cs
+++ b/Scripts/Services/Assistant/V2/Model/RuntimeEntity.cs
@@ -21,7 +21,7 @@ using Newtonsoft.Json;
 namespace IBM.Watson.Assistant.V2.Model
 {
     /// <summary>
-    /// A term from the request that was identified as an entity.
+    /// The entity value that was recognized in the user input.
     /// </summary>
     public class RuntimeEntity
     {
@@ -42,7 +42,7 @@ namespace IBM.Watson.Assistant.V2.Model
         [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
         public string Value { get; set; }
         /// <summary>
-        /// A decimal percentage that represents Watson's confidence in the entity.
+        /// A decimal percentage that represents Watson's confidence in the recognized entity.
         /// </summary>
         [JsonProperty("confidence", NullValueHandling = NullValueHandling.Ignore)]
         public float? Confidence { get; set; }
@@ -56,5 +56,12 @@ namespace IBM.Watson.Assistant.V2.Model
         /// </summary>
         [JsonProperty("groups", NullValueHandling = NullValueHandling.Ignore)]
         public List<CaptureGroup> Groups { get; set; }
+        /// <summary>
+        /// An object containing detailed information about the entity recognized in the user input.
+        ///
+        /// This property is a part of the new system entities, which are a beta feature.
+        /// </summary>
+        [JsonProperty("interpretation", NullValueHandling = NullValueHandling.Ignore)]
+        public RuntimeEntityInterpretation Interpretation { get; set; }
     }
 }

--- a/Scripts/Services/Assistant/V2/Model/RuntimeEntityInterpretation.cs
+++ b/Scripts/Services/Assistant/V2/Model/RuntimeEntityInterpretation.cs
@@ -1,0 +1,234 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Newtonsoft.Json;
+
+namespace IBM.Watson.Assistant.V2.Model
+{
+    /// <summary>
+    /// RuntimeEntityInterpretation.
+    /// </summary>
+    public class RuntimeEntityInterpretation
+    {
+        /// <summary>
+        /// The precision or duration of a time range specified by a recognized `@sys-time` or `@sys-date` entity.
+        /// </summary>
+        public class GranularityValue
+        {
+            /// <summary>
+            /// Constant DAY for day
+            /// </summary>
+            public const string DAY = "day";
+            /// <summary>
+            /// Constant FORTNIGHT for fortnight
+            /// </summary>
+            public const string FORTNIGHT = "fortnight";
+            /// <summary>
+            /// Constant HOUR for hour
+            /// </summary>
+            public const string HOUR = "hour";
+            /// <summary>
+            /// Constant INSTANT for instant
+            /// </summary>
+            public const string INSTANT = "instant";
+            /// <summary>
+            /// Constant MINUTE for minute
+            /// </summary>
+            public const string MINUTE = "minute";
+            /// <summary>
+            /// Constant MONTH for month
+            /// </summary>
+            public const string MONTH = "month";
+            /// <summary>
+            /// Constant QUARTER for quarter
+            /// </summary>
+            public const string QUARTER = "quarter";
+            /// <summary>
+            /// Constant SECOND for second
+            /// </summary>
+            public const string SECOND = "second";
+            /// <summary>
+            /// Constant WEEK for week
+            /// </summary>
+            public const string WEEK = "week";
+            /// <summary>
+            /// Constant WEEKEND for weekend
+            /// </summary>
+            public const string WEEKEND = "weekend";
+            /// <summary>
+            /// Constant YEAR for year
+            /// </summary>
+            public const string YEAR = "year";
+            
+        }
+
+        /// <summary>
+        /// The precision or duration of a time range specified by a recognized `@sys-time` or `@sys-date` entity.
+        /// Constants for possible values can be found using RuntimeEntityInterpretation.GranularityValue
+        /// </summary>
+        [JsonProperty("granularity", NullValueHandling = NullValueHandling.Ignore)]
+        public string Granularity { get; set; }
+        /// <summary>
+        /// The calendar used to represent a recognized date (for example, `Gregorian`).
+        /// </summary>
+        [JsonProperty("calendar_type", NullValueHandling = NullValueHandling.Ignore)]
+        public string CalendarType { get; set; }
+        /// <summary>
+        /// A unique identifier used to associate a recognized time and date. If the user input contains a date and time
+        /// that are mentioned together (for example, `Today at 5`, the same **datetime_link** value is returned for
+        /// both the `@sys-date` and `@sys-time` entities).
+        /// </summary>
+        [JsonProperty("datetime_link", NullValueHandling = NullValueHandling.Ignore)]
+        public string DatetimeLink { get; set; }
+        /// <summary>
+        /// A locale-specific holiday name (such as `thanksgiving` or `christmas`). This property is included when a
+        /// `@sys-date` entity is recognized based on a holiday name in the user input.
+        /// </summary>
+        [JsonProperty("festival", NullValueHandling = NullValueHandling.Ignore)]
+        public string Festival { get; set; }
+        /// <summary>
+        /// A unique identifier used to associate multiple recognized `@sys-date`, `@sys-time`, or `@sys-number`
+        /// entities that are recognized as a range of values in the user's input (for example, `from July 4 until July
+        /// 14` or `from 20 to 25`).
+        /// </summary>
+        [JsonProperty("range_link", NullValueHandling = NullValueHandling.Ignore)]
+        public string RangeLink { get; set; }
+        /// <summary>
+        /// The word in the user input that indicates that a `sys-date` or `sys-time` entity is part of an implied range
+        /// where only one date or time is specified (for example, `since` or `until`).
+        /// </summary>
+        [JsonProperty("range_modifier", NullValueHandling = NullValueHandling.Ignore)]
+        public string RangeModifier { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative day, represented numerically as an offset from the current date (for
+        /// example, `-1` for `yesterday` or `10` for `in ten days`).
+        /// </summary>
+        [JsonProperty("relative_day", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeDay { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative month, represented numerically as an offset from the current month (for
+        /// example, `1` for `next month` or `-3` for `three months ago`).
+        /// </summary>
+        [JsonProperty("relative_month", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeMonth { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative week, represented numerically as an offset from the current week (for
+        /// example, `2` for `in two weeks` or `-1` for `last week).
+        /// </summary>
+        [JsonProperty("relative_week", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeWeek { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative date range for a weekend, represented numerically as an offset from the
+        /// current weekend (for example, `0` for `this weekend` or `-1` for `last weekend`).
+        /// </summary>
+        [JsonProperty("relative_weekend", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeWeekend { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative year, represented numerically as an offset from the current year (for
+        /// example, `1` for `next year` or `-5` for `five years ago`).
+        /// </summary>
+        [JsonProperty("relative_year", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeYear { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific date, represented numerically as the date within the month (for example,
+        /// `30` for `June 30`.).
+        /// </summary>
+        [JsonProperty("specific_day", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificDay { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific day of the week as a lowercase string (for example, `monday`).
+        /// </summary>
+        [JsonProperty("specific_day_of_week", NullValueHandling = NullValueHandling.Ignore)]
+        public string SpecificDayOfWeek { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific month, represented numerically (for example, `7` for `July`).
+        /// </summary>
+        [JsonProperty("specific_month", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificMonth { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific quarter, represented numerically (for example, `3` for `the third
+        /// quarter`).
+        /// </summary>
+        [JsonProperty("specific_quarter", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificQuarter { get; set; }
+        /// <summary>
+        /// A recognized mention of a specific year (for example, `2016`).
+        /// </summary>
+        [JsonProperty("specific_year", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificYear { get; set; }
+        /// <summary>
+        /// A recognized numeric value, represented as an integer or double.
+        /// </summary>
+        [JsonProperty("numeric_value", NullValueHandling = NullValueHandling.Ignore)]
+        public float? NumericValue { get; set; }
+        /// <summary>
+        /// The type of numeric value recognized in the user input (`integer` or `rational`).
+        /// </summary>
+        [JsonProperty("subtype", NullValueHandling = NullValueHandling.Ignore)]
+        public string Subtype { get; set; }
+        /// <summary>
+        /// A recognized term for a time that was mentioned as a part of the day in the user's input (for example,
+        /// `morning` or `afternoon`). In addition, the returned entity value is set to a specific time:
+        ///
+        /// - `09:00:00` for `morning`
+        /// - `15:00:00` for `afternoon`
+        /// - `18:00:00` for `evening`
+        /// - `22:00:00` for `night`
+        /// - `00:00:00` for `midnight`.
+        /// </summary>
+        [JsonProperty("part_of_day", NullValueHandling = NullValueHandling.Ignore)]
+        public string PartOfDay { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative hour, represented numerically as an offset from the current hour (for
+        /// example, `3` for `in three hours` or `-1` for `an hour ago`).
+        /// </summary>
+        [JsonProperty("relative_hour", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeHour { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative time, represented numerically as an offset in minutes from the current
+        /// time (for example, `5` for `in five minutes` or `-15` for `fifteen minutes ago`).
+        /// </summary>
+        [JsonProperty("relative_minute", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeMinute { get; set; }
+        /// <summary>
+        /// A recognized mention of a relative time, represented numerically as an offset in seconds from the current
+        /// time (for example, `10` for `in ten seconds` or `-30` for `thirty seconds ago`).
+        /// </summary>
+        [JsonProperty("relative_second", NullValueHandling = NullValueHandling.Ignore)]
+        public float? RelativeSecond { get; set; }
+        /// <summary>
+        /// A recognized specific hour mentioned as part of a time value (for example, `10` for `10:15 AM`.).
+        /// </summary>
+        [JsonProperty("specific_hour", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificHour { get; set; }
+        /// <summary>
+        /// A recognized specific minute mentioned as part of a time value (for example, `15` for `10:15 AM`.).
+        /// </summary>
+        [JsonProperty("specific_minute", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificMinute { get; set; }
+        /// <summary>
+        /// A recognized specific second mentioned as part of a time value (for example, `30` for `10:15:30 AM`.).
+        /// </summary>
+        [JsonProperty("specific_second", NullValueHandling = NullValueHandling.Ignore)]
+        public float? SpecificSecond { get; set; }
+        /// <summary>
+        /// A recognized time zone mentioned as part of a time value (for example, `EST`).
+        /// </summary>
+        [JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)]
+        public string Timezone { get; set; }
+    }
+}

--- a/Scripts/Services/Assistant/V2/Model/SearchResult.cs
+++ b/Scripts/Services/Assistant/V2/Model/SearchResult.cs
@@ -1,0 +1,64 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Newtonsoft.Json;
+
+namespace IBM.Watson.Assistant.V2.Model
+{
+    /// <summary>
+    /// SearchResult.
+    /// </summary>
+    public class SearchResult
+    {
+        /// <summary>
+        /// The unique identifier of the document in the Discovery service collection.
+        ///
+        /// This property is included in responses from search skills, which are a beta feature available only to Plus
+        /// or Premium plan users.
+        /// </summary>
+        [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
+        public string Id { get; set; }
+        /// <summary>
+        /// An object containing search result metadata from the Discovery service.
+        /// </summary>
+        [JsonProperty("result_metadata", NullValueHandling = NullValueHandling.Ignore)]
+        public SearchResultMetadata ResultMetadata { get; set; }
+        /// <summary>
+        /// A description of the search result. This is taken from an abstract, summary, or highlight field in the
+        /// Discovery service response, as specified in the search skill configuration.
+        /// </summary>
+        [JsonProperty("body", NullValueHandling = NullValueHandling.Ignore)]
+        public string Body { get; set; }
+        /// <summary>
+        /// The title of the search result. This is taken from a title or name field in the Discovery service response,
+        /// as specified in the search skill configuration.
+        /// </summary>
+        [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
+        public string Title { get; set; }
+        /// <summary>
+        /// The URL of the original data object in its native data source.
+        /// </summary>
+        [JsonProperty("url", NullValueHandling = NullValueHandling.Ignore)]
+        public string Url { get; set; }
+        /// <summary>
+        /// An object containing segments of text from search results with query-matching text highlighted using HTML
+        /// <em> tags.
+        /// </summary>
+        [JsonProperty("highlight", NullValueHandling = NullValueHandling.Ignore)]
+        public SearchResultHighlight Highlight { get; set; }
+    }
+}

--- a/Scripts/Services/Assistant/V2/Model/SearchResultHighlight.cs
+++ b/Scripts/Services/Assistant/V2/Model/SearchResultHighlight.cs
@@ -1,0 +1,48 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace IBM.Watson.Assistant.V2.Model
+{
+    /// <summary>
+    /// An object containing segments of text from search results with query-matching text highlighted using HTML <em>
+    /// tags.
+    /// </summary>
+    public class SearchResultHighlight
+    {
+        /// <summary>
+        /// An array of strings containing segments taken from body text in the search results, with query-matching
+        /// substrings highlighted.
+        /// </summary>
+        [JsonProperty("body", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> Body { get; set; }
+        /// <summary>
+        /// An array of strings containing segments taken from title text in the search results, with query-matching
+        /// substrings highlighted.
+        /// </summary>
+        [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> Title { get; set; }
+        /// <summary>
+        /// An array of strings containing segments taken from URLs in the search results, with query-matching
+        /// substrings highlighted.
+        /// </summary>
+        [JsonProperty("url", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> Url { get; set; }
+    }
+}

--- a/Scripts/Services/Assistant/V2/Model/SearchResultMetadata.cs
+++ b/Scripts/Services/Assistant/V2/Model/SearchResultMetadata.cs
@@ -1,0 +1,40 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Newtonsoft.Json;
+
+namespace IBM.Watson.Assistant.V2.Model
+{
+    /// <summary>
+    /// An object containing search result metadata from the Discovery service.
+    /// </summary>
+    public class SearchResultMetadata
+    {
+        /// <summary>
+        /// The confidence score for the given result. For more information about how the confidence is calculated, see
+        /// the Discovery service [documentation](../discovery#query-your-collection).
+        /// </summary>
+        [JsonProperty("confidence", NullValueHandling = NullValueHandling.Ignore)]
+        public double? Confidence { get; set; }
+        /// <summary>
+        /// An unbounded measure of the relevance of a particular result, dependent on the query and matching document.
+        /// A higher score indicates a greater match to the query parameters.
+        /// </summary>
+        [JsonProperty("score", NullValueHandling = NullValueHandling.Ignore)]
+        public double? Score { get; set; }
+    }
+}

--- a/Scripts/Services/CompareComply/V1/Model/Attribute.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Attribute.cs
@@ -38,6 +38,10 @@ namespace IBM.Watson.CompareComply.V1.Model
             /// </summary>
             public const string DATETIME = "DateTime";
             /// <summary>
+            /// Constant DEFINEDTERM for DefinedTerm
+            /// </summary>
+            public const string DEFINEDTERM = "DefinedTerm";
+            /// <summary>
             /// Constant DURATION for Duration
             /// </summary>
             public const string DURATION = "Duration";
@@ -45,6 +49,10 @@ namespace IBM.Watson.CompareComply.V1.Model
             /// Constant LOCATION for Location
             /// </summary>
             public const string LOCATION = "Location";
+            /// <summary>
+            /// Constant NUMBER for Number
+            /// </summary>
+            public const string NUMBER = "Number";
             /// <summary>
             /// Constant ORGANIZATION for Organization
             /// </summary>

--- a/Scripts/Services/CompareComply/V1/Model/Category.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Category.cs
@@ -91,6 +91,10 @@ namespace IBM.Watson.CompareComply.V1.Model
             /// </summary>
             public const string LIABILITY = "Liability";
             /// <summary>
+            /// Constant ORDER_OF_PRECEDENCE for Order of Precedence
+            /// </summary>
+            public const string ORDER_OF_PRECEDENCE = "Order of Precedence";
+            /// <summary>
             /// Constant PAYMENT_TERMS_BILLING for Payment Terms & Billing
             /// </summary>
             public const string PAYMENT_TERMS_BILLING = "Payment Terms & Billing";

--- a/Scripts/Services/CompareComply/V1/Model/CategoryComparison.cs
+++ b/Scripts/Services/CompareComply/V1/Model/CategoryComparison.cs
@@ -90,6 +90,10 @@ namespace IBM.Watson.CompareComply.V1.Model
             /// </summary>
             public const string LIABILITY = "Liability";
             /// <summary>
+            /// Constant ORDER_OF_PRECEDENCE for Order of Precedence
+            /// </summary>
+            public const string ORDER_OF_PRECEDENCE = "Order of Precedence";
+            /// <summary>
             /// Constant PAYMENT_TERMS_BILLING for Payment Terms & Billing
             /// </summary>
             public const string PAYMENT_TERMS_BILLING = "Payment Terms & Billing";

--- a/Scripts/Services/CompareComply/V1/Model/ClassifyReturn.cs
+++ b/Scripts/Services/CompareComply/V1/Model/ClassifyReturn.cs
@@ -47,21 +47,6 @@ namespace IBM.Watson.CompareComply.V1.Model
         [JsonProperty("elements", NullValueHandling = NullValueHandling.Ignore)]
         public List<Element> Elements { get; set; }
         /// <summary>
-        /// Definition of tables identified in the input document.
-        /// </summary>
-        [JsonProperty("tables", NullValueHandling = NullValueHandling.Ignore)]
-        public List<Tables> Tables { get; set; }
-        /// <summary>
-        /// The structure of the input document.
-        /// </summary>
-        [JsonProperty("document_structure", NullValueHandling = NullValueHandling.Ignore)]
-        public DocStructure DocumentStructure { get; set; }
-        /// <summary>
-        /// Definitions of the parties identified in the input document.
-        /// </summary>
-        [JsonProperty("parties", NullValueHandling = NullValueHandling.Ignore)]
-        public List<Parties> Parties { get; set; }
-        /// <summary>
         /// The date or dates on which the document becomes effective.
         /// </summary>
         [JsonProperty("effective_dates", NullValueHandling = NullValueHandling.Ignore)]
@@ -80,7 +65,32 @@ namespace IBM.Watson.CompareComply.V1.Model
         /// <summary>
         /// The document's contract type or types as declared in the document.
         /// </summary>
-        [JsonProperty("contract_type", NullValueHandling = NullValueHandling.Ignore)]
-        public List<ContractType> ContractType { get; set; }
+        [JsonProperty("contract_types", NullValueHandling = NullValueHandling.Ignore)]
+        public List<ContractTypes> ContractTypes { get; set; }
+        /// <summary>
+        /// The duration or durations of the contract.
+        /// </summary>
+        [JsonProperty("contract_terms", NullValueHandling = NullValueHandling.Ignore)]
+        public List<ContractTerms> ContractTerms { get; set; }
+        /// <summary>
+        /// The document's payment duration or durations.
+        /// </summary>
+        [JsonProperty("payment_terms", NullValueHandling = NullValueHandling.Ignore)]
+        public List<PaymentTerms> PaymentTerms { get; set; }
+        /// <summary>
+        /// Definition of tables identified in the input document.
+        /// </summary>
+        [JsonProperty("tables", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Tables> Tables { get; set; }
+        /// <summary>
+        /// The structure of the input document.
+        /// </summary>
+        [JsonProperty("document_structure", NullValueHandling = NullValueHandling.Ignore)]
+        public DocStructure DocumentStructure { get; set; }
+        /// <summary>
+        /// Definitions of the parties identified in the input document.
+        /// </summary>
+        [JsonProperty("parties", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Parties> Parties { get; set; }
     }
 }

--- a/Scripts/Services/CompareComply/V1/Model/Contexts.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Contexts.cs
@@ -15,32 +15,25 @@
 *
 */
 
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
+namespace IBM.Watson.CompareComply.V1.Model
 {
     /// <summary>
-    /// EntityMention.
+    /// Text that is related to the contents of the table and that precedes or follows the current table.
     /// </summary>
-    public class EntityMention
+    public class Contexts
     {
         /// <summary>
-        /// Entity mention text.
+        /// The related text.
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
         /// <summary>
-        /// Character offsets indicating the beginning and end of the mention in the analyzed text.
+        /// The numeric location of the identified element in the document, represented with two integers labeled
+        /// `begin` and `end`.
         /// </summary>
         [JsonProperty("location", NullValueHandling = NullValueHandling.Ignore)]
-        public List<long?> Location { get; set; }
-        /// <summary>
-        /// Confidence in the entity identification from 0 to 1. Higher values indicate higher confidence. In standard
-        /// entities requests, confidence is returned only for English text. All entities requests that use custom
-        /// models return the confidence score.
-        /// </summary>
-        [JsonProperty("confidence", NullValueHandling = NullValueHandling.Ignore)]
-        public double? Confidence { get; set; }
+        public Location Location { get; set; }
     }
 }

--- a/Scripts/Services/CompareComply/V1/Model/ContractAmts.cs
+++ b/Scripts/Services/CompareComply/V1/Model/ContractAmts.cs
@@ -15,6 +15,7 @@
 *
 */
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace IBM.Watson.CompareComply.V1.Model
@@ -55,6 +56,23 @@ namespace IBM.Watson.CompareComply.V1.Model
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
+        /// <summary>
+        /// The normalized form of the amount, which is listed as a string. This element is optional; that is, the
+        /// service output lists it only if normalized text exists.
+        /// </summary>
+        [JsonProperty("text_normalized", NullValueHandling = NullValueHandling.Ignore)]
+        public string TextNormalized { get; set; }
+        /// <summary>
+        /// The details of the normalized text, if applicable. This element is optional; that is, the service output
+        /// lists it only if normalized text exists.
+        /// </summary>
+        [JsonProperty("interpretation", NullValueHandling = NullValueHandling.Ignore)]
+        public Interpretation Interpretation { get; set; }
+        /// <summary>
+        /// One or more hash values that you can send to IBM to provide feedback or receive support.
+        /// </summary>
+        [JsonProperty("provenance_ids", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> ProvenanceIds { get; set; }
         /// <summary>
         /// The numeric location of the identified element in the document, represented with two integers labeled
         /// `begin` and `end`.

--- a/Scripts/Services/CompareComply/V1/Model/ContractTerms.cs
+++ b/Scripts/Services/CompareComply/V1/Model/ContractTerms.cs
@@ -21,12 +21,12 @@ using Newtonsoft.Json;
 namespace IBM.Watson.CompareComply.V1.Model
 {
     /// <summary>
-    /// Termination dates identified in the input document.
+    /// The duration or durations of the contract.
     /// </summary>
-    public class TerminationDates
+    public class ContractTerms
     {
         /// <summary>
-        /// The confidence level in the identification of the termination date.
+        /// The confidence level in the identification of the contract term.
         /// </summary>
         public class ConfidenceLevelValue
         {
@@ -46,22 +46,28 @@ namespace IBM.Watson.CompareComply.V1.Model
         }
 
         /// <summary>
-        /// The confidence level in the identification of the termination date.
-        /// Constants for possible values can be found using TerminationDates.ConfidenceLevelValue
+        /// The confidence level in the identification of the contract term.
+        /// Constants for possible values can be found using ContractTerms.ConfidenceLevelValue
         /// </summary>
         [JsonProperty("confidence_level", NullValueHandling = NullValueHandling.Ignore)]
         public string ConfidenceLevel { get; set; }
         /// <summary>
-        /// The termination date.
+        /// The contract term (duration).
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
         /// <summary>
-        /// The normalized form of the termination date, which is listed as a string. This element is optional; that is,
+        /// The normalized form of the contract term, which is listed as a string. This element is optional; that is,
         /// the service output lists it only if normalized text exists.
         /// </summary>
         [JsonProperty("text_normalized", NullValueHandling = NullValueHandling.Ignore)]
         public string TextNormalized { get; set; }
+        /// <summary>
+        /// The details of the normalized text, if applicable. This element is optional; that is, the service output
+        /// lists it only if normalized text exists.
+        /// </summary>
+        [JsonProperty("interpretation", NullValueHandling = NullValueHandling.Ignore)]
+        public Interpretation Interpretation { get; set; }
         /// <summary>
         /// One or more hash values that you can send to IBM to provide feedback or receive support.
         /// </summary>

--- a/Scripts/Services/CompareComply/V1/Model/ContractTypes.cs
+++ b/Scripts/Services/CompareComply/V1/Model/ContractTypes.cs
@@ -21,12 +21,12 @@ using Newtonsoft.Json;
 namespace IBM.Watson.CompareComply.V1.Model
 {
     /// <summary>
-    /// Termination dates identified in the input document.
+    /// The contract type identified in the input document.
     /// </summary>
-    public class TerminationDates
+    public class ContractTypes
     {
         /// <summary>
-        /// The confidence level in the identification of the termination date.
+        /// The confidence level in the identification of the contract type.
         /// </summary>
         public class ConfidenceLevelValue
         {
@@ -46,22 +46,16 @@ namespace IBM.Watson.CompareComply.V1.Model
         }
 
         /// <summary>
-        /// The confidence level in the identification of the termination date.
-        /// Constants for possible values can be found using TerminationDates.ConfidenceLevelValue
+        /// The confidence level in the identification of the contract type.
+        /// Constants for possible values can be found using ContractTypes.ConfidenceLevelValue
         /// </summary>
         [JsonProperty("confidence_level", NullValueHandling = NullValueHandling.Ignore)]
         public string ConfidenceLevel { get; set; }
         /// <summary>
-        /// The termination date.
+        /// The contract type.
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
-        /// <summary>
-        /// The normalized form of the termination date, which is listed as a string. This element is optional; that is,
-        /// the service output lists it only if normalized text exists.
-        /// </summary>
-        [JsonProperty("text_normalized", NullValueHandling = NullValueHandling.Ignore)]
-        public string TextNormalized { get; set; }
         /// <summary>
         /// One or more hash values that you can send to IBM to provide feedback or receive support.
         /// </summary>

--- a/Scripts/Services/CompareComply/V1/Model/DocStructure.cs
+++ b/Scripts/Services/CompareComply/V1/Model/DocStructure.cs
@@ -36,5 +36,11 @@ namespace IBM.Watson.CompareComply.V1.Model
         /// </summary>
         [JsonProperty("leading_sentences", NullValueHandling = NullValueHandling.Ignore)]
         public List<LeadingSentence> LeadingSentences { get; set; }
+        /// <summary>
+        /// An array containing one object per paragraph, in parallel with the `section_titles` and `leading_sentences`
+        /// arrays.
+        /// </summary>
+        [JsonProperty("paragraphs", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Paragraphs> Paragraphs { get; set; }
     }
 }

--- a/Scripts/Services/CompareComply/V1/Model/EffectiveDates.cs
+++ b/Scripts/Services/CompareComply/V1/Model/EffectiveDates.cs
@@ -15,6 +15,7 @@
 *
 */
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace IBM.Watson.CompareComply.V1.Model
@@ -55,6 +56,17 @@ namespace IBM.Watson.CompareComply.V1.Model
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
+        /// <summary>
+        /// The normalized form of the effective date, which is listed as a string. This element is optional; that is,
+        /// the service output lists it only if normalized text exists.
+        /// </summary>
+        [JsonProperty("text_normalized", NullValueHandling = NullValueHandling.Ignore)]
+        public string TextNormalized { get; set; }
+        /// <summary>
+        /// One or more hash values that you can send to IBM to provide feedback or receive support.
+        /// </summary>
+        [JsonProperty("provenance_ids", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> ProvenanceIds { get; set; }
         /// <summary>
         /// The numeric location of the identified element in the document, represented with two integers labeled
         /// `begin` and `end`.

--- a/Scripts/Services/CompareComply/V1/Model/Interpretation.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Interpretation.cs
@@ -1,0 +1,49 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Newtonsoft.Json;
+
+namespace IBM.Watson.CompareComply.V1.Model
+{
+    /// <summary>
+    /// The details of the normalized text, if applicable. This element is optional; that is, the service output lists
+    /// it only if normalized text exists.
+    /// </summary>
+    public class Interpretation
+    {
+        /// <summary>
+        /// The value that was located in the normalized text.
+        /// </summary>
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
+        public string Value { get; set; }
+        /// <summary>
+        /// An integer or float expressing the numeric value of the `value` key.
+        /// </summary>
+        [JsonProperty("numeric_value", NullValueHandling = NullValueHandling.Ignore)]
+        public float? NumericValue { get; set; }
+        /// <summary>
+        /// A string listing the unit of the value that was found in the normalized text.
+        ///
+        /// **Note:** The value of `unit` is the [ISO-4217 currency
+        /// code](https://www.iso.org/iso-4217-currency-codes.html) identified for the currency amount (for example,
+        /// `USD` or `EUR`). If the service cannot disambiguate a currency symbol (for example, `$` or `£`), the value
+        /// of `unit` contains the ambiguous symbol as-is.
+        /// </summary>
+        [JsonProperty("unit", NullValueHandling = NullValueHandling.Ignore)]
+        public string Unit { get; set; }
+    }
+}

--- a/Scripts/Services/CompareComply/V1/Model/Mention.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Mention.cs
@@ -15,32 +15,25 @@
 *
 */
 
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
+namespace IBM.Watson.CompareComply.V1.Model
 {
     /// <summary>
-    /// EntityMention.
+    /// A mention of a party.
     /// </summary>
-    public class EntityMention
+    public class Mention
     {
         /// <summary>
-        /// Entity mention text.
+        /// The name of the party.
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
         /// <summary>
-        /// Character offsets indicating the beginning and end of the mention in the analyzed text.
+        /// The numeric location of the identified element in the document, represented with two integers labeled
+        /// `begin` and `end`.
         /// </summary>
         [JsonProperty("location", NullValueHandling = NullValueHandling.Ignore)]
-        public List<long?> Location { get; set; }
-        /// <summary>
-        /// Confidence in the entity identification from 0 to 1. Higher values indicate higher confidence. In standard
-        /// entities requests, confidence is returned only for English text. All entities requests that use custom
-        /// models return the confidence score.
-        /// </summary>
-        [JsonProperty("confidence", NullValueHandling = NullValueHandling.Ignore)]
-        public double? Confidence { get; set; }
+        public Location Location { get; set; }
     }
 }

--- a/Scripts/Services/CompareComply/V1/Model/Paragraphs.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Paragraphs.cs
@@ -15,22 +15,20 @@
 *
 */
 
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace IBM.Watson.TextToSpeech.V1.Model
+namespace IBM.Watson.CompareComply.V1.Model
 {
     /// <summary>
-    /// Information about existing custom voice models.
+    /// The locations of each paragraph in the input document.
     /// </summary>
-    public class VoiceModels
+    public class Paragraphs
     {
         /// <summary>
-        /// An array of `VoiceModel` objects that provides information about each available custom voice model. The
-        /// array is empty if the requesting credentials own no custom voice models (if no language is specified) or own
-        /// no custom voice models for the specified language.
+        /// The numeric location of the identified element in the document, represented with two integers labeled
+        /// `begin` and `end`.
         /// </summary>
-        [JsonProperty("customizations", NullValueHandling = NullValueHandling.Ignore)]
-        public List<VoiceModel> Customizations { get; set; }
+        [JsonProperty("location", NullValueHandling = NullValueHandling.Ignore)]
+        public Location Location { get; set; }
     }
 }

--- a/Scripts/Services/CompareComply/V1/Model/Parties.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Parties.cs
@@ -48,7 +48,7 @@ namespace IBM.Watson.CompareComply.V1.Model
         [JsonProperty("importance", NullValueHandling = NullValueHandling.Ignore)]
         public string Importance { get; set; }
         /// <summary>
-        /// A string identifying the party.
+        /// The normalized form of the party's name.
         /// </summary>
         [JsonProperty("party", NullValueHandling = NullValueHandling.Ignore)]
         public string Party { get; set; }
@@ -58,14 +58,19 @@ namespace IBM.Watson.CompareComply.V1.Model
         [JsonProperty("role", NullValueHandling = NullValueHandling.Ignore)]
         public string Role { get; set; }
         /// <summary>
-        /// List of the party's address or addresses.
+        /// A list of the party's address or addresses.
         /// </summary>
         [JsonProperty("addresses", NullValueHandling = NullValueHandling.Ignore)]
         public List<Address> Addresses { get; set; }
         /// <summary>
-        /// List of the names and roles of contacts identified in the input document.
+        /// A list of the names and roles of contacts identified in the input document.
         /// </summary>
         [JsonProperty("contacts", NullValueHandling = NullValueHandling.Ignore)]
         public List<Contact> Contacts { get; set; }
+        /// <summary>
+        /// A list of the party's mentions in the input document.
+        /// </summary>
+        [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Mention> Mentions { get; set; }
     }
 }

--- a/Scripts/Services/CompareComply/V1/Model/PaymentTerms.cs
+++ b/Scripts/Services/CompareComply/V1/Model/PaymentTerms.cs
@@ -21,12 +21,12 @@ using Newtonsoft.Json;
 namespace IBM.Watson.CompareComply.V1.Model
 {
     /// <summary>
-    /// Termination dates identified in the input document.
+    /// The document's payment duration or durations.
     /// </summary>
-    public class TerminationDates
+    public class PaymentTerms
     {
         /// <summary>
-        /// The confidence level in the identification of the termination date.
+        /// The confidence level in the identification of the payment term.
         /// </summary>
         public class ConfidenceLevelValue
         {
@@ -46,22 +46,28 @@ namespace IBM.Watson.CompareComply.V1.Model
         }
 
         /// <summary>
-        /// The confidence level in the identification of the termination date.
-        /// Constants for possible values can be found using TerminationDates.ConfidenceLevelValue
+        /// The confidence level in the identification of the payment term.
+        /// Constants for possible values can be found using PaymentTerms.ConfidenceLevelValue
         /// </summary>
         [JsonProperty("confidence_level", NullValueHandling = NullValueHandling.Ignore)]
         public string ConfidenceLevel { get; set; }
         /// <summary>
-        /// The termination date.
+        /// The payment term (duration).
         /// </summary>
         [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
         /// <summary>
-        /// The normalized form of the termination date, which is listed as a string. This element is optional; that is,
-        /// the service output lists it only if normalized text exists.
+        /// The normalized form of the payment term, which is listed as a string. This element is optional; that is, the
+        /// service output lists it only if normalized text exists.
         /// </summary>
         [JsonProperty("text_normalized", NullValueHandling = NullValueHandling.Ignore)]
         public string TextNormalized { get; set; }
+        /// <summary>
+        /// The details of the normalized text, if applicable. This element is optional; that is, the service output
+        /// lists it only if normalized text exists.
+        /// </summary>
+        [JsonProperty("interpretation", NullValueHandling = NullValueHandling.Ignore)]
+        public Interpretation Interpretation { get; set; }
         /// <summary>
         /// One or more hash values that you can send to IBM to provide feedback or receive support.
         /// </summary>

--- a/Scripts/Services/CompareComply/V1/Model/TableTitle.cs
+++ b/Scripts/Services/CompareComply/V1/Model/TableTitle.cs
@@ -1,0 +1,40 @@
+/**
+* Copyright 2018, 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using Newtonsoft.Json;
+
+namespace IBM.Watson.CompareComply.V1.Model
+{
+    /// <summary>
+    /// If identified, the title or caption of the current table of the form `Table x.: ...`. Empty when no title is
+    /// identified. When exposed, the `title` is also excluded from the `contexts` array of the same table.
+    /// </summary>
+    public class TableTitle
+    {
+        /// <summary>
+        /// The numeric location of the identified element in the document, represented with two integers labeled
+        /// `begin` and `end`.
+        /// </summary>
+        [JsonProperty("location", NullValueHandling = NullValueHandling.Ignore)]
+        public Location Location { get; set; }
+        /// <summary>
+        /// The text of the identified table title or caption.
+        /// </summary>
+        [JsonProperty("text", NullValueHandling = NullValueHandling.Ignore)]
+        public string Text { get; set; }
+    }
+}

--- a/Scripts/Services/CompareComply/V1/Model/Tables.cs
+++ b/Scripts/Services/CompareComply/V1/Model/Tables.cs
@@ -42,6 +42,12 @@ namespace IBM.Watson.CompareComply.V1.Model
         [JsonProperty("section_title", NullValueHandling = NullValueHandling.Ignore)]
         public SectionTitle SectionTitle { get; set; }
         /// <summary>
+        /// If identified, the title or caption of the current table of the form `Table x.: ...`. Empty when no title is
+        /// identified. When exposed, the `title` is also excluded from the `contexts` array of the same table.
+        /// </summary>
+        [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
+        public TableTitle Title { get; set; }
+        /// <summary>
         /// An array of table-level cells that apply as headers to all the other cells in the current table.
         /// </summary>
         [JsonProperty("table_headers", NullValueHandling = NullValueHandling.Ignore)]
@@ -59,15 +65,21 @@ namespace IBM.Watson.CompareComply.V1.Model
         [JsonProperty("column_headers", NullValueHandling = NullValueHandling.Ignore)]
         public List<ColumnHeaders> ColumnHeaders { get; set; }
         /// <summary>
-        /// An array of key-value pairs identified in the current table.
-        /// </summary>
-        [JsonProperty("key_value_pairs", NullValueHandling = NullValueHandling.Ignore)]
-        public List<KeyValuePair> KeyValuePairs { get; set; }
-        /// <summary>
         /// An array of cells that are neither table header nor column header nor row header cells, of the current table
         /// with corresponding row and column header associations.
         /// </summary>
         [JsonProperty("body_cells", NullValueHandling = NullValueHandling.Ignore)]
         public List<BodyCells> BodyCells { get; set; }
+        /// <summary>
+        /// An array of objects that list text that is related to the table contents and that precedes or follows the
+        /// current table.
+        /// </summary>
+        [JsonProperty("contexts", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Contexts> Contexts { get; set; }
+        /// <summary>
+        /// An array of key-value pairs identified in the current table.
+        /// </summary>
+        [JsonProperty("key_value_pairs", NullValueHandling = NullValueHandling.Ignore)]
+        public List<KeyValuePair> KeyValuePairs { get; set; }
     }
 }

--- a/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
+++ b/Scripts/Services/LanguageTranslator/V3/LanguageTranslatorService.cs
@@ -458,7 +458,7 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// cumulative file size of all uploaded files is limited to <b>250 MB</b>. To successfully train with a
         /// parallel corpus you must have at least <b>5,000 parallel sentences</b> in your corpus.
         ///
-        /// You can have a <b>maxium of 10 custom models per language pair</b>.
+        /// You can have a <b>maximum of 10 custom models per language pair</b>.
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="baseModelId">The model ID of the model to use as the base for customization. To see available
@@ -781,6 +781,7 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// types](https://cloud.ibm.com/docs/services/language-translator?topic=language-translator-document-translator-tutorial#supported-file-formats)
         ///
         /// Maximum file size: **20 MB**.</param>
+        /// <param name="filename">The filename for file.</param>
         /// <param name="fileContentType">The content type of file. (optional)</param>
         /// <param name="modelId">The model to use for translation. `model_id` or both `source` and `target` are
         /// required. (optional)</param>
@@ -789,13 +790,13 @@ namespace IBM.Watson.LanguageTranslator.V3
         /// <param name="documentId">To use a previously submitted document as the source for a new translation, enter
         /// the `document_id` of the document. (optional)</param>
         /// <returns><see cref="DocumentStatus" />DocumentStatus</returns>
-        public bool TranslateDocument(Callback<DocumentStatus> callback, System.IO.MemoryStream file, string filename,  string fileContentType = null, string modelId = null, string source = null, string target = null, string documentId = null)
+        public bool TranslateDocument(Callback<DocumentStatus> callback, System.IO.MemoryStream file, string filename, string fileContentType = null, string modelId = null, string source = null, string target = null, string documentId = null)
         {
             if (callback == null)
                 throw new ArgumentNullException("`callback` is required for `TranslateDocument`");
             if (file == null)
                 throw new ArgumentNullException("`file` is required for `TranslateDocument`");
-            if (filename == null)
+            if (string.IsNullOrEmpty(filename))
                 throw new ArgumentNullException("`filename` is required for `TranslateDocument`");
 
             RequestObject<DocumentStatus> req = new RequestObject<DocumentStatus>

--- a/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/EntitiesResult.cs
+++ b/Scripts/Services/NaturalLanguageUnderstanding/V1/Model/EntitiesResult.cs
@@ -41,6 +41,13 @@ namespace IBM.Watson.NaturalLanguageUnderstanding.V1.Model
         [JsonProperty("relevance", NullValueHandling = NullValueHandling.Ignore)]
         public double? Relevance { get; set; }
         /// <summary>
+        /// Confidence in the entity identification from 0 to 1. Higher values indicate higher confidence. In standard
+        /// entities requests, confidence is returned only for English text. All entities requests that use custom
+        /// models return the confidence score.
+        /// </summary>
+        [JsonProperty("confidence", NullValueHandling = NullValueHandling.Ignore)]
+        public double? Confidence { get; set; }
+        /// <summary>
         /// Entity mentions and locations.
         /// </summary>
         [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]

--- a/Scripts/Services/PersonalityInsights/V3/PersonalityInsightsService.cs
+++ b/Scripts/Services/PersonalityInsights/V3/PersonalityInsightsService.cs
@@ -194,9 +194,7 @@ namespace IBM.Watson.PersonalityInsights.V3
         /// <param name="consumptionPreferences">Indicates whether consumption preferences are returned with the
         /// results. By default, no consumption preferences are returned. (optional, default to false)</param>
         /// <param name="contentType">The type of the input. For more information, see **Content types** in the method
-        /// description.
-        ///
-        /// Default: `text/plain`. (optional)</param>
+        /// description. (optional, default to text/plain)</param>
         /// <returns><see cref="Profile" />Profile</returns>
         public bool Profile(Callback<Profile> callback, Content content, string contentLanguage = null, string acceptLanguage = null, bool? rawScores = null, bool? csvHeaders = null, bool? consumptionPreferences = null, string contentType = null)
         {
@@ -358,9 +356,7 @@ namespace IBM.Watson.PersonalityInsights.V3
         /// <param name="consumptionPreferences">Indicates whether consumption preferences are returned with the
         /// results. By default, no consumption preferences are returned. (optional, default to false)</param>
         /// <param name="contentType">The type of the input. For more information, see **Content types** in the method
-        /// description.
-        ///
-        /// Default: `text/plain`. (optional)</param>
+        /// description. (optional, default to text/plain)</param>
         /// <returns><see cref="System.IO.MemoryStream" />System.IO.MemoryStream</returns>
         public bool ProfileAsCsv(Callback<System.IO.MemoryStream> callback, Content content, string contentLanguage = null, string acceptLanguage = null, bool? rawScores = null, bool? csvHeaders = null, bool? consumptionPreferences = null, string contentType = null)
         {

--- a/Scripts/Services/SpeechToText/V1/Model/AcousticModel.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/AcousticModel.cs
@@ -92,6 +92,13 @@ namespace IBM.Watson.SpeechToText.V1.Model
         [JsonProperty("created", NullValueHandling = NullValueHandling.Ignore)]
         public string Created { get; set; }
         /// <summary>
+        /// The date and time in Coordinated Universal Time (UTC) at which the custom acoustic model was last modified.
+        /// The `created` and `updated` fields are equal when an acoustic model is first added but has yet to be
+        /// updated. The value is provided in full ISO 8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+        /// </summary>
+        [JsonProperty("updated", NullValueHandling = NullValueHandling.Ignore)]
+        public string Updated { get; set; }
+        /// <summary>
         /// The language identifier of the custom acoustic model (for example, `en-US`).
         /// </summary>
         [JsonProperty("language", NullValueHandling = NullValueHandling.Ignore)]

--- a/Scripts/Services/SpeechToText/V1/Model/LanguageModel.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/LanguageModel.cs
@@ -92,6 +92,13 @@ namespace IBM.Watson.SpeechToText.V1.Model
         [JsonProperty("created", NullValueHandling = NullValueHandling.Ignore)]
         public string Created { get; set; }
         /// <summary>
+        /// The date and time in Coordinated Universal Time (UTC) at which the custom language model was last modified.
+        /// The `created` and `updated` fields are equal when a language model is first added but has yet to be updated.
+        /// The value is provided in full ISO 8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+        /// </summary>
+        [JsonProperty("updated", NullValueHandling = NullValueHandling.Ignore)]
+        public string Updated { get; set; }
+        /// <summary>
         /// The language identifier of the custom language model (for example, `en-US`).
         /// </summary>
         [JsonProperty("language", NullValueHandling = NullValueHandling.Ignore)]

--- a/Scripts/Services/SpeechToText/V1/Model/ProcessingMetrics.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/ProcessingMetrics.cs
@@ -20,7 +20,8 @@ using Newtonsoft.Json;
 namespace IBM.Watson.SpeechToText.V1.Model
 {
     /// <summary>
-    /// If processing metrics are requested, information about the service's processing of the input audio.
+    /// If processing metrics are requested, information about the service's processing of the input audio. Processing
+    /// metrics are not available with the synchronous **Recognize audio** method.
     /// </summary>
     public class ProcessingMetrics
     {

--- a/Scripts/Services/SpeechToText/V1/Model/SpeechRecognitionResults.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/SpeechRecognitionResults.cs
@@ -50,6 +50,7 @@ namespace IBM.Watson.SpeechToText.V1.Model
         public List<SpeakerLabelsResult> SpeakerLabels { get; set; }
         /// <summary>
         /// If processing metrics are requested, information about the service's processing of the input audio.
+        /// Processing metrics are not available with the synchronous **Recognize audio** method.
         /// </summary>
         [JsonProperty("processing_metrics", NullValueHandling = NullValueHandling.Ignore)]
         public ProcessingMetrics ProcessingMetrics { get; set; }

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextService.cs
@@ -93,7 +93,7 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="credentials">The service credentials.</param>
         public SpeechToTextService(Credentials credentials) : base(credentials, serviceId)
         {
-            if (credentials.HasCredentials() || credentials.HasIamTokenData())
+            if (credentials.HasCredentials() || credentials.HasTokenData())
             {
                 Credentials = credentials;
 
@@ -462,22 +462,6 @@ namespace IBM.Watson.SpeechToText.V1
         /// See [Numeric
         /// redaction](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-output#redaction).
         /// (optional, default to false)</param>
-        /// <param name="processingMetrics">If `true`, requests processing metrics about the service's transcription of
-        /// the input audio. The service returns processing metrics at the interval specified by the
-        /// `processing_metrics_interval` parameter. It also returns processing metrics for transcription events, for
-        /// example, for final and interim results. By default, the service returns no processing metrics. (optional,
-        /// default to false)</param>
-        /// <param name="processingMetricsInterval">Specifies the interval in real wall-clock seconds at which the
-        /// service is to return processing metrics. The parameter is ignored unless the `processing_metrics` parameter
-        /// is set to `true`.
-        ///
-        /// The parameter accepts a minimum value of 0.1 seconds. The level of precision is not restricted, so you can
-        /// specify values such as 0.25 and 0.125.
-        ///
-        /// The service does not impose a maximum value. If you want to receive processing metrics only for
-        /// transcription events instead of at periodic intervals, set the value to a large number. If the value is
-        /// larger than the duration of the audio, the service returns processing metrics only for transcription events.
-        /// (optional)</param>
         /// <param name="audioMetrics">If `true`, requests detailed information about the signal characteristics of the
         /// input audio. The service returns audio metrics with the final transcription results. By default, the service
         /// returns no audio metrics. (optional, default to false)</param>
@@ -2252,10 +2236,15 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="corpusName">The name of the new corpus for the custom language model. Use a localized name that
         /// matches the language of the custom model and reflects the contents of the corpus.
         /// * Include a maximum of 128 characters in the name.
-        /// * Do not include spaces, slashes, or backslashes in the name.
+        /// * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes,
+        /// colons, ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The
+        /// service does not prevent the use of these characters. But because they must be URL-encoded wherever used,
+        /// their use is strongly discouraged.)
         /// * Do not use the name of an existing corpus or grammar that is already defined for the custom model.
         /// * Do not use the name `user`, which is reserved by the service to denote custom words that are added or
-        /// modified by the user.</param>
+        /// modified by the user.
+        /// * Do not use the name `base_lm` or `default_lm`. Both names are reserved for future use by the
+        /// service.</param>
         /// <param name="corpusFile">A plain text file that contains the training data for the corpus. Encode the file
         /// in UTF-8 if it contains non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII
         /// characters.
@@ -2535,7 +2524,7 @@ namespace IBM.Watson.SpeechToText.V1
         /// ascending or descending order. By default, words are sorted in ascending alphabetical order. For
         /// alphabetical ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase
         /// letters. For count ordering, values with the same count are ordered alphabetically. With the `curl` command,
-        /// URL encode the `+` symbol as `%2B`. (optional, default to alphabetical)</param>
+        /// URL-encode the `+` symbol as `%2B`. (optional, default to alphabetical)</param>
         /// <returns><see cref="Words" />Words</returns>
         public bool ListWords(Callback<Words> callback, string customizationId, string wordType = null, string sort = null)
         {
@@ -3157,10 +3146,15 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="grammarName">The name of the new grammar for the custom language model. Use a localized name
         /// that matches the language of the custom model and reflects the contents of the grammar.
         /// * Include a maximum of 128 characters in the name.
-        /// * Do not include spaces, slashes, or backslashes in the name.
+        /// * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes,
+        /// colons, ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The
+        /// service does not prevent the use of these characters. But because they must be URL-encoded wherever used,
+        /// their use is strongly discouraged.)
         /// * Do not use the name of an existing grammar or corpus that is already defined for the custom model.
         /// * Do not use the name `user`, which is reserved by the service to denote custom words that are added or
-        /// modified by the user.</param>
+        /// modified by the user.
+        /// * Do not use the name `base_lm` or `default_lm`. Both names are reserved for future use by the
+        /// service.</param>
         /// <param name="grammarFile">A plain text file that contains the grammar in the format specified by the
         /// `Content-Type` header. Encode the file in UTF-8 (ASCII is a subset of UTF-8). Using any other encoding can
         /// lead to issues when compiling the grammar or to unexpected results in decoding. The service ignores an
@@ -3766,8 +3760,9 @@ namespace IBM.Watson.SpeechToText.V1
         /// You can monitor the status of the training by using the **Get a custom acoustic model** method to poll the
         /// model's status. Use a loop to check the status once a minute. The method returns an `AcousticModel` object
         /// that includes `status` and `progress` fields. A status of `available` indicates that the custom model is
-        /// trained and ready to use. The service cannot accept subsequent training requests, or requests to add new
-        /// audio resources, until the existing request completes.
+        /// trained and ready to use. The service cannot train a model while it is handling another request for the
+        /// model. The service cannot accept subsequent training requests, or requests to add new audio resources, until
+        /// the existing training request completes.
         ///
         /// You can use the optional `custom_language_model_id` parameter to specify the GUID of a separately created
         /// custom language model that is to be used during training. Train with a custom language model if you have
@@ -3875,8 +3870,10 @@ namespace IBM.Watson.SpeechToText.V1
         ///
         /// Resets a custom acoustic model by removing all audio resources from the model. Resetting a custom acoustic
         /// model initializes the model to its state when it was first created. Metadata such as the name and language
-        /// of the model are preserved, but the model's audio resources are removed and must be re-created. You must use
-        /// credentials for the instance of the service that owns a model to reset it.
+        /// of the model are preserved, but the model's audio resources are removed and must be re-created. The service
+        /// cannot reset a model while it is handling another request for the model. The service cannot accept
+        /// subsequent requests for the model until the existing reset request completes. You must use credentials for
+        /// the instance of the service that owns a model to reset it.
         ///
         /// **See also:** [Resetting a custom acoustic
         /// model](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-manageAcousticModels#resetModel-acoustic).
@@ -3963,7 +3960,8 @@ namespace IBM.Watson.SpeechToText.V1
         /// model's status. The method returns an `AcousticModel` object that includes `status` and `progress` fields.
         /// Use a loop to check the status once a minute. While it is being upgraded, the custom model has the status
         /// `upgrading`. When the upgrade is complete, the model resumes the status that it had prior to upgrade. The
-        /// service cannot accept subsequent requests for the model until the upgrade completes.
+        /// service cannot upgrade a model while it is handling another request for the model. The service cannot accept
+        /// subsequent requests for the model until the existing upgrade request completes.
         ///
         /// If the custom acoustic model was trained with a separately created custom language model, you must use the
         /// `custom_language_model_id` parameter to specify the GUID of that custom language model. The custom language
@@ -4151,18 +4149,18 @@ namespace IBM.Watson.SpeechToText.V1
         /// You can add audio resources in any format that the service supports for speech recognition.
         ///
         /// You can use this method to add any number of audio resources to a custom model by calling the method once
-        /// for each audio or archive file. But the addition of one audio resource must be fully complete before you can
-        /// add another. You must add a minimum of 10 minutes and a maximum of 200 hours of audio that includes speech,
-        /// not just silence, to a custom acoustic model before you can train it. No audio resource, audio- or
-        /// archive-type, can be larger than 100 MB. To add an audio resource that has the same name as an existing
-        /// audio resource, set the `allow_overwrite` parameter to `true`; otherwise, the request fails.
+        /// for each audio or archive file. You can add multiple different audio resources at the same time. You must
+        /// add a minimum of 10 minutes and a maximum of 200 hours of audio that includes speech, not just silence, to a
+        /// custom acoustic model before you can train it. No audio resource, audio- or archive-type, can be larger than
+        /// 100 MB. To add an audio resource that has the same name as an existing audio resource, set the
+        /// `allow_overwrite` parameter to `true`; otherwise, the request fails.
         ///
         /// The method is asynchronous. It can take several seconds to complete depending on the duration of the audio
         /// and, in the case of an archive file, the total number of audio files being processed. The service returns a
         /// 201 response code if the audio is valid. It then asynchronously analyzes the contents of the audio file or
         /// files and automatically extracts information about the audio such as its length, sampling rate, and
-        /// encoding. You cannot submit requests to add additional audio resources to a custom acoustic model, or to
-        /// train the model, until the service's analysis of all audio files for the current request completes.
+        /// encoding. You cannot submit requests to train or upgrade the model until the service's analysis of all audio
+        /// resources for current requests completes.
         ///
         /// To determine the status of the service's analysis of the audio, use the **Get an audio resource** method to
         /// poll the status of the audio. The method accepts the customization ID of the custom model and the name of
@@ -4226,12 +4224,8 @@ namespace IBM.Watson.SpeechToText.V1
         ///
         /// ### Naming restrictions for embedded audio files
         ///
-        ///  The name of an audio file that is embedded within an archive-type resource must meet the following
-        /// restrictions:
-        /// * Include a maximum of 128 characters in the file name; this includes the file extension.
-        /// * Do not include spaces, slashes, or backslashes in the file name.
-        /// * Do not use the name of an audio file that has already been added to the custom model as part of an
-        /// archive-type resource.
+        ///  The name of an audio file that is contained in an archive-type resource can include a maximum of 128
+        /// characters. This includes the file extension and all elements of the name (for example, slashes).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom acoustic model that is to be used
@@ -4240,7 +4234,10 @@ namespace IBM.Watson.SpeechToText.V1
         /// <param name="audioName">The name of the new audio resource for the custom acoustic model. Use a localized
         /// name that matches the language of the custom model and reflects the contents of the resource.
         /// * Include a maximum of 128 characters in the name.
-        /// * Do not include spaces, slashes, or backslashes in the name.
+        /// * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes,
+        /// colons, ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The
+        /// service does not prevent the use of these characters. But because they must be URL-encoded wherever used,
+        /// their use is strongly discouraged.)
         /// * Do not use the name of an audio resource that has already been added to the custom model.</param>
         /// <param name="audioResource">The audio resource that is to be added to the custom acoustic model, an
         /// individual audio file or an archive file.
@@ -4447,10 +4444,13 @@ namespace IBM.Watson.SpeechToText.V1
         /// Delete an audio resource.
         ///
         /// Deletes an existing audio resource from a custom acoustic model. Deleting an archive-type audio resource
-        /// removes the entire archive of files; the current interface does not allow deletion of individual files from
-        /// an archive resource. Removing an audio resource does not affect the custom model until you train the model
-        /// on its updated data by using the **Train a custom acoustic model** method. You must use credentials for the
-        /// instance of the service that owns a model to delete its audio resources.
+        /// removes the entire archive of files. The service does not allow deletion of individual files from an archive
+        /// resource.
+        ///
+        /// Removing an audio resource does not affect the custom model until you train the model on its updated data by
+        /// using the **Train a custom acoustic model** method. You can delete an existing audio resource from a model
+        /// while a different resource is being added to the model. You must use credentials for the instance of the
+        /// service that owns a model to delete its audio resources.
         ///
         /// **See also:** [Deleting an audio resource from a custom acoustic
         /// model](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-manageAudio#deleteAudio).

--- a/Scripts/Services/TextToSpeech/V1/Model/VoiceModel.cs
+++ b/Scripts/Services/TextToSpeech/V1/Model/VoiceModel.cs
@@ -42,7 +42,7 @@ namespace IBM.Watson.TextToSpeech.V1.Model
         [JsonProperty("language", NullValueHandling = NullValueHandling.Ignore)]
         public string Language { get; set; }
         /// <summary>
-        /// The GUID of the service credentials for the instance of the service that owns the custom voice model.
+        /// The GUID of the credentials for the instance of the service that owns the custom voice model.
         /// </summary>
         [JsonProperty("owner", NullValueHandling = NullValueHandling.Ignore)]
         public string Owner { get; set; }
@@ -53,9 +53,9 @@ namespace IBM.Watson.TextToSpeech.V1.Model
         [JsonProperty("created", NullValueHandling = NullValueHandling.Ignore)]
         public string Created { get; set; }
         /// <summary>
-        /// The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified.
-        /// Equals `created` when a new voice model is first added but has yet to be updated. The value is provided in
-        /// full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+        /// The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified. The
+        /// `created` and `updated` fields are equal when a voice model is first added but has yet to be updated. The
+        /// value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
         /// </summary>
         [JsonProperty("last_modified", NullValueHandling = NullValueHandling.Ignore)]
         public string LastModified { get; set; }

--- a/Scripts/Services/TextToSpeech/V1/TextToSpeechService.cs
+++ b/Scripts/Services/TextToSpeech/V1/TextToSpeechService.cs
@@ -184,8 +184,9 @@ namespace IBM.Watson.TextToSpeech.V1
         /// Get a voice.
         ///
         /// Gets information about the specified voice. The information includes the name, language, gender, and other
-        /// details about the voice. Specify a customization ID to obtain information for that custom voice model of the
-        /// specified voice. To list information about all available voices, use the **List voices** method.
+        /// details about the voice. Specify a customization ID to obtain information for a custom voice model that is
+        /// defined for the language of the specified voice. To list information about all available voices, use the
+        /// **List voices** method.
         ///
         /// **See also:** [Listing a specific
         /// voice](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-voices#listVoice).
@@ -193,9 +194,9 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="voice">The voice for which information is to be returned.</param>
         /// <param name="customizationId">The customization ID (GUID) of a custom voice model for which information is
-        /// to be returned. You must make the request with service credentials created for the instance of the service
-        /// that owns the custom model. Omit the parameter to see information about the specified voice with no
-        /// customization. (optional)</param>
+        /// to be returned. You must make the request with credentials for the instance of the service that owns the
+        /// custom model. Omit the parameter to see information about the specified voice with no customization.
+        /// (optional)</param>
         /// <returns><see cref="Voice" />Voice</returns>
         public bool GetVoice(Callback<Voice> callback, string voice, string customizationId = null)
         {
@@ -350,14 +351,12 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="voice">The voice to use for synthesis. (optional, default to en-US_MichaelVoice)</param>
         /// <param name="customizationId">The customization ID (GUID) of a custom voice model to use for the synthesis.
         /// If a custom voice model is specified, it is guaranteed to work only if it matches the language of the
-        /// indicated voice. You must make the request with service credentials created for the instance of the service
-        /// that owns the custom model. Omit the parameter to use the specified voice with no customization.
-        /// (optional)</param>
+        /// indicated voice. You must make the request with credentials for the instance of the service that owns the
+        /// custom model. Omit the parameter to use the specified voice with no customization. (optional)</param>
         /// <param name="accept">The requested format (MIME type) of the audio. You can use the `Accept` header or the
         /// `accept` parameter to specify the audio format. For more information about specifying an audio format, see
-        /// **Audio formats (accept types)** in the method description.
-        ///
-        /// Default: `audio/ogg;codecs=opus`. (optional)</param>
+        /// **Audio formats (accept types)** in the method description. (optional, default to
+        /// audio/ogg;codecs=opus)</param>
         /// <returns><see cref="byte[]" />byte[]</returns>
         public bool Synthesize(Callback<byte[]> callback, string text, string voice = null, string customizationId = null, string accept = null)
         {
@@ -453,9 +452,9 @@ namespace IBM.Watson.TextToSpeech.V1
         /// <param name="customizationId">The customization ID (GUID) of a custom voice model for which the
         /// pronunciation is to be returned. The language of a specified custom model must match the language of the
         /// specified voice. If the word is not defined in the specified custom model, the service returns the default
-        /// translation for the custom model's language. You must make the request with service credentials created for
-        /// the instance of the service that owns the custom model. Omit the parameter to see the translation for the
-        /// specified voice with no customization. (optional)</param>
+        /// translation for the custom model's language. You must make the request with credentials for the instance of
+        /// the service that owns the custom model. Omit the parameter to see the translation for the specified voice
+        /// with no customization. (optional)</param>
         /// <returns><see cref="Pronunciation" />Pronunciation</returns>
         public bool GetPronunciation(Callback<Pronunciation> callback, string text, string voice = null, string format = null, string customizationId = null)
         {
@@ -641,7 +640,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// models](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customModels#cuModelsQueryAll).
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
-        /// <param name="language">The language for which custom voice models that are owned by the requesting service
+        /// <param name="language">The language for which custom voice models that are owned by the requesting
         /// credentials are to be returned. Omit the parameter to see all custom voice models that are owned by the
         /// requester. (optional)</param>
         /// <returns><see cref="VoiceModels" />VoiceModels</returns>
@@ -741,7 +740,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <param name="name">A new name for the custom voice model. (optional)</param>
         /// <param name="description">A new description for the custom voice model. (optional)</param>
         /// <param name="words">An array of `Word` objects that provides the words and their translations that are to be
@@ -835,7 +834,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <returns><see cref="VoiceModel" />VoiceModel</returns>
         public bool GetVoiceModel(Callback<VoiceModel> callback, string customizationId)
         {
@@ -912,7 +911,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <returns><see cref="object" />object</returns>
         public bool DeleteVoiceModel(Callback<object> callback, string customizationId)
         {
@@ -1007,7 +1006,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <param name="words">The **Add custom words** method accepts an array of `Word` objects. Each object provides
         /// a word that is to be added or updated for the custom voice model and the word's translation.
         ///
@@ -1100,7 +1099,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <returns><see cref="Words" />Words</returns>
         public bool ListWords(Callback<Words> callback, string customizationId)
         {
@@ -1195,7 +1194,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <param name="word">The word that is to be added or updated for the custom voice model.</param>
         /// <param name="translation">The phonetic or sounds-like translation for the word. A phonetic translation is
         /// based on the SSML format for representing the phonetic string of a word either as an IPA translation or as
@@ -1295,7 +1294,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <param name="word">The word that is to be queried from the custom voice model.</param>
         /// <returns><see cref="Translation" />Translation</returns>
         public bool GetWord(Callback<Translation> callback, string customizationId, string word)
@@ -1375,7 +1374,7 @@ namespace IBM.Watson.TextToSpeech.V1
         /// </summary>
         /// <param name="callback">The callback function that is invoked when the operation completes.</param>
         /// <param name="customizationId">The customization ID (GUID) of the custom voice model. You must make the
-        /// request with service credentials created for the instance of the service that owns the custom model.</param>
+        /// request with credentials for the instance of the service that owns the custom model.</param>
         /// <param name="word">The word that is to be deleted from the custom voice model.</param>
         /// <returns><see cref="object" />object</returns>
         public bool DeleteWord(Callback<object> callback, string customizationId, string word)

--- a/Tests/AssistantV2IntegrationTests.cs
+++ b/Tests/AssistantV2IntegrationTests.cs
@@ -29,7 +29,7 @@ namespace IBM.Watson.Tests
     public class AssistantV2IntegrationTests
     {
         private AssistantService service;
-        private string versionDate = "2019-02-13";
+        private string versionDate = "2019-02-28";
         private string assistantId;
         private string sessionId;
 
@@ -56,7 +56,7 @@ namespace IBM.Watson.Tests
             service.CreateSession(
                 callback: (DetailedResponse<SessionResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
                     createSessionResponse = response.Result;
                     sessionId = createSessionResponse.SessionId;
                     Assert.IsNotNull(createSessionResponse);
@@ -75,7 +75,7 @@ namespace IBM.Watson.Tests
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -101,7 +101,7 @@ namespace IBM.Watson.Tests
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -128,7 +128,7 @@ namespace IBM.Watson.Tests
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -156,7 +156,7 @@ namespace IBM.Watson.Tests
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -184,7 +184,7 @@ namespace IBM.Watson.Tests
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -212,7 +212,34 @@ namespace IBM.Watson.Tests
             service.Message(
                 callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
+                    messageResponse = response.Result;
+                    Assert.IsNotNull(messageResponse);
+                    Assert.IsNull(error);
+                },
+                assistantId: assistantId,
+                sessionId: sessionId,
+                input: input
+            );
+
+            while (messageResponse == null)
+                yield return null;
+
+            messageResponse = null;
+            input = new MessageInput()
+            {
+                Text = "who did Watson beat on Jeopardy?",
+                Options = new MessageInputOptions()
+                {
+                    ReturnContext = true
+                }
+            };
+            Log.Debug("AssistantV2IntegrationTests", "Attempting to Message...who did Watson beat on Jeopardy?");
+            service.WithHeader("X-Watson-Test", "1");
+            service.Message(
+                callback: (DetailedResponse<MessageResponse> response, IBMError error) =>
+                {
+                Log.Debug("AssistantV2IntegrationTests", "result: {0} {1}", response.Response, assistantId);
                     messageResponse = response.Result;
                     Assert.IsNotNull(messageResponse);
                     Assert.IsNull(error);
@@ -231,7 +258,7 @@ namespace IBM.Watson.Tests
             service.DeleteSession(
                 callback: (DetailedResponse<object> response, IBMError error) =>
                 {
-                    Log.Debug("AssistantV1IntegrationTests", "result: {0}", response.Response);
+                    Log.Debug("AssistantV2IntegrationTests", "result: {0}", response.Response);
                     deleteSessionResponse = response.Result;
                     Assert.IsNotNull(response.Result);
                     Assert.IsNull(error);


### PR DESCRIPTION
## Release 4 - 2019

Includes
- [x] Assistant Search Skill support
- [x] Compare and Comply basicauth constructor
- [x] Compare and Comply model changes
- [x] NLU Confidence field in EntitesResult and EntityMention
- [x] STT AcousticModel & LanguageModel have Updated field
- [x] Compare Comply `contract_type` --> `contract_types`. `contract_type` was never returned by the service so not a breaking change. 
- [x] Ensure STT `TrainLanguageModel` and `TrainAcousticModel` return void/empty object and not `TrainingResponse` (service only returns `TrainingResponse` if we set `strict` to false)
- [x] Integration tests