### PR TITLE
Update gateway urls [skip ci]

### DIFF
--- a/Examples/ExampleAssistantV2.cs
+++ b/Examples/ExampleAssistantV2.cs
@@ -34,7 +34,7 @@ namespace IBM.Watson.Examples
         [Tooltip("The IAM apikey.")]
         [SerializeField]
         private string iamApikey;
-        [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/assistant/api\"")]
+        [Tooltip("The service URL (optional). This defaults to \"https://api.us-south.assistant.watson.cloud.ibm.com\"")]
         [SerializeField]
         private string serviceUrl;
         [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]

--- a/Examples/ExampleDiscoveryV1.cs
+++ b/Examples/ExampleDiscoveryV1.cs
@@ -15,7 +15,7 @@ public class ExampleDiscoveryV1 : MonoBehaviour
     [Tooltip("The IAM apikey.")]
     [SerializeField]
     private string iamApikey;
-    [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/discovery/api\"")]
+    [Tooltip("The service URL (optional). This defaults to \"https://api.us-south.discovery.watson.cloud.ibm.com\"")]
     [SerializeField]
     private string serviceUrl;
     [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]

--- a/Examples/ExampleDiscoveryV2.cs
+++ b/Examples/ExampleDiscoveryV2.cs
@@ -15,7 +15,7 @@ public class ExampleDiscoveryV2 : MonoBehaviour
     [Tooltip("The Bearer Token.")]
     [SerializeField]
     private string bearerToken;
-    [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/discovery/api\"")]
+    [Tooltip("The service URL (optional). This defaults to \"https://api.us-south.discovery.watson.cloud.ibm.com\"")]
     [SerializeField]
     private string serviceUrl;
     [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]

--- a/Examples/ExampleLanguageTranslatorV3.cs
+++ b/Examples/ExampleLanguageTranslatorV3.cs
@@ -15,7 +15,7 @@ public class ExampleLanguageTranslatorV3 : MonoBehaviour
     [Tooltip("The IAM apikey.")]
     [SerializeField]
     private string iamApikey;
-    [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/discovery/api\"")]
+    [Tooltip("The service URL (optional). This defaults to \"https://api.us-south.language-translator.watson.cloud.ibm.com\"")]
     [SerializeField]
     private string serviceUrl;
     [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]

--- a/Examples/ExampleNaturalLanguageClassifierV1.cs
+++ b/Examples/ExampleNaturalLanguageClassifierV1.cs
@@ -35,7 +35,7 @@ namespace IBM.Watson.Examples
         [Tooltip("The IAM apikey.")]
         [SerializeField]
         private string iamApikey;
-		[Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/natural-language-understanding/api\"")]
+		[Tooltip("The service URL (optional). This defaults to \"https://api.us-south.natural-language-classifier.watson.cloud.ibm.com\"")]
         [SerializeField]
         private string serviceUrl;
         #endregion

--- a/Examples/ExampleNaturalLanguageUnderstandingV1.cs
+++ b/Examples/ExampleNaturalLanguageUnderstandingV1.cs
@@ -35,7 +35,7 @@ namespace IBM.Watson.Examples
         [Tooltip("The IAM apikey.")]
         [SerializeField]
         private string iamApikey;
-		[Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/natural-language-understanding/api\"")]
+		[Tooltip("The service URL (optional). This defaults to \"https://api.us-south.natural-language-understanding.watson.cloud.ibm.com\"")]
         [SerializeField]
         private string serviceUrl;
         [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]

--- a/Examples/ExampleStreaming.cs
+++ b/Examples/ExampleStreaming.cs
@@ -33,7 +33,7 @@ namespace IBM.Watsson.Examples
     {
         #region PLEASE SET THESE VARIABLES IN THE INSPECTOR
         [Space(10)]
-        [Tooltip("The service URL (optional). This defaults to \"https://stream.watsonplatform.net/speech-to-text/api\"")]
+        [Tooltip("The service URL (optional). This defaults to \"https://api.us-south.speech-to-text.watson.cloud.ibm.com\"")]
         [SerializeField]
         private string _serviceUrl;
         [Tooltip("Text field to display the results of streaming.")]

--- a/Examples/ExampleTextToSpeechV1.cs
+++ b/Examples/ExampleTextToSpeechV1.cs
@@ -36,7 +36,7 @@ namespace IBM.Watson.Examples
         [Tooltip("The IAM apikey.")]
         [SerializeField]
         private string iamApikey;
-        [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/text-to-speech/api\"")]
+        [Tooltip("The service URL (optional). This defaults to \"https://api.us-south.text-to-speech.watson.cloud.ibm.com\"")]
         [SerializeField]
         private string serviceUrl;
         private TextToSpeechService service;

--- a/Examples/ExampleTextToSpeechV1.unity
+++ b/Examples/ExampleTextToSpeechV1.unity
@@ -151,7 +151,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   iamApikey: 
-  serviceUrl: https://stream.watsonplatform.net/text-to-speech/api
+  serviceUrl: https://api.us-south.text-to-speech.watson.cloud.ibm.com
   textInput: {fileID: 1552819768}
 --- !u!224 &275913467
 RectTransform:

--- a/Examples/ExampleToneAnalyzerV3.cs
+++ b/Examples/ExampleToneAnalyzerV3.cs
@@ -34,7 +34,7 @@ namespace IBM.Watson.Examples
         [Tooltip("The IAM apikey.")]
         [SerializeField]
         private string iamApikey;
-        [Tooltip("The service URL (optional). This defaults to \"https://gateway.watsonplatform.net/assistant/api\"")]
+        [Tooltip("The service URL (optional). This defaults to \"https://api.us-south.tone-analyzer.watson.cloud.ibm.com\"")]
         [SerializeField]
         private string serviceUrl;
         [Tooltip("The version date with which you would like to use the service in the form YYYY-MM-DD.")]

--- a/Scripts/Services/SpeechToText/V1/SpeechToTextServiceExtension.cs
+++ b/Scripts/Services/SpeechToText/V1/SpeechToTextServiceExtension.cs
@@ -105,7 +105,7 @@ namespace IBM.Watson.SpeechToText.V1
         private float _silenceDuration = 0.0f;
         private float _silenceCutoff = 1.0f;
 
-        private string _url = "https://stream.watsonplatform.net/speech-to-text/api";
+        private string _url = "https://api.us-south.speech-to-text.watson.cloud.ibm.com";
         #endregion
 
         #region Public Properties

--- a/Scripts/Services/TextToSpeech/V1/TextToSpeechServiceExtension.cs
+++ b/Scripts/Services/TextToSpeech/V1/TextToSpeechServiceExtension.cs
@@ -54,7 +54,7 @@ namespace IBM.Watson.TextToSpeech.V1
         private string customization_id = null;
         private string[] timings = null;
 
-        private string url = "https://stream.watsonplatform.net/text-to-speech/api";
+        private string url = "https://api.us-south.text-to-speech.watson.cloud.ibm.com";
         #endregion
 
         #region Public Properties

--- a/Tests/LanguageTranslatorV3UnitTests.cs
+++ b/Tests/LanguageTranslatorV3UnitTests.cs
@@ -66,7 +66,7 @@ namespace IBM.Watson.Tests
                     Assert.IsTrue(req.Headers["Accept"] == "application/json");
                     if (((RequestObject<TranslationResult>)req).Callback != null)
                     {
-                        Assert.IsTrue(conn.URL == "https://gateway.watsonplatform.net/language-translator/api/v3/translate");
+                        Assert.IsTrue(conn.URL == "https://api.us-south.language-translator.watson.cloud.ibm.com/v3/translate");
                         ((RequestObject<TranslationResult>)req).Callback(translationResponse, null);
                     }
                 }
@@ -118,7 +118,7 @@ namespace IBM.Watson.Tests
                 req => {
                     if (((RequestObject<IdentifiableLanguages>)req).Callback != null)
                     {
-                        Assert.IsTrue(conn.URL == "https://gateway.watsonplatform.net/language-translator/api/v3/identifiable_languages");
+                        Assert.IsTrue(conn.URL == "https://api.us-south.language-translator.watson.cloud.ibm.com/v3/identifiable_languages");
                         ((RequestObject<IdentifiableLanguages>)req).Callback(identifiableLanguagesResponse, null);
                     }
                 }
@@ -168,7 +168,7 @@ namespace IBM.Watson.Tests
                 req => {
                     if (((RequestObject<IdentifiedLanguages>)req).Callback != null)
                     {
-                        Assert.IsTrue(conn.URL == "https://gateway.watsonplatform.net/language-translator/api/v3/identify");
+                        Assert.IsTrue(conn.URL == "https://api.us-south.language-translator.watson.cloud.ibm.com/v3/identify");
                         ((RequestObject<IdentifiedLanguages>)req).Callback(identifyMockResponse, null);
                     }
                 }
@@ -227,7 +227,7 @@ namespace IBM.Watson.Tests
                 req => {
                     if (((RequestObject<TranslationModels>)req).Callback != null)
                     {
-                        Assert.IsTrue(conn.URL == "https://gateway.watsonplatform.net/language-translator/api/v3/models");
+                        Assert.IsTrue(conn.URL == "https://api.us-south.language-translator.watson.cloud.ibm.com/v3/models");
                         ((RequestObject<TranslationModels>)req).Callback(translationModelsResponse, null);
                     }
                 }


### PR DESCRIPTION
### Summary
Watsonplatform.net urls will cease to function starting 12 Feb 2021. This pull request updates gateway urls to their onecloud equivalents. 