### PR TITLE
fix(Speech to Text): Revise SpeechRecognitionAlternative model

### DIFF
--- a/Scripts/Services/SpeechToText/V1/Model/SpeechRecognitionAlternative.cs
+++ b/Scripts/Services/SpeechToText/V1/Model/SpeechRecognitionAlternative.cs
@@ -42,7 +42,7 @@ namespace IBM.Watson.SpeechToText.V1.Model
         /// `[["hello",0.0,1.2],["world",1.2,2.5]]`. Timestamps are returned only for the best alternative.
         /// </summary>
         [JsonProperty("timestamps", NullValueHandling = NullValueHandling.Ignore)]
-        public List<string> Timestamps { get; set; }
+        public List<List<string>> Timestamps { get; set; }
         /// <summary>
         /// A confidence score for each word of the transcript as a list of lists. Each inner list consists of two
         /// elements: the word and its confidence score in the range of 0.0 to 1.0, for example:
@@ -50,6 +50,6 @@ namespace IBM.Watson.SpeechToText.V1.Model
         /// with results marked as final.
         /// </summary>
         [JsonProperty("word_confidence", NullValueHandling = NullValueHandling.Ignore)]
-        public List<string> WordConfidence { get; set; }
+        public List<List<string>> WordConfidence { get; set; }
     }
 }


### PR DESCRIPTION
### Summary
Addresses https://github.com/watson-developer-cloud/unity-sdk/issues/637

This pull request revises the type for `Timestamps` and `WordConfidence` for SpeechToText SpeechRecognitionAlternative model.